### PR TITLE
Initial support for docfx: building and uploading support documentation

### DIFF
--- a/.kokoro/BuildAndUploadSupportDocs.bat
+++ b/.kokoro/BuildAndUploadSupportDocs.bat
@@ -1,0 +1,2 @@
+cd /d %~dp0
+"C:\Program Files\Git\bin\bash.exe" BuildAndUploadSupportDocs.sh

--- a/.kokoro/BuildAndUploadSupportDocs.sh
+++ b/.kokoro/BuildAndUploadSupportDocs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+declare -r docs_credentials="$KOKORO_KEYSTORE_DIR/73713_docuploader_service_account"
+
+./BuildSupportDocs.sh
+
+# Push documentation, if we've got the keystore key
+if [ -f $docs_credentials ]
+then
+  echo "Uploading documentation to googleapis.dev"
+  ./UploadSupportDocs.sh $docs_credentials docs-staging
+else
+  echo "No credentials for googleapis.dev; skipping"
+fi

--- a/.kokoro/BuildSupportDocs.sh
+++ b/.kokoro/BuildSupportDocs.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+declare -r repo_root=$(git rev-parse --show-toplevel)
+
+cd $repo_root
+
+source DocfxFunctions.sh
+install_docfx
+
+rm -rf Src/Support/*/obj
+rm -rf Src/Support/*/bin
+dotnet build Src/Support/GoogleApisClient.sln
+
+# Some versions of docfx fail if VSINSTALLDIR is set (and isn't a version they expect)
+export VSINSTALLDIR=
+
+# Extract the support libraries version number from the XML.
+# This is pretty horrible, but it works...
+declare -r version=$(grep \<Version\> Src/Support/CommonProjectProperties.xml | sed 's/</>/g' | cut -d\> -f 3)
+
+build_site() {
+  declare -r package=$1
+  declare -r directory=Src/Support/$1
+  declare -r dependencies="$2"
+  declare -r target_framework="$3"
+  declare -r json=$directory/docfx.json
+
+  cp Docs/docfx-1.json $json
+  cp Docs/index.md $directory
+  for dep in $dependencies
+  do
+    echo "      \"../$dep/obj/site/xrefmap.yml\"," >> $json
+  done
+  cat Docs/docfx-2.json >> $json
+  sed -i "s/\\\$package/$package/g" $json
+  sed -i "s/\\\$target/$target_framework/g" $json
+  sed -i "s/\\\$package/$package/g" $directory/index.md  
+  
+  $DOCFX metadata -f --disableGitFeatures $json
+  $DOCFX build --disableGitFeatures $json
+
+  sed -i "1s/^/baseUrl: https:\/\/googleapis.dev\/dotnet\/$package\/$version\/\n/" $directory/obj/site/xrefmap.yml
+}
+
+build_site Google.Apis.Core "" netstandard2.0
+build_site Google.Apis Google.Apis.Core netstandard2.0
+build_site Google.Apis.Auth "Google.Apis.Core Google.Apis" netstandard2.0
+build_site Google.Apis.Auth.Mvc "Google.Apis.Core Google.Apis Google.Apis.Auth" net45
+build_site Google.Apis.Auth.AspNetCore "Google.Apis.Core Google.Apis Google.Apis.Auth" netstandard2.0

--- a/.kokoro/UploadSupportDocs.sh
+++ b/.kokoro/UploadSupportDocs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+# Assumption: documentation has already been built
+
+if [[ -z "$1" || -z "$2" ]]
+then
+  echo "Usage: UploadSupportDocs.sh <service account json> <staging bucket>"
+  exit 1
+fi
+
+# Make sure we have the most recent version of pip, then install the gcp-docuploader package
+python -m pip install --upgrade pip
+python -m pip install -q gcp-docuploader
+
+declare -r service_account_json=$(realpath $1)
+declare -r staging_bucket=$2
+declare -r repo_root=$(git rev-parse --show-toplevel)
+cd $repo_root
+
+# Extract the support libraries version number from the XML.
+# This is pretty horrible, but it works...
+declare -r version=$(grep \<Version\> Src/Support/CommonProjectProperties.xml | sed 's/</>/g' | cut -d\> -f 3)
+declare -r packages="Google.Apis.Core Google.Apis Google.Apis.Auth Google.Apis.Auth.Mvc Google.Apis.Auth.AspNetCore"
+
+for pkg in $packages
+do
+  pushd Src/Support/$pkg/obj/site
+  echo "Generating metadata for $pkg"
+  python -m docuploader create-metadata --name $pkg --version $version --language dotnet --github-repository https://github.com/googleapis/google-api-dotnet-client
+
+  echo "Final upload stage"
+  python -m docuploader upload . --credentials $service_account_json --staging-bucket $staging_bucket
+  popd > /dev/null
+done

--- a/DocfxFunctions.sh
+++ b/DocfxFunctions.sh
@@ -1,0 +1,22 @@
+# This is intended to be imported using the "source" function from
+# any scripts that use docfx.
+
+declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
+declare -r TOOL_PACKAGES=$REPO_ROOT/packages
+declare -r DOCFX_VERSION=2.39.1
+declare -r DOCFX=$TOOL_PACKAGES/docfx.$DOCFX_VERSION/docfx.exe
+
+install_docfx() {
+  if [[ ! -f $DOCFX ]]
+  then
+    (echo "Fetching docfx v${DOCFX_VERSION}";
+     mkdir -p $TOOL_PACKAGES;
+     cd $TOOL_PACKAGES;
+     mkdir docfx.$DOCFX_VERSION;
+     cd docfx.$DOCFX_VERSION;
+     curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
+     unzip -q tmp.zip;
+     rm tmp.zip;
+     )
+  fi  
+}

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -1,0 +1,1 @@
+This directory contains template files used when generating documentation with docfx.

--- a/Docs/docfx-1.json
+++ b/Docs/docfx-1.json
@@ -1,0 +1,30 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "$package.csproj",
+          ],
+        },
+      ],
+      "dest": "obj/api",
+      "properties": {
+        "TargetFramework": "$target"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": "*.yml",
+        "src": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [
+          "index.md"
+        ]
+      }
+    ],
+    "xref": [

--- a/Docs/docfx-2.json
+++ b/Docs/docfx-2.json
@@ -1,0 +1,9 @@
+   ],
+    "globalMetadata": {
+      "_appTitle": "Google API support libraries",
+      "_disableContribution": true,
+      "_appFooter": " "
+    },
+    "dest": "obj/site"
+  }
+}

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -1,0 +1,1 @@
+This page is present as a root for the [API reference documentation](obj/api/$package.yml)


### PR DESCRIPTION
The scripts are all within the .kokoro directory to avoid confusion with the regular release process. Eventually we'd probably want to move them.