### PR TITLE
Added Metadata-Flavor header in request for IsRunningOnComputeEngine

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
@@ -119,6 +119,7 @@ namespace Google.Apis.Auth.OAuth2
                     try
                     {
                         var httpRequest = new HttpRequestMessage(HttpMethod.Get, MetadataServerUrl);
+                        httpRequest.Headers.Add(MetadataFlavor, GoogleMetadataHeader);
                         var response = await httpClient.SendAsync(httpRequest, cts.Token).ConfigureAwait(false);
                         if (response.Headers.TryGetValues(MetadataFlavor, out var headerValues)
                             && headerValues.Contains(GoogleMetadataHeader))


### PR DESCRIPTION
Fixes #1409

The method IsRunningOnComputeEngineNoCache checks that the metadata server returns the header Metadata-Flavor: Google. However, that endpoint will return an error if that same header is not also supplied in the request.

This means that one cannot use the default compute service account or [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)