### PR TITLE
Allow creating a GoogleCredential from a service credential

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
@@ -302,7 +302,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
                 User = "a_user",
                 Scopes = new[] { "scope1" },
             }.FromPrivateKey(PrivateKey));
-            var cred1 = GoogleCredential.FromCredential(serviceAccountCred);
+            var cred1 = GoogleCredential.FromServiceAccountCredential(serviceAccountCred);
             var cred2 = cred1.CreateScoped("scope2");
 
             var svc1 = (ServiceAccountCredential)cred1.UnderlyingCredential;
@@ -337,7 +337,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
                 User = "user1",
                 Scopes = new[] { "scope1" },
             }.FromPrivateKey(PrivateKey));
-            var cred1 = GoogleCredential.FromCredential(serviceAccountCred);
+            var cred1 = GoogleCredential.FromServiceAccountCredential(serviceAccountCred);
             var cred2 = cred1.CreateWithUser("user2");
 
             var svc1 = (ServiceAccountCredential)cred1.UnderlyingCredential;

--- a/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
@@ -199,7 +199,7 @@ namespace Google.Apis.Auth.OAuth2
                 case JsonCredentialParameters.AuthorizedUserCredentialType:
                     return new GoogleCredential(CreateUserCredentialFromParameters(credentialParameters));
                 case JsonCredentialParameters.ServiceAccountCredentialType:
-                    return GoogleCredential.FromCredential(
+                    return GoogleCredential.FromServiceAccountCredential(
                         CreateServiceAccountCredentialFromParameters(credentialParameters));
                 default:
                     throw new InvalidOperationException(

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -244,7 +244,7 @@ namespace Google.Apis.Auth.OAuth2
         public ICredential UnderlyingCredential => credential;
 
         /// <summary>Creates a <c>GoogleCredential</c> wrapping a <see cref="ServiceAccountCredential"/>.</summary>
-        internal static GoogleCredential FromCredential(ServiceAccountCredential credential)
+        public static GoogleCredential FromServiceAccountCredential(ServiceAccountCredential credential)
         {
             return new ServiceAccountGoogleCredential(credential);
         }


### PR DESCRIPTION
@jskeet Can you see any reason not to do this? We already allow creating a `GoogleCredential` from a compute credential, and an access token.

Fixes #1282