### PR TITLE
.NET Core port of Google.Apis.Auth.Mvc project

### DIFF
--- a/Src/Support/Google.Apis.Auth.MvcCore/Google.Apis.Auth.MvcCore.csproj
+++ b/Src/Support/Google.Apis.Auth.MvcCore/Google.Apis.Auth.MvcCore.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Apis.Auth" Version="1.40.0" />
+    <PackageReference Include="Google.Apis.Calendar.v3" Version="1.40.0.1580" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.2.0" />
+  </ItemGroup>
+</Project>

--- a/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/AuthorizationCodeMvcApp.cs
+++ b/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/AuthorizationCodeMvcApp.cs
@@ -1,0 +1,74 @@
+/*
+Copyright 2013 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Extensions;
+
+using Google.Apis.Auth.OAuth2.Web;
+
+
+namespace Google.Apis.Auth.OAuth2.MvcCore
+{
+	/// <summary>
+	/// Thread-safe OAuth 2.0 authorization code flow for a MVC web application that persists end-user credentials.
+	/// </summary>
+	public class AuthorizationCodeMvcApp : AuthorizationCodeWebApp
+	{
+		// TODO(peleyal): we should also follow the MVC framework Authorize attribute
+
+		/// <summary>Gets the controller which is the owner of this authorization code MVC app instance.</summary>
+		public Controller Controller { get; }
+
+		/// <summary>Gets the <see cref="Google.Apis.Auth.OAuth2.MvcCore.FlowMetadata"/> object.</summary>
+		public FlowMetadata FlowData { get; }
+
+		/// <summary>Constructs a new authorization code MVC app using the given controller and flow data.</summary>
+		public AuthorizationCodeMvcApp(Controller controller, FlowMetadata flowData)
+			: base(
+				flowData.Flow,
+				new UriBuilder
+				{
+					Scheme = controller.Request.Scheme,
+					Host = controller.Request.Host.Host,
+					Port = controller.Request.Host.Port.GetValueOrDefault(-1),
+					Path = flowData.AuthCallback
+				}.ToString(),
+				controller.Request.GetDisplayUrl())
+		{
+			this.Controller = controller;
+			this.FlowData = flowData;
+		}
+
+		/// <summary>
+		/// Asynchronously authorizes the installed application to access user's protected data. It gets the user 
+		/// identifier by calling to <see cref="Google.Apis.Auth.OAuth2.MvcCore.FlowMetadata.GetUserId"/> and then calls to
+		/// <see cref="Google.Apis.Auth.OAuth2.Web.AuthorizationCodeWebApp.AuthorizeAsync"/>.
+		/// </summary>
+		/// <param name="taskCancellationToken">Cancellation token to cancel an operation</param>
+		/// <returns>
+		/// Auth result object which contains the user's credential or redirect URI for the authorization server
+		/// </returns>
+		public Task<AuthResult> AuthorizeAsync(CancellationToken taskCancellationToken)
+		{
+			return base.AuthorizeAsync(
+				this.FlowData.GetUserId(this.Controller),
+				taskCancellationToken);
+		}
+	}
+}

--- a/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/Controllers/AuthCallbackControllerBase.cs
+++ b/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/Controllers/AuthCallbackControllerBase.cs
@@ -1,0 +1,108 @@
+/*
+Copyright 2013 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.MvcCore.Filters;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Auth.OAuth2.Web;
+using Google.Apis.Logging;
+
+
+namespace Google.Apis.Auth.OAuth2.MvcCore.Controllers
+{
+	/// <summary>
+	/// Auth callback to process the authorization code or error response from the authorization redirect page.
+	/// </summary>
+	[AuthorizationCodeActionFilter]
+	public abstract class AuthCallbackControllerBase : Controller
+	{
+		/// <summary>Logger for this class.</summary>
+		protected static readonly ILogger Logger = ApplicationContext.Logger.ForType<AuthCallbackControllerBase>();
+
+		/// <summary>Gets the authorization code flow.</summary>
+		protected IAuthorizationCodeFlow Flow { get { return FlowData.Flow; } }
+
+		/// <summary>
+		/// Gets the user identifier. Potential logic is to use session variables to retrieve that information.
+		/// </summary>
+		protected string UserId { get { return FlowData.GetUserId(this); } }
+
+		#region Abstract and Virtual Members
+
+		/// <summary>Gets the flow data which contains </summary>
+		protected abstract FlowMetadata FlowData { get; }
+
+		/// <summary>
+		/// A callback which gets the error when this controller didn't receive an authorization code. The default 
+		/// implementation throws a <see cref="Google.Apis.Auth.OAuth2.Responses.TokenResponseException"/>.
+		/// </summary>
+		protected virtual ActionResult OnTokenError(TokenErrorResponse errorResponse)
+		{
+			throw new TokenResponseException(errorResponse);
+		}
+
+		/// <summary>
+		/// The authorization callback which receives an authorization code which contains an error or a code.
+		/// If a code is available the method exchange the coed with an access token and redirect back to the original
+		/// page which initialized the auth process (using the state parameter).
+		/// </summary>
+		/// <param name="authorizationCode">Authorization code response which contains the code or an error.</param>
+		/// <param name="taskCancellationToken">Cancellation token to cancel operation.</param>
+		/// <returns>
+		/// Redirect action to the state parameter or <see cref="OnTokenError"/> in case of an error.
+		/// </returns>
+		public async virtual Task<ActionResult> IndexAsync(AuthorizationCodeResponseUrl authorizationCode,
+			CancellationToken taskCancellationToken)
+		{
+			if (string.IsNullOrEmpty(authorizationCode.Code))
+			{
+				var errorResponse = new TokenErrorResponse(authorizationCode);
+				Logger.Info("Received an error. The response is: {0}", errorResponse);
+
+				return OnTokenError(errorResponse);
+			}
+
+			Logger.Debug("Received \"{0}\" code", authorizationCode.Code);
+
+			var returnUrl = new UriBuilder
+			{
+				Scheme = Request.Scheme,
+				Host = Request.Host.Host,
+				Port = Request.Host.Port.GetValueOrDefault(-1),
+				Path = Request.Path.Value
+			}.ToString();
+
+			await Flow.ExchangeCodeForTokenAsync(UserId, authorizationCode.Code,
+				returnUrl, taskCancellationToken)
+				.ConfigureAwait(false);
+
+			// Extract the right state.
+			var oauthState = await
+				AuthWebUtility.ExtracRedirectFromState(Flow.DataStore, UserId,
+					authorizationCode.State)
+				.ConfigureAwait(false);
+
+			return new RedirectResult(oauthState);
+		}
+
+		#endregion
+	}
+}

--- a/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/Filters/AuthActionFilter.cs
+++ b/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/Filters/AuthActionFilter.cs
@@ -1,0 +1,58 @@
+/*
+Copyright 2013 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+using Google.Apis.Auth.OAuth2.Responses;
+
+
+namespace Google.Apis.Auth.OAuth2.MvcCore.Filters
+{
+	/// <summary>
+	/// An action filter which parses the query parameters into
+	/// <see cref="Google.Apis.Auth.OAuth2.Responses.AuthorizationCodeResponseUrl"/>.
+	/// </summary>
+	public class AuthorizationCodeActionFilter : ActionFilterAttribute, IActionFilter
+	{
+		/// <summary>
+		/// Parses the request into <see cref="Google.Apis.Auth.OAuth2.Responses.AuthorizationCodeResponseUrl"/>.
+		/// </summary>
+		public override void OnActionExecuting(ActionExecutingContext context)
+		{
+			(context.ActionArguments["authorizationCode"] as AuthorizationCodeResponseUrl)
+				.ParseRequest(context.HttpContext.Request);
+
+			base.OnActionExecuting(context);
+		}
+	}
+
+	/// <summary>Auth extensions methods.</summary>
+	public static class AuthExtensions
+	{
+		/// <summary>Parses the HTTP request query parameters into the Authorization code response.</summary>
+		internal static void ParseRequest(
+			this AuthorizationCodeResponseUrl authorizationCode,
+			HttpRequest request)
+		{
+			authorizationCode.Code = request.Query["code"];
+			authorizationCode.Error = request.Query["error"];
+			authorizationCode.ErrorDescription = request.Query["error_description"];
+			authorizationCode.ErrorUri = request.Query["error_uri"];
+			authorizationCode.State = request.Query["state"];
+		}
+	}
+}

--- a/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/FlowMetadata.cs
+++ b/Src/Support/Google.Apis.Auth.MvcCore/OAuth2/MvcCore/FlowMetadata.cs
@@ -1,0 +1,50 @@
+/*
+Copyright 2013 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Microsoft.AspNetCore.Mvc;
+
+
+using Google.Apis.Auth.OAuth2.Flows;
+
+namespace Google.Apis.Auth.OAuth2.MvcCore
+{
+    /// <summary>
+    /// Flow metadata abstract class which contains the reference to the
+    /// <see cref="Google.Apis.Auth.OAuth2.Flows.IAuthorizationCodeFlow"/> and
+    /// method to get the user identifier.
+    /// </summary>
+    public abstract class FlowMetadata
+    {
+        /// <summary>
+        /// Gets the user identifier.
+        /// </summary>
+        /// <param name="controller">The controller</param>
+        /// <returns>User identifier</returns>
+        public abstract string GetUserId(Controller controller);
+
+        /// <summary>Gets the authorization code flow.</summary>
+        public abstract IAuthorizationCodeFlow Flow { get; }
+
+        /// <summary>
+        /// Gets the authorization application's call back. That relative URL will handle the authorization code 
+        /// response.
+        /// </summary>
+        public virtual string AuthCallback
+        {
+            get { return @"/AuthCallback/IndexAsync"; }
+        }
+    }
+}


### PR DESCRIPTION
I have an ASP.NET Core project, where I needed to add integration with Google Calendar via OAuth2.  The Google.Apis.Auth.Mvc project is .NET Framework (and therefore, Windows) only, therefore I couldn't use it.

The simplest solution, considering its small size, was to do a straight port of the Mvc project, replacing some references and .NET API calls.

The result is in this PR, thought it might be useful for others.