### PR TITLE
Fix upload request handling

### DIFF
--- a/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.cs
@@ -934,7 +934,9 @@ namespace Google.Apis.Tests.Apis.Upload
             public bool Equals(TestRequest other)
             {
                 if (other == null)
+                {
                     return false;
+                }
 
                 return Name == null ? other.Name == null : Name.Equals(other.Name) &&
                     Description == null ? other.Description == null : Description.Equals(other.Description);
@@ -951,7 +953,9 @@ namespace Google.Apis.Tests.Apis.Upload
             public bool Equals(TestResponse other)
             {
                 if (other == null)
+                {
                     return false;
+                }
 
                 return Id.Equals(other.Id) &&
                     Name == null ? other.Name == null : Name.Equals(other.Name) &&


### PR DESCRIPTION
Note: no tests, as we're trying to obtain the same behavior in a safer way. Trying to test that we don't affect the client would be really painful.

I *did* check that after I'd removed the "attach to the HttpClient" and before I'd added the "attach to the request", the tests failed.