### PR TITLE
Reapply "Update version v1.40.3 -> v1.41.0"

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/features.json
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/features.json
@@ -1,8 +1,8 @@
 {
   "language": "csharp",
   "description": "C# libraries for Google APIs.",
-  "releaseVersion": "1.40.3", "comment1": "Version of generated package.",
-  "currentSupportVersion": "1.40.3", "comment2": "Version of support library upon which to depend.",
+  "releaseVersion": "1.41.0", "comment1": "Version of generated package.",
+  "currentSupportVersion": "1.41.0", "comment2": "Version of support library upon which to depend.",
   "pclSupportVersion": "1.25.0", "comment3": "Version of PCL support library.",
   "net40SupportVersion": "1.10.0", "comment4": "Version of net40 support library.",
 

--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -2,7 +2,7 @@
 
   <!-- common nupkg information -->
   <PropertyGroup>
-    <Version>1.40.3</Version>
+    <Version>1.41.0</Version>
     <Authors>Google Inc.</Authors>
     <Copyright>Copyright 2017 Google Inc.</Copyright>
     <PackageTags>Google</PackageTags>


### PR DESCRIPTION
Reverts googleapis/google-api-dotnet-client#1445, which itself reverted #1443.

The issues have been resolved server-side, so we're now okay to go ahead with this.