### PR TITLE
Fixes service/call credential clashes in REST clients.

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -151,7 +151,8 @@ namespace Google.Apis.Auth.OAuth2
             private readonly string _accessToken;
             private readonly IAccessMethod _accessMethod;
 
-            public void Initialize(ConfigurableHttpClient httpClient) => httpClient.MessageHandler.AddExecuteInterceptor(this);
+            public void Initialize(ConfigurableHttpClient httpClient) =>
+                httpClient.MessageHandler.Credential = this;
 
             public Task<string> GetAccessTokenForRequestAsync(string authUri = null, CancellationToken cancellationToken = default(CancellationToken)) =>
                 Task.FromResult(_accessToken);

--- a/Src/Support/Google.Apis.Auth/OAuth2/RequestExtensions.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/RequestExtensions.cs
@@ -51,13 +51,8 @@ namespace Google.Apis.Auth.OAuth2
             {
                 throw new ArgumentException("Credential must implement IHttpExecuteInterceptor.", nameof(credential));
             }
-            request.AddExecuteInterceptor(httpExecuteInterceptor);
-            // Add the optional unsuccessful interceptor to this request.
-            if (credential is IHttpUnsuccessfulResponseHandler httpUnsuccessfulResponseHandler)
-            {
-                request.AddUnsuccessfulResponseHandler(httpUnsuccessfulResponseHandler);
-            }
-            // Return the request.
+            request.Credential = httpExecuteInterceptor;
+
             return request;
         }
     }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -147,11 +147,8 @@ namespace Google.Apis.Auth.OAuth2
         #region IConfigurableHttpClientInitializer
 
         /// <inheritdoc/>
-        public void Initialize(ConfigurableHttpClient httpClient)
-        {
-            httpClient.MessageHandler.AddExecuteInterceptor(this);
-            httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
-        }
+        public void Initialize(ConfigurableHttpClient httpClient) =>
+            httpClient.MessageHandler.Credential = this;
 
         #endregion
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
@@ -119,11 +119,8 @@ namespace Google.Apis.Auth.OAuth2
         #region IConfigurableHttpClientInitializer
 
         /// <inheritdoc/>
-        public void Initialize(ConfigurableHttpClient httpClient)
-        {
-            httpClient.MessageHandler.AddExecuteInterceptor(this);
-            httpClient.MessageHandler.AddUnsuccessfulResponseHandler(this);
-        }
+        public void Initialize(ConfigurableHttpClient httpClient) =>
+            httpClient.MessageHandler.Credential = this;
 
         #endregion
 

--- a/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
+++ b/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
@@ -47,6 +47,13 @@ namespace Google.Apis.Requests
         protected List<IHttpExecuteInterceptor> _executeInterceptors;
 
         /// <summary>
+        /// Credential to use for this request.
+        /// If <see cref="Credential"/> implements <see cref="IHttpUnsuccessfulResponseHandler"/>
+        /// then it will also be included as a handler of an unsuccessful response.
+        /// </summary>
+        public IHttpExecuteInterceptor Credential { get; set; }
+
+        /// <summary>
         /// Add an unsuccessful response handler for this request only.
         /// </summary>
         /// <param name="handler">The unsuccessful response handler. Must not be <c>null</c>.</param>
@@ -271,6 +278,10 @@ namespace Google.Apis.Requests
             if (_executeInterceptors != null)
             {
                 request.Properties.Add(ConfigurableMessageHandler.ExecuteInterceptorKey, _executeInterceptors);
+            }
+            if (Credential != null)
+            {
+                request.Properties.Add(ConfigurableMessageHandler.CredentialKey, Credential);
             }
             ModifyRequest?.Invoke(request);
             return request;


### PR DESCRIPTION
I prefer this one to #1512 but still I'm not oh so happy. I've tried to change as least as possible, and this is the best I can come up with. Ideas are more than welcome.

If we were to take a `Google.Apis.Auth` dependency on `Google.Apis` and `Google.Apis.Core`, we can expect the credentials to be `ICredential` instead of `IHttpExecuteInterceptor`, but I think that anyway, they need to be `IHttpExecuteInterceptor` so no real advantage to that.

The integration tests are the same in both PRs.