### PR TITLE
Fix disposal of TwoWay handler

### DIFF
--- a/Src/Support/Google.Apis.Core/Http/TwoWayDelegatingHandler.cs
+++ b/Src/Support/Google.Apis.Core/Http/TwoWayDelegatingHandler.cs
@@ -46,15 +46,9 @@ namespace Google.Apis.Http
             if (disposing && !disposed)
             {
                 disposed = true;
-                try
-                {
-                    base.Dispose();
-                }
-                finally
-                {
-                    _alternativeHandler.Dispose();
-                }
+                _alternativeHandler.Dispose();
             }
+            base.Dispose(disposing);
         }
 
         /// <summary>


### PR DESCRIPTION
Previous code never called Dispose() on the base DelegatingHandler, meaning the inner handler was never dispoesd of. Fixes #1399