### PR TITLE
Include a build in the pack stage of building support libraries

### DIFF
--- a/BuildSupport.sh
+++ b/BuildSupport.sh
@@ -15,4 +15,4 @@ export CI=true
 
 dotnet restore Src/Support/GoogleApisClient.sln
 dotnet build Src/Support/GoogleApisClient.sln --configuration $BUILD_CONFIGURATION --no-restore
-dotnet pack Src/Support/GoogleApisClient.sln --configuration $BUILD_CONFIGURATION --no-restore --no-build --output $NUPKG_DIR
+dotnet pack Src/Support/GoogleApisClient.sln --configuration $BUILD_CONFIGURATION --no-restore --output $NUPKG_DIR


### PR DESCRIPTION
I don't understand why this is now required. I'll investigate further once we're successfully releasing again.