### PR TITLE
Add a unit test for the new Initializer.BaseUri property

### DIFF
--- a/Src/Support/Google.Apis.Tests/Apis/Services/BaseClientServiceTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Services/BaseClientServiceTest.cs
@@ -20,6 +20,7 @@ using Google.Apis.Json;
 using Google.Apis.Requests;
 using Google.Apis.Services;
 using Google.Apis.Tests.Mocks;
+using Google.Apis.Translate.v2;
 using Google.Apis.Util;
 using Newtonsoft.Json;
 using System;
@@ -203,6 +204,18 @@ namespace Google.Apis.Tests.Apis.Services
                 Assert.Equal("Required", error.Message);
                 Assert.Equal(1, error.Errors.Count);
             }
+        }
+
+        [Theory]
+        [InlineData(null, "https://translation.googleapis.com/language/translate/")]
+        [InlineData("https://alternative-uri", "https://alternative-uri")]
+        public void InitializerBaseUriIsUsedByGeneratedServices(string initializerUri, string expectedServiceUri)
+        {
+            var service = new TranslateService(new BaseClientService.Initializer
+            {
+                BaseUri = initializerUri
+            });
+            Assert.Equal(expectedServiceUri, service.BaseUri);
         }
 
         /// <summary>

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -21,6 +21,11 @@
     <Compile Include="..\..\Generated\Google.Apis.Translate.v2\Google.Apis.Translate.v2.cs" Link="Apis\Services\Google.Apis.Translate.v2.cs" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Hack to force Google.Apis.Translate.v2 to compile as we want :) -->
+    <DefineConstants>NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)'=='net452' or '$(TargetFramework)'=='net46'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
+    <Compile Include="..\..\Generated\Google.Apis.Translate.v2\Google.Apis.Translate.v2.cs" Link="Apis\Services\Google.Apis.Translate.v2.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452' or '$(TargetFramework)'=='net46'">


### PR DESCRIPTION
This can only be merged after:

- Support libraries 1.40.0 have been released
- Generated libraries have been regenerated (but not necessarily released)