### PR TITLE
Fix bug with asp.net core auth

### DIFF
--- a/Src/Support/Google.Apis.Auth.AspNetCore.IntegrationTests/Startup.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore.IntegrationTests/Startup.cs
@@ -19,7 +19,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 using System.Linq;
 
 namespace Google.Apis.Auth.AspNetCore.IntegrationTests
@@ -29,7 +28,7 @@ namespace Google.Apis.Auth.AspNetCore.IntegrationTests
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-                .AddCookie(options => options.ExpireTimeSpan = TimeSpan.FromMinutes(2))
+                .AddCookie()
                 .AddGoogleOpenIdConnect(options =>
                 {
                     var clientInfo = (ClientInfo)services.First(x => x.ServiceType == typeof(ClientInfo)).ImplementationInstance;

--- a/Src/Support/Google.Apis.Auth.AspNetCore/GoogleAuthProvider.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore/GoogleAuthProvider.cs
@@ -24,6 +24,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
@@ -60,12 +61,17 @@ namespace Google.Apis.Auth.AspNetCore
             }
             var accessToken = auth.Properties.GetTokenValue(OpenIdConnectParameterNames.AccessToken);
             var refreshToken = auth.Properties.GetTokenValue(OpenIdConnectParameterNames.RefreshToken);
-            var expiresUtc = auth.Properties.ExpiresUtc;
-            if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(refreshToken) || expiresUtc == null)
+            // Get expiration of Google auth-token. The "expires_at" name and "o" format are hard-coded into:
+            // https://github.com/aspnet/AspNetCore/blob/562d119ca4a4275359f6fae359120a2459cd39e9/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs#L940
+            // Do not use `auth.Properties.ExpiresUtc`, as this is the cookie expiration time, not the Google IdToken expiration time.
+            var expiresUtcStr = auth.Properties.GetTokenValue("expires_at");
+            if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(refreshToken) || expiresUtcStr == null ||
+                !DateTime.TryParseExact(expiresUtcStr, "o", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var expiresUtc))
             {
-                throw new InvalidOperationException("Invalid auth. access_token, refresh_token, and expires_utc must all be present.");
+                throw new InvalidOperationException("Invalid auth. access_token, refresh_token, and expires_at must all be present.");
             }
-            if (expiresUtc.Value - (accessTokenRefreshWindow ?? s_accessTokenRefreshWindow) < _clock.UtcNow)
+            var now = _clock.UtcNow;
+            if (expiresUtc - (accessTokenRefreshWindow ?? s_accessTokenRefreshWindow) < now)
             {
                 // Refresh required. This has to be done inline here (it can't be done in the background)
                 // because the request auth properties need to be updated with the result.
@@ -81,19 +87,25 @@ namespace Google.Apis.Auth.AspNetCore
                 try
                 {
                     var refreshResponse = await options.Backchannel.PostAsync(oidcConfig.TokenEndpoint, refreshContent, cancellationToken);
+                    refreshResponse.EnsureSuccessStatusCode();
                     var payload = JObject.Parse(await refreshResponse.Content.ReadAsStringAsync());
                     var refreshedAccessToken = payload.Value<string>("access_token");
                     var refreshedRefreshToken = payload.Value<string>("refresh_token");
                     var refreshedExpiresIn = payload.Value<string>("expires_in");
+                    var refreshedIdToken = payload.Value<string>("id_token");
                     auth.Properties.UpdateTokenValue(OpenIdConnectParameterNames.AccessToken, refreshedAccessToken);
                     if (!string.IsNullOrEmpty(refreshedRefreshToken))
                     {
                         auth.Properties.UpdateTokenValue(OpenIdConnectParameterNames.RefreshToken, refreshedRefreshToken);
                     }
-                    auth.Properties.IssuedUtc = _clock.UtcNow;
                     if (int.TryParse(refreshedExpiresIn, out int expiresInSeconds))
                     {
-                        auth.Properties.ExpiresUtc = _clock.UtcNow + TimeSpan.FromSeconds(expiresInSeconds);
+                        var refreshedExpiresAt = now + TimeSpan.FromSeconds(expiresInSeconds);
+                        auth.Properties.UpdateTokenValue("expires_at", refreshedExpiresAt.ToString("o"));
+                    }
+                    if (!string.IsNullOrEmpty(refreshedIdToken))
+                    {
+                        auth.Properties.UpdateTokenValue(OpenIdConnectParameterNames.IdToken, refreshedIdToken);
                     }
                     accessToken = refreshedAccessToken;
                 }

--- a/Src/Support/Google.Apis.Auth.AspNetCore/GoogleAuthProvider.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore/GoogleAuthProvider.cs
@@ -100,7 +100,7 @@ namespace Google.Apis.Auth.AspNetCore
                     }
                     if (int.TryParse(refreshedExpiresIn, out int expiresInSeconds))
                     {
-                        var refreshedExpiresAt = now + TimeSpan.FromSeconds(expiresInSeconds);
+                        var refreshedExpiresAt = now.AddSeconds(expiresInSeconds);
                         auth.Properties.UpdateTokenValue("expires_at", refreshedExpiresAt.ToString("o"));
                     }
                     if (!string.IsNullOrEmpty(refreshedIdToken))

--- a/Src/Support/Google.Apis.Auth.AspNetCore/GoogleOpenIdConnectExtensions.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore/GoogleOpenIdConnectExtensions.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.Authority = "https://accounts.google.com";
                 // Response-type of "code" gets just an authorization-code from the authorization endpoint,
                 // then both an access-token and an id-token (JWT) from the token endpoint.
-                // For the id-token to be returned requires the "openid" scope to be set.
+                // An id-token is returned from the token endpoint because Google is an openid-connect
+                // provider (not just an oauth2 provider), and the "openid" scope is set below.
                 // Useful reference for openid-connect flows:
                 // https://medium.com/@darutk/diagrams-of-all-the-openid-connect-flows-6968e3990660
                 options.ResponseType = "code";

--- a/Src/Support/Google.Apis.Auth.AspNetCore/GoogleOpenIdConnectExtensions.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore/GoogleOpenIdConnectExtensions.cs
@@ -16,6 +16,7 @@ limitations under the License.
 
 using Google.Apis.Auth.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth.Claims;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -87,16 +88,20 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 // Google's OpenID authority URL.
                 options.Authority = "https://accounts.google.com";
-                // Response-code to get an id-token with profile information,
-                // and a code to use to get an access-token and refresh-token.
-                options.ResponseType = "id_token code";
+                // Response-type of "code" gets just an authorization-code from the authorization endpoint,
+                // then both an access-token and an id-token (JWT) from the token endpoint.
+                // For the id-token to be returned requires the "openid" scope to be set.
+                // Useful reference for openid-connect flows:
+                // https://medium.com/@darutk/diagrams-of-all-the-openid-connect-flows-6968e3990660
+                options.ResponseType = "code";
                 // Scopes to announce this is an OpenID auth, and get simple profile information.
                 options.Scope.Clear();
                 options.Scope.Add("openid");
                 options.Scope.Add("email");
                 options.Scope.Add("profile");
-                // Save the id-token, access-token and refresh-token in the auth properties.
+                // Save the id-token, access-token, refresh-token, and expiry in the auth properties.
                 options.SaveTokens = true;
+                options.GetClaimsFromUserInfoEndpoint = false;
                 // Call user configuration.
                 configureOptions(options);
                 // Add event handlers.


### PR DESCRIPTION
Previously this was incorrectly determining when to refresh the Google auth token using the cookie expiration time rather than the Google access-token expiration time. Now fixed. Fixes #1345