### PR TITLE
Minor changes to quota project as a header related code.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
@@ -42,7 +42,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
 ""client_secret"": ""CLIENT_SECRET"",
 ""refresh_token"": ""REFRESH_TOKEN"",
 ""project_id"": ""PROJECT_ID"",
-""quota_project"": ""QUOTA_PROJECT"",
+""quota_project_id"": ""QUOTA_PROJECT"",
 ""type"": ""authorized_user""}";
         private const string DummyServiceAccountCredentialFileContents = @"{
 ""private_key_id"": ""PRIVATE_KEY_ID"",

--- a/Src/Support/Google.Apis.Auth/OAuth2/AccessTokenWithHeaders.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/AccessTokenWithHeaders.cs
@@ -30,25 +30,30 @@ namespace Google.Apis.Auth.OAuth2
         private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> s_emptyHeaders = 
             new ReadOnlyDictionary<string, IReadOnlyList<string>>(new Dictionary<string, IReadOnlyList<string>>());
 
-        internal AccessTokenWithHeaders(string token, string quotaProject = null)
+        /// <summary>
+        /// Constructs an <see cref="AccessTokenWithHeaders"/> based on a given token and headers.
+        /// </summary>
+        /// <param name="token">The token to build this instance for. May be null.</param>
+        /// <param name="headers">The collection of headers that may accompany the token. May be null.</param>
+        public AccessTokenWithHeaders(string token, IReadOnlyDictionary<string, IReadOnlyList<string>> headers)
         {
             AccessToken = token;
-            if (quotaProject == null)
-            {
-                Headers = s_emptyHeaders;
-            }
-            else
-            {
-                Headers = new ReadOnlyDictionary<string, IReadOnlyList<string>>(
+            Headers = headers ?? s_emptyHeaders;
+        }
+
+        internal AccessTokenWithHeaders(string token, string quotaProject = null)
+            : this (token,
+                  quotaProject == null ?
+                  null :
+                  new ReadOnlyDictionary<string, IReadOnlyList<string>>(
                     new Dictionary<string, IReadOnlyList<string>>
                     {
-                        { 
+                        {
                             QuotaProjectHeaderName,
                             new List<string> { quotaProject }.AsReadOnly()
                         }
-                    });
-            }
-        }
+                    }))
+        { }
 
         /// <summary>
         /// An access token that can be used to authorize a request.

--- a/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
@@ -57,7 +57,7 @@ namespace Google.Apis.Auth.OAuth2
         /// Project ID associated with this credential for the purposes
         /// of quota calculations and billing.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("quota_project")]
+        [Newtonsoft.Json.JsonProperty("quota_project_id")]
         public string QuotaProject { get; set; }
 
         /// <summary>


### PR DESCRIPTION
- Changes the JSON var name for quota project from `quota_project` to `quota_project_id`.
- Adds a public constructor to `AccessTokenWithHeaders`, mainly to be used for testing purposes outside of `Google.Apis.Auth`