### PR TITLE
Allow the "entry namespace" in index.md to vary from the package name

### DIFF
--- a/.kokoro/BuildGeneratedDocs.sh
+++ b/.kokoro/BuildGeneratedDocs.sh
@@ -56,7 +56,7 @@ build_site() {
   sed -i "s/\\\$package/$package/g" $json
   sed -i "s/\\\$target/netstandard2.0/g" $json
   sed -i "s/\\\$title/$package/g" $json
-  sed -i "s/\\\$package/$package/g" $directory/index.md  
+  sed -i "s/\\\$entry_namespace/$package/g" $directory/index.md  
   
   $DOCFX metadata -f --disableGitFeatures $json
   $DOCFX build --disableGitFeatures $json

--- a/.kokoro/BuildSupportDocs.sh
+++ b/.kokoro/BuildSupportDocs.sh
@@ -28,6 +28,7 @@ build_site() {
   declare -r directory=Src/Support/$1
   declare -r dependencies="$2"
   declare -r target_framework="$3"
+  declare -r entry_namespace=$4
   declare -r json=$directory/docfx.json
 
   cp Docs/docfx-1.json $json
@@ -40,7 +41,7 @@ build_site() {
   sed -i "s/\\\$package/$package/g" $json
   sed -i "s/\\\$target/$target_framework/g" $json
   sed -i "s/\\\$title/Google API support libraries/g" $json
-  sed -i "s/\\\$package/$package/g" $directory/index.md  
+  sed -i "s/\\\$entry_namespace/$entry_namespace/g" $directory/index.md  
   
   $DOCFX metadata -f --disableGitFeatures $json
   $DOCFX build --disableGitFeatures $json
@@ -48,8 +49,8 @@ build_site() {
   sed -i "1s/^/baseUrl: https:\/\/googleapis.dev\/dotnet\/$package\/$version\/\n/" $directory/obj/site/xrefmap.yml
 }
 
-build_site Google.Apis.Core "" netstandard2.0
-build_site Google.Apis Google.Apis.Core netstandard2.0
-build_site Google.Apis.Auth "Google.Apis.Core Google.Apis" netstandard2.0
-build_site Google.Apis.Auth.Mvc "Google.Apis.Core Google.Apis Google.Apis.Auth" net45
-build_site Google.Apis.Auth.AspNetCore "Google.Apis.Core Google.Apis Google.Apis.Auth" netstandard2.0
+build_site Google.Apis.Core "" netstandard2.0 Google.Apis
+build_site Google.Apis Google.Apis.Core netstandard2.0 Google.Apis
+build_site Google.Apis.Auth "Google.Apis.Core Google.Apis" netstandard2.0 Google.Apis.Auth
+build_site Google.Apis.Auth.Mvc "Google.Apis.Core Google.Apis Google.Apis.Auth" net45 Google.Apis.Auth.Mvc
+build_site Google.Apis.Auth.AspNetCore "Google.Apis.Core Google.Apis Google.Apis.Auth" netstandard2.0 Google.Apis.Auth.AspNetCore

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -1,1 +1,1 @@
-This page is present as a root for the [API reference documentation](obj/api/$package.yml)
+This page is present as a root for the [API reference documentation](obj/api/$entry_namespace.yml)


### PR DESCRIPTION
This is needed because Google.Apis.Core is the name of a package, but it doesn't contain a Google.Apis.Core namespace.