### PR TITLE
Allow null Scopes

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
@@ -72,7 +72,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             Assert.IsType<SystemClock>(flow.Clock);
             Assert.Null(flow.DataStore);
             Assert.NotNull(flow.HttpClient);
-            Assert.NotNull(flow.Scopes);
+            Assert.Null(flow.Scopes);
             Assert.Equal("https://token.com", flow.TokenServerUrl);
 
             // Disable "<member> is obsolete" warning for these uses.
@@ -140,6 +140,18 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             Assert.Equal("redirect", request.RedirectUri);
             Assert.Equal("code", request.ResponseType);
             Assert.Equal("a b", request.Scope);
+            Assert.Null(request.State);
+        }
+
+        [Fact]
+        public void TestCreateAuthorizationCodeRequest_DefaultValues()
+        {
+            var request = CreateFlow().CreateAuthorizationCodeRequest("redirect");
+            Assert.Equal(new Uri(AuthorizationCodeUrl), request.AuthorizationServerUrl);
+            Assert.Equal("id", request.ClientId);
+            Assert.Equal("redirect", request.RedirectUri);
+            Assert.Equal("code", request.ResponseType);
+            Assert.Null(request.Scope);
             Assert.Null(request.State);
         }
 
@@ -408,10 +420,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             {
                 initializer.DataStore = dataStore;
             }
-            if (scopes != null)
-            {
-                initializer.Scopes = scopes;
-            }
+            initializer.Scopes = scopes;
             return new AuthorizationCodeFlow(initializer);
         }
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -231,7 +231,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             return new AuthorizationCodeRequestUrl(new Uri(AuthorizationServerUrl))
             {
                 ClientId = ClientSecrets.ClientId,
-                Scope = string.Join(" ", Scopes),
+                Scope = Scopes == null ? null : string.Join(" ", Scopes),
                 RedirectUri = redirectUri
             };
         }


### PR DESCRIPTION
Previously, using an initializer with Scopes set to null would crash
when CreateAuthorizationCodeRequest() was called. Now, the null Scopes
propogates safely through as a null Scope for AuthorizationCodeRequestUrl.

This is necessary because some OAuth sites do not recognize the "scope"
parameter and will return an error instead of the authorization token if
the URL contains it.

I have updated the tests and added one for the default authorization
code request.