### PR TITLE
Clone VersionHeaderBuilder before modifying it in BaseClientService

### DIFF
--- a/Src/Support/Google.Apis.Tests/Apis/Services/BaseClientServiceTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Services/BaseClientServiceTest.cs
@@ -381,5 +381,13 @@ namespace Google.Apis.Tests.Apis.Services
             Assert.Contains("gl-dotnet/", header);
             Assert.Contains("gdcl/", header);
         }
+
+        [Fact]
+        public void SharedInitializer()
+        {
+            var initializer = new BaseClientService.Initializer();
+            var service1 = new TranslateService(initializer);
+            var service2 = new TranslateService(initializer);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1453

(We should wait for verification that my intuition was correct on #1453 before releasing a new version though.)