### PR TITLE
Proposal: Fixes service/call credential clashes.

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -151,7 +151,8 @@ namespace Google.Apis.Auth.OAuth2
             private readonly string _accessToken;
             private readonly IAccessMethod _accessMethod;
 
-            public void Initialize(ConfigurableHttpClient httpClient) => httpClient.MessageHandler.AddExecuteInterceptor(this);
+            public void Initialize(ConfigurableHttpClient httpClient) => 
+                OverridableCredential.WrapInitialize(this, httpClient);
 
             public Task<string> GetAccessTokenForRequestAsync(string authUri = null, CancellationToken cancellationToken = default(CancellationToken)) =>
                 Task.FromResult(_accessToken);

--- a/Src/Support/Google.Apis.Auth/OAuth2/OverridableCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/OverridableCredential.cs
@@ -1,0 +1,122 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+using Google.Apis.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    // TODO: Consider making public so that implementons of ICredential other than us
+    // can benefit.
+    /// <summary>
+    /// Wrapper used by credentials when included at the service level so that they are 
+    /// overwritten by any specific call credential.
+    /// </summary>
+    /// <remarks>
+    /// Credentials are included at the service level through the
+    /// <see cref="IConfigurableHttpClientInitializer.Initialize(ConfigurableHttpClient)"/> method.
+    /// For a credential to be able to be overwritten by a call credential, instead of directly adding
+    /// its handlers and interceptors to the <see cref="ConfigurableHttpClient"/> it needs to wrap itself
+    /// in an <see cref="OverridableCredential"/> and have the overridable credential initialize the
+    /// <see cref="ConfigurableHttpClient"/>. The overridable credential will add the same handlers and interceptors
+    /// as the original credential would but wrapping them in some code that stops them from executing if other credentials
+    /// are present on the request.
+    /// </remarks>
+    internal class OverridableCredential : ICredential, IHttpExecuteInterceptor, IHttpUnsuccessfulResponseHandler
+    {
+        private readonly ICredential _underlyingCredential;
+
+        internal OverridableCredential(ICredential underlyingCredential) =>
+            _underlyingCredential = underlyingCredential.ThrowIfNull(nameof(underlyingCredential));
+
+        internal static void WrapInitialize(ICredential credential, ConfigurableHttpClient httpClient)
+        {
+            OverridableCredential cred = new OverridableCredential(credential);
+            cred.Initialize(httpClient);
+        }
+
+        public Task<string> GetAccessTokenForRequestAsync(string authUri = null, CancellationToken cancellationToken = default) =>
+            _underlyingCredential.GetAccessTokenForRequestAsync(authUri, cancellationToken);
+
+
+        public void Initialize(ConfigurableHttpClient httpClient)
+        {
+
+            if (_underlyingCredential is IHttpExecuteInterceptor)
+            {
+                httpClient.MessageHandler.AddExecuteInterceptor(this);
+            }
+            if (_underlyingCredential is IHttpUnsuccessfulResponseHandler)
+            {
+                httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
+            }
+        }
+
+        public async Task InterceptAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Only intercept service level if there's no call level credential.
+            if (!HasPerCallCredentials(request))
+            {
+                await (_underlyingCredential as IHttpExecuteInterceptor)
+                    .InterceptAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        public async Task<bool> HandleResponseAsync(HandleUnsuccessfulResponseArgs args)
+        {
+            // Even though the call level credential might only be an interceptor and not
+            // a response handler we cannot execute the service level response handler
+            // associated to another (the service level) credential.
+            if (!HasPerCallCredentials(args.Request))
+            {
+                return await (_underlyingCredential as IHttpUnsuccessfulResponseHandler)
+                    .HandleResponseAsync(args)
+                    .ConfigureAwait(false);
+            }
+
+            return false;
+        }
+
+        private bool HasPerCallCredentials(HttpRequestMessage request)
+        {
+            if (request.Properties.TryGetValue(ConfigurableMessageHandler.ExecuteInterceptorKey, out var interceptors) &&
+                interceptors is IList<IHttpExecuteInterceptor> perCallInterceptors &&
+                perCallInterceptors.Any(i => i is ICredential))
+            {
+                return true;
+            }
+
+            // Very unlikely but technically possible 
+            // that a credential is not an interceptor but only a response handler.
+            if (request.Properties.TryGetValue(ConfigurableMessageHandler.UnsuccessfulResponseHandlerKey, out var handlers) &&
+                handlers is IList<IHttpUnsuccessfulResponseHandler> perCallHandlers &&
+                perCallHandlers.Any(i => i is ICredential))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -147,11 +147,8 @@ namespace Google.Apis.Auth.OAuth2
         #region IConfigurableHttpClientInitializer
 
         /// <inheritdoc/>
-        public void Initialize(ConfigurableHttpClient httpClient)
-        {
-            httpClient.MessageHandler.AddExecuteInterceptor(this);
-            httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
-        }
+        public void Initialize(ConfigurableHttpClient httpClient) =>
+            OverridableCredential.WrapInitialize(this, httpClient);
 
         #endregion
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
@@ -119,11 +119,8 @@ namespace Google.Apis.Auth.OAuth2
         #region IConfigurableHttpClientInitializer
 
         /// <inheritdoc/>
-        public void Initialize(ConfigurableHttpClient httpClient)
-        {
-            httpClient.MessageHandler.AddExecuteInterceptor(this);
-            httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
-        }
+        public void Initialize(ConfigurableHttpClient httpClient) =>
+            OverridableCredential.WrapInitialize(this, httpClient);
 
         #endregion
 

--- a/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
+++ b/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
@@ -61,6 +61,15 @@ namespace Google.Apis.Requests
         }
 
         /// <summary>
+        /// Removes all unsuccessful response handler of the given type if there are any.
+        /// </summary>
+        /// <typeparam name="THandler">The type of the handlers to remove.</typeparam>
+        public void RemoveUnsuccessfulResponseHandlers<THandler>()
+        {
+            _unsuccessfulResponseHandlers?.RemoveAll(handler => handler is THandler);
+        }
+
+        /// <summary>
         /// Add an exception handler for this request only.
         /// </summary>
         /// <param name="handler">The exception handler. Must not be <c>null</c>.</param>
@@ -86,6 +95,15 @@ namespace Google.Apis.Requests
                 _executeInterceptors = new List<IHttpExecuteInterceptor>();
             }
             _executeInterceptors.Add(handler);
+        }
+
+        /// <summary>
+        /// Removes all execute interceptors of the given type if there are any.
+        /// </summary>
+        /// <typeparam name="TInterceptor">The type of the interceptors to remove.</typeparam>
+        public void RemoveExecuteInterceptors<TInterceptor>()
+        {
+            _executeInterceptors?.RemoveAll(handler => handler is TInterceptor);
         }
     }
 

--- a/Src/Support/IntegrationTests/PerCallAuthTests.cs
+++ b/Src/Support/IntegrationTests/PerCallAuthTests.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Http;
 using Google.Apis.Requests;
@@ -22,9 +23,11 @@ using Google.Apis.Storage.v1;
 using Google.Apis.Storage.v1.Data;
 using IntegrationTests.Utils;
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Apis.Auth.OAuth2.GoogleCredential;
 
 namespace IntegrationTests
 {
@@ -46,7 +49,7 @@ namespace IntegrationTests
         }
 
         [Fact]
-        public void OverrideServiceCredentialWithPerCallCredential()
+        public void OverridesServiceCredentialWithPerCallCredential_Header()
         {
             // Broken credential in the client.
             StorageService client = new StorageService(new BaseClientService.Initializer
@@ -59,6 +62,151 @@ namespace IntegrationTests
             Buckets buckets = client.Buckets.List(Helper.GetProjectId()).AddCredential(credential).Execute();
             // Check the response is sane.
             Assert.NotNull(buckets.Items);
+        }
+
+        private class RequestInterceptorCredentialWrapper : IConfigurableHttpClientInitializer, IHttpExecuteInterceptor
+        {
+            private AccessTokenCredential _credential;
+            public HttpRequestMessage Request { get; private set; }
+
+            public RequestInterceptorCredentialWrapper(string accessToken, IAccessMethod accessMethod) =>
+                _credential = new AccessTokenCredential(accessToken, accessMethod);
+
+            public void Initialize(ConfigurableHttpClient httpClient)
+            {
+                _credential.Initialize(httpClient);
+                httpClient.MessageHandler.AddExecuteInterceptor(this);
+            }
+
+            public Task InterceptAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Request = request;
+                return Task.FromResult(true);
+            }
+        }
+
+        [Fact]
+        public void OverridesServiceCredentialWithPerCallCredential_QueryString()
+        {
+            var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+            var callCredential = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+
+            // Set one credential in the client
+            StorageService client = new StorageService(new BaseClientService.Initializer
+            {
+                ApplicationName = "IntegrationTest",
+                HttpClientInitializer = serviceCredential
+            }); ;
+
+            // Create a request with a per-call credential.; this overrides the service-level credential.
+            var request = client.Buckets.List(Helper.GetProjectId()).AddCredential(callCredential);
+
+            // This should throw unauthorized, the credentials are fake, but let's make sure the
+            // request got to the server so we know all appropiate interceptors executed.
+            var exception = Assert.ThrowsAny<GoogleApiException>(() => request.Execute());
+            Assert.Equal(401, exception.Error.Code);
+
+            string query = serviceCredential.Request.RequestUri.Query;
+
+            int serviceIndex = query.IndexOf("access_token=SERVICE_CREDENTIAL_TOKEN", StringComparison.OrdinalIgnoreCase);
+            int callIndex = query.LastIndexOf("access_token=CALL_CREDENTIAL_TOKEN", StringComparison.OrdinalIgnoreCase);
+
+            Assert.Equal(-1, serviceIndex);
+            Assert.NotEqual(-1, callIndex);
+        }
+
+        [Fact]
+        public void OverridesServiceCredentialWithPerCallCredential_Mixed_Header_Query()
+        {
+            var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.AuthorizationHeaderAccessMethod());
+            var callCredential = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+
+            // Set one credential in the client
+            StorageService client = new StorageService(new BaseClientService.Initializer
+            {
+                ApplicationName = "IntegrationTest",
+                HttpClientInitializer = serviceCredential
+            }); ;
+
+            // Create a request with a per-call credential.; this overrides the service-level credential.
+            var request = client.Buckets.List(Helper.GetProjectId()).AddCredential(callCredential);
+
+            // This should throw unauthorized, the credentials are fake, but let's make sure the
+            // request got to the server so we know all appropiate interceptors executed.
+            var exception = Assert.ThrowsAny<GoogleApiException>(() => request.Execute());
+            Assert.Equal(401, exception.Error.Code);
+
+            HttpRequestMessage httpRequest = serviceCredential.Request;
+            string query = httpRequest.RequestUri.Query;
+
+            int callIndex = query.LastIndexOf("access_token=CALL_CREDENTIAL_TOKEN", StringComparison.OrdinalIgnoreCase);
+
+            Assert.Null(httpRequest.Headers.Authorization);
+            Assert.NotEqual(-1, callIndex);
+        }
+
+        [Fact]
+        public void OverridesServiceCredentialWithPerCallCredential_Mixed_Query_Header()
+        {
+            var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+            var callCredential = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN", new BearerToken.AuthorizationHeaderAccessMethod());
+
+            // Set one credential in the client
+            StorageService client = new StorageService(new BaseClientService.Initializer
+            {
+                ApplicationName = "IntegrationTest",
+                HttpClientInitializer = serviceCredential
+            }); ;
+
+            // Create a request with a per-call credential.; this overrides the service-level credential.
+            var request = client.Buckets.List(Helper.GetProjectId()).AddCredential(callCredential);
+
+            // This should throw unauthorized, the credentials are fake, but let's make sure the
+            // request got to the server so we know all appropiate interceptors executed.
+            var exception = Assert.ThrowsAny<GoogleApiException>(() => request.Execute());
+            Assert.Equal(401, exception.Error.Code);
+
+            HttpRequestMessage httpRequest = serviceCredential.Request;
+            string query = httpRequest.RequestUri.Query;
+
+            int serviceIndex = query.LastIndexOf("access_token=SERVICE_CREDENTIAL_TOKEN", StringComparison.OrdinalIgnoreCase);
+
+            Assert.Equal(-1, serviceIndex);
+            Assert.Equal("CALL_CREDENTIAL_TOKEN", httpRequest.Headers.Authorization.Parameter);
+        }
+
+        [Fact]
+        public void OverridesServiceCredentialWithPerCallCredential_TwoCallCredentials()
+        {
+            var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+            var callCredential1 = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN_1", new BearerToken.QueryParameterAccessMethod());
+            var callCredential2 = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN_2", new BearerToken.QueryParameterAccessMethod());
+
+            // Set one credential in the client
+            StorageService client = new StorageService(new BaseClientService.Initializer
+            {
+                ApplicationName = "IntegrationTest",
+                HttpClientInitializer = serviceCredential
+            }); ;
+
+            // Create a request with a per-call credential.; this overrides the service-level credential.
+            var request = client.Buckets.List(Helper.GetProjectId()).AddCredential(callCredential1);
+            request.AddCredential(callCredential2);
+
+            // This should throw unauthorized, the credentials are fake, but let's make sure the
+            // request got to the server so we know all appropiate interceptors executed.
+            var exception = Assert.ThrowsAny<GoogleApiException>(() => request.Execute());
+            Assert.Equal(401, exception.Error.Code);
+
+            string query = serviceCredential.Request.RequestUri.Query;
+
+            int serviceIndex = query.IndexOf("access_token=SERVICE_CREDENTIAL_TOKEN", StringComparison.OrdinalIgnoreCase);
+            int call1Index = query.LastIndexOf("access_token=CALL_CREDENTIAL_TOKEN_1", StringComparison.OrdinalIgnoreCase);
+            int call2Index = query.LastIndexOf("access_token=CALL_CREDENTIAL_TOKEN_2", StringComparison.OrdinalIgnoreCase);
+
+            Assert.Equal(-1, serviceIndex);
+            Assert.Equal(-1, call1Index);
+            Assert.NotEqual(-1, call2Index);
         }
 
         [Fact]


### PR DESCRIPTION
Creating a draft PR because this needs more testing. But it works because the itegration tests in the last commit are all green. All other tests as well.

This is extremely fidley (the second commit mostly) and won't work for credentials that don't use the `OverridableCredential` to wrap themselves on `Initialize`. I don't know if there are people out there implementing `ICredential`, they'd probably need to use `OverridableCredential`.

I'm trying to work out another solution that I think might be slightly better, but I'm really not sure yet if it's going to work. And for it to work, we might need for Google.Apis.Core to depend on Google.Apis.Auth and I don't know if we want that.