### PR TITLE
Allow null Scopes in ExchangeCodeForTokenAsync()

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
@@ -72,7 +72,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             Assert.IsType<SystemClock>(flow.Clock);
             Assert.Null(flow.DataStore);
             Assert.NotNull(flow.HttpClient);
-            Assert.NotNull(flow.Scopes);
+            Assert.Null(flow.Scopes);
             Assert.Equal("https://token.com", flow.TokenServerUrl);
 
             // Disable "<member> is obsolete" warning for these uses.
@@ -140,6 +140,18 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             Assert.Equal("redirect", request.RedirectUri);
             Assert.Equal("code", request.ResponseType);
             Assert.Equal("a b", request.Scope);
+            Assert.Null(request.State);
+        }
+
+        [Fact]
+        public void TestCreateAuthorizationCodeRequest_DefaultValues()
+        {
+            var request = CreateFlow().CreateAuthorizationCodeRequest("redirect");
+            Assert.Equal(new Uri(AuthorizationCodeUrl), request.AuthorizationServerUrl);
+            Assert.Equal("id", request.ClientId);
+            Assert.Equal("redirect", request.RedirectUri);
+            Assert.Equal("code", request.ResponseType);
+            Assert.Null(request.Scope);
             Assert.Null(request.State);
         }
 
@@ -408,10 +420,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             {
                 initializer.DataStore = dataStore;
             }
-            if (scopes != null)
-            {
-                initializer.Scopes = scopes;
-            }
+            initializer.Scopes = scopes;
             return new AuthorizationCodeFlow(initializer);
         }
 

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
@@ -182,6 +182,30 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
         }
 
         [Fact]
+        public void TestExchangeCodeForTokenAsync_NullScopes()
+        {
+            var mock = new Mock<IDataStore>();
+            var handler = new FetchTokenMessageHandler();
+            handler.AuthorizationCodeTokenRequest = new AuthorizationCodeTokenRequest()
+            {
+                Code = "c0de",
+                RedirectUri = "redIrect",
+                Scope = null
+            };
+            MockHttpClientFactory mockFactory = new MockHttpClientFactory(handler);
+
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+            tcs.SetResult(null);
+            mock.Setup(ds => ds.StoreAsync("uSer", It.IsAny<TokenResponse>())).Returns(tcs.Task);
+
+            var flow = CreateFlow(httpClientFactory: mockFactory, scopes: null, dataStore: mock.Object);
+            var response = flow.ExchangeCodeForTokenAsync("uSer", "c0de", "redIrect", CancellationToken.None).Result;
+            SubtestTokenResponse(response);
+
+            mock.Verify(ds => ds.StoreAsync("uSer", It.IsAny<TokenResponse>()));
+        }
+
+        [Fact]
         public void TestRefreshTokenAsync()
         {
             var mock = new Mock<IDataStore>();

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -231,7 +231,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             return new AuthorizationCodeRequestUrl(new Uri(AuthorizationServerUrl))
             {
                 ClientId = ClientSecrets.ClientId,
-                Scope = string.Join(" ", Scopes),
+                Scope = Scopes == null ? null : string.Join(" ", Scopes),
                 RedirectUri = redirectUri
             };
         }

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -242,7 +242,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
         {
             var authorizationCodeTokenReq = new AuthorizationCodeTokenRequest
             {
-                Scope = string.Join(" ", Scopes),
+                Scope = Scopes == null ? null : string.Join(" ", Scopes),
                 RedirectUri = redirectUri,
                 Code = code,
             };


### PR DESCRIPTION
I added the same check and a test for ExchangeCodeForTokenAsync() in the second CL.