### PR TITLE
OIDC Token emission support

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
@@ -15,6 +15,9 @@ limitations under the License.
 */
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Tests.Mocks;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Apis.Auth.Tests.OAuth2
@@ -36,6 +39,92 @@ namespace Google.Apis.Auth.Tests.OAuth2
             // Two subsequent invocations should return the same task.
             Assert.Same(ComputeCredential.IsRunningOnComputeEngine(),
                 ComputeCredential.IsRunningOnComputeEngine());
+        }
+
+        [Fact]
+        public async Task FetchesOidcToken()
+        {
+            var clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            var messageHandler = new OidcTokenSuccessMessageHandler(clock);
+            var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
+            {
+                Clock = clock,
+                HttpClientFactory = new MockHttpClientFactory(messageHandler)
+            };
+            var credential = new ComputeCredential(initializer);
+
+            var oidcToken = await credential.GetOidcTokenAsync(OidcTokenOptions.FromTargetAudience("audience"));
+
+            Assert.Equal("very_fake_access_token_1", await oidcToken.GetAccessTokenAsync());
+            // Move the clock some but not enough that the token expires.
+            clock.UtcNow = clock.UtcNow.AddMinutes(20);
+            Assert.Equal("very_fake_access_token_1", await oidcToken.GetAccessTokenAsync());
+            // Only the first call should have resulted in a request. The second time the token hadn't expired.
+            Assert.Equal(1, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task RefreshesOidcToken()
+        {
+            var clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            var messageHandler = new OidcTokenSuccessMessageHandler(clock);
+            var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
+            {
+                Clock = clock,
+                HttpClientFactory = new MockHttpClientFactory(messageHandler)
+            };
+            var credential = new ComputeCredential(initializer);
+
+            var oidcToken = await credential.GetOidcTokenAsync(OidcTokenOptions.FromTargetAudience("audience"));
+
+            Assert.Equal("very_fake_access_token_1", await oidcToken.GetAccessTokenAsync());
+            // Move the clock so that the token expires.
+            clock.UtcNow = clock.UtcNow.AddHours(2);
+            Assert.Equal("very_fake_access_token_2", await oidcToken.GetAccessTokenAsync());
+            // Two calls, because the second time we tried to get the token, the first one had expired.
+            Assert.Equal(2, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task FetchesOidcToken_WithDefaultOptions()
+        {
+            var clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            var messageHandler = new OidcTokenSuccessMessageHandler(clock);
+            var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
+            {
+                Clock = clock,
+                HttpClientFactory = new MockHttpClientFactory(messageHandler)
+            };
+            var credential = new ComputeCredential(initializer);
+
+            var oidcToken = await credential.GetOidcTokenAsync(OidcTokenOptions.FromTargetAudience("any_audience"));
+            await oidcToken.GetAccessTokenAsync();
+
+            Assert.Equal("?audience=any_audience&format=full", messageHandler.LatestRequest.RequestUri.Query);
+        }
+
+        [Theory]
+        [InlineData(OidcTokenFormat.Full, "another_audience", "?audience=another_audience&format=full")]
+        [InlineData(OidcTokenFormat.Standard, "another_audience", "?audience=another_audience")]
+        [InlineData(OidcTokenFormat.FullWithLicences, "another_audience", "?audience=another_audience&format=full&licenses=true")]
+        public async Task FetchesOidcToken_WithOptions(OidcTokenFormat format, string targetAudience, string expectedQueryString)
+        {
+            var clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            var messageHandler = new OidcTokenSuccessMessageHandler(clock);
+            var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
+            {
+                Clock = clock,
+                HttpClientFactory = new MockHttpClientFactory(messageHandler)
+            };
+            var credential = new ComputeCredential(initializer);
+
+            var oidcToken = await credential.GetOidcTokenAsync(
+                OidcTokenOptions.FromTargetAudience("any_audience")
+                .WithTargetAudience(targetAudience)
+                .WithTokenFormat(format));
+            await oidcToken.GetAccessTokenAsync();
+
+            Assert.Equal(expectedQueryString, messageHandler.LatestRequest.RequestUri.Query);
         }
     }
 }

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenFakes.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenFakes.cs
@@ -1,0 +1,63 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Json;
+using Google.Apis.Tests.Mocks;
+using Google.Apis.Util;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    internal class OidcTokenSuccessMessageHandler : CountableMessageHandler
+    {
+        private readonly IClock _clock;
+
+        public HttpRequestMessage LatestRequest { get; private set; }
+        public string LatestRequestContent { get; private set; }
+
+        public OidcTokenSuccessMessageHandler(IClock clock) => _clock = clock;
+
+        protected override async Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LatestRequest = request;
+            // We need this because by the time we are back on test code this stream is closed.
+            if (request.Content != null)
+            {
+                LatestRequestContent = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            TokenResponse token = new TokenResponse
+            {
+                AccessToken = $"very_fake_access_token_{Calls}",
+                ExpiresInSeconds = (long)TimeSpan.FromHours(1).TotalSeconds,
+                IssuedUtc = _clock.UtcNow
+            };
+            var serializedToken = NewtonsoftJsonSerializer.Instance.Serialize(token);
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(serializedToken),
+                RequestMessage = request
+            };
+            return response;
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenOptionsTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenOptionsTests.cs
@@ -1,0 +1,79 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using System;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    public class OidcTokenOptionsTests
+    {
+        [Fact]
+        public void FromTargetAudience()
+        {
+            var options = OidcTokenOptions.FromTargetAudience("dummy_target_audience");
+
+            Assert.Equal("dummy_target_audience", options.TargetAudience);
+            Assert.Equal(OidcTokenFormat.Full, options.TokenFormat);
+        }
+
+        [Fact]
+        public void WithTargetAudience()
+        {
+            var options = OidcTokenOptions
+                .FromTargetAudience("dummy_target_audience")
+                .WithTokenFormat(OidcTokenFormat.Standard);
+
+            var newOptions = options.WithTargetAudience("another_target_audience");
+
+            Assert.NotSame(options, newOptions);
+            // Original unchanged.
+            Assert.Equal("dummy_target_audience", options.TargetAudience);
+            Assert.Equal(OidcTokenFormat.Standard, options.TokenFormat);
+            // New only changes target audience.
+            Assert.Equal("another_target_audience", newOptions.TargetAudience);
+            Assert.Equal(OidcTokenFormat.Standard, newOptions.TokenFormat);
+        }
+
+        [Fact]
+        public void WithTokenFormat()
+        {
+            var options = OidcTokenOptions
+                .FromTargetAudience("dummy_target_audience")
+                .WithTokenFormat(OidcTokenFormat.Standard);
+
+            var newOptions = options.WithTokenFormat(OidcTokenFormat.FullWithLicences);
+
+            Assert.NotSame(options, newOptions);
+            // Original unchanged.
+            Assert.Equal("dummy_target_audience", options.TargetAudience);
+            Assert.Equal(OidcTokenFormat.Standard, options.TokenFormat);
+            // New only changes token format.
+            Assert.Equal("dummy_target_audience", newOptions.TargetAudience);
+            Assert.Equal(OidcTokenFormat.FullWithLicences, newOptions.TokenFormat);
+        }
+
+        [Fact]
+        public void WithInvalidTokenFormat()
+        {
+            Assert.Throws<ArgumentException>(
+                () => OidcTokenOptions
+                .FromTargetAudience("dummy_target_audience")
+                .WithTokenFormat((OidcTokenFormat) 5));
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenTests.cs
@@ -1,0 +1,129 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Logging;
+using Google.Apis.Tests.Mocks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    public class OidcTokenTests
+    {
+        [Fact]
+        public async Task FetchesAccessToken()
+        {
+            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+
+            TokenRefreshManager refreshManager = null;
+            refreshManager = new TokenRefreshManager(RefreshTokenAsync, clock, new NullLogger());
+            OidcToken token = new OidcToken(refreshManager);
+
+            Assert.Equal("very_fake_access_token", await token.GetAccessTokenAsync(default));
+
+            Task<bool> RefreshTokenAsync(CancellationToken cancellationToken)
+            {
+                TokenResponse tokenResponse = new TokenResponse
+                {
+                    AccessToken = "very_fake_access_token",
+                    ExpiresInSeconds = (long)TimeSpan.FromHours(1).TotalSeconds,
+                    IssuedUtc = clock.UtcNow
+                };
+                refreshManager.Token = tokenResponse;
+                return Task.FromResult(true);
+            }
+        }
+
+        [Fact]
+        public async Task RefreshesAccessToken()
+        {
+            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+
+            TokenRefreshManager refreshManager = null;
+            bool firstToken = true;
+            refreshManager = new TokenRefreshManager(RefreshTokenAsync, clock, new NullLogger());
+            OidcToken token = new OidcToken(refreshManager);
+
+            Assert.Equal("very_fake_first_token", await token.GetAccessTokenAsync(default));
+            // Move the clock over 1 hour so that the first token expires.
+            clock.UtcNow = clock.UtcNow.AddHours(2);
+            Assert.Equal("very_fake_second_token", await token.GetAccessTokenAsync(default));
+
+            Task<bool> RefreshTokenAsync(CancellationToken cancellationToken)
+            {
+                string tokenData = firstToken ? "very_fake_first_token" : "very_fake_second_token";
+                firstToken = false;
+
+                TokenResponse tokenResponse = new TokenResponse
+                {
+                    AccessToken = tokenData,
+                    ExpiresInSeconds = (long)TimeSpan.FromHours(1).TotalSeconds,
+                    IssuedUtc = clock.UtcNow
+                };
+                refreshManager.Token = tokenResponse;
+                return Task.FromResult(true);
+            }
+        }
+
+        [Fact]
+        public async Task FetchTokenFails()
+        {
+            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+
+            TokenRefreshManager refreshManager = new TokenRefreshManager(ct => Task.FromResult(false), clock, new NullLogger());
+            OidcToken token = new OidcToken(refreshManager);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => token.GetAccessTokenAsync(default));
+        }
+
+        [Fact]
+        public async Task RefreshTokenFails()
+        {
+            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+
+            TokenRefreshManager refreshManager = null;
+            bool firstToken = true;
+            refreshManager = new TokenRefreshManager(RefreshTokenAsync, clock, new NullLogger());
+            OidcToken token = new OidcToken(refreshManager);
+
+            Assert.Equal("very_fake_first_token", await token.GetAccessTokenAsync(default));
+            // Move the clock over 1 hour so that the first token expires.
+            clock.UtcNow = clock.UtcNow.AddHours(2);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => token.GetAccessTokenAsync(default));
+
+            Task<bool> RefreshTokenAsync(CancellationToken cancellationToken)
+            {
+                if (firstToken)
+                {
+                    firstToken = false;
+                    TokenResponse tokenResponse = new TokenResponse
+                    {
+                        AccessToken = "very_fake_first_token",
+                        ExpiresInSeconds = (long)TimeSpan.FromHours(1).TotalSeconds,
+                        IssuedUtc = clock.UtcNow
+                    };
+                    refreshManager.Token = tokenResponse;
+                    return Task.FromResult(true);
+                }
+                return Task.FromResult(false);
+            }
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/JsonWebToken.cs
+++ b/Src/Support/Google.Apis.Auth/JsonWebToken.cs
@@ -68,6 +68,14 @@ namespace Google.Apis.Auth
             public object Audience { get; set; }
 
             /// <summary>
+            /// Gets or sets the target audience claim that identifies the audience that an OIDC token generated from
+            /// this JWT is intended for. Maybe be null. Multiple target audiences are not supported.
+            /// <c>null</c>.
+            /// </summary>
+            [Newtonsoft.Json.JsonPropertyAttribute("target_audience")]
+            public string TargetAudience { get; set; }
+
+            /// <summary>
             /// Gets or sets expiration time claim that identifies the expiration time (in seconds) on or after which 
             /// the token MUST NOT be accepted for processing or <c>null</c>.
             /// </summary>

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleAuthConsts.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleAuthConsts.cs
@@ -52,6 +52,11 @@ namespace Google.Apis.Auth.OAuth2
         public const string ComputeTokenUrl =
             "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token";
 
+        /// <summary>The Compute Engine authorization token server URL for OIDC. This requires an audience parameter to be added.</summary>
+        /// <remarks>IP address instead of name to avoid DNS resolution</remarks>
+        internal const string ComputeOidcTokenUrl =
+            "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/identity";
+
         /// <summary>The path to the Google revocation endpoint.</summary>
         public const string RevokeTokenUrl = "https://oauth2.googleapis.com/revoke";
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -33,7 +33,7 @@ namespace Google.Apis.Auth.OAuth2
     /// See <see cref="GetApplicationDefaultAsync(CancellationToken)"/> for the credential retrieval logic.
     /// </para>
     /// </summary>
-    public class GoogleCredential : ICredential, ITokenAccessWithHeaders
+    public class GoogleCredential : ICredential, ITokenAccessWithHeaders, IOidcTokenProvider
     {
         /// <summary>Provider implements the logic for creating the application default credential.</summary>
         private static DefaultCredentialProvider defaultCredentialProvider = new DefaultCredentialProvider();
@@ -289,6 +289,13 @@ namespace Google.Apis.Auth.OAuth2
                 await credentialWithHeaders.GetAccessTokenWithHeadersForRequestAsync(authUri, cancellationToken).ConfigureAwait(false) :
                 new AccessTokenWithHeaders(await credential.GetAccessTokenForRequestAsync(authUri, cancellationToken).ConfigureAwait(false));
         }
+
+        /// <inheritdoc/>
+        public Task<OidcToken> GetOidcTokenAsync(OidcTokenOptions options, CancellationToken cancellationToken = default) =>
+            (UnderlyingCredential is IOidcTokenProvider provider) ?
+            provider.GetOidcTokenAsync(options, cancellationToken) :
+            throw new InvalidOperationException(
+                $"{nameof(UnderlyingCredential)} is not an OIDC token provider. Only {nameof(ServiceAccountCredential)}, {nameof(ComputeCredential)} are supported OIDC token providers.");
 
         /// <summary>
         /// Gets the underlying credential instance being wrapped.

--- a/Src/Support/Google.Apis.Auth/OAuth2/IOIdCTokenProvider.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/IOIdCTokenProvider.cs
@@ -1,0 +1,35 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Represents an OIDC token provider.
+    /// </summary>
+    public interface IOidcTokenProvider
+    {
+        /// <summary>
+        /// Returns an OIDC token for the given options.
+        /// </summary>
+        /// <param name="options">The options to create the token from.</param>
+        /// <param name="cancellationToken">The cancellation token that may be used to cancel the request.</param>
+        /// <returns>The OIDC token.</returns>
+        Task<OidcToken> GetOidcTokenAsync(OidcTokenOptions options, CancellationToken cancellationToken = default);
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/OIdCToken.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/OIdCToken.cs
@@ -1,0 +1,43 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Util;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Represents an OIDC Token.
+    /// </summary>
+    public sealed class OidcToken
+    {
+        private readonly TokenRefreshManager _refreshManager;
+
+        internal OidcToken(TokenRefreshManager refreshManager) =>
+            _refreshManager = refreshManager.ThrowIfNull(nameof(refreshManager));
+
+        /// <summary>
+        /// Gets the access token that should be included in headers when performing
+        /// requests with this <see cref="OidcToken"/>.
+        /// This method will refresh the access token if the current one has expired.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to use for cancelling the operation.</param>
+        /// <returns>The valid access token associated to this <see cref="OidcToken"/>.</returns>
+        public Task<string> GetAccessTokenAsync(CancellationToken cancellationToken = default) =>
+            _refreshManager.GetAccessTokenForRequestAsync(cancellationToken);
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/OIdCTokenFormat.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/OIdCTokenFormat.cs
@@ -1,0 +1,45 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Represents the OIDC token formats supported when the token is obtained using the GCE metadata server.
+    /// </summary>
+    public enum OidcTokenFormat
+    {
+        /// <summary>
+        /// Specifies that the project and instance details should not be
+        /// included in the payload of the JWT token returned by the GCE
+        /// metadata server.
+        /// </summary>
+        Standard,
+
+        /// <summary>
+        /// Specifies that the project and instance details should be
+        /// included in the payload of the JWT token returned by the GCE
+        /// metadata server.
+        /// </summary>
+        Full,
+
+        /// <summary>
+        /// Same as <see cref="Full"/>. License codes for images associated with the
+        /// GCE instance the token is being obtained from will also be included in the
+        /// payload of the JWT token returned by the GCE metadata server.
+        /// </summary>
+        FullWithLicences
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/OIdCTokenOptions.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/OIdCTokenOptions.cs
@@ -1,0 +1,72 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Util;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Options used to create an <see cref="OidcToken"/>.
+    /// </summary>
+    public class OidcTokenOptions
+    {
+        /// <summary>
+        /// The target audience the generated token should be valid for.
+        /// Must not be null.
+        /// </summary>
+        public string TargetAudience { get; }
+
+        /// <summary>
+        /// The token format of the expected OIDC token when obtained from the
+        /// GCE metadata server.
+        /// This value will be ignored when the token provider is other then the GCE
+        /// metadata server.
+        /// <see cref="OidcTokenFormat"/> for the meaning of each value.
+        /// Defaults to <see cref="OidcTokenFormat.Full"/>.
+        /// </summary>
+        public OidcTokenFormat TokenFormat { get; }
+
+        private OidcTokenOptions(string targetAudience, OidcTokenFormat tokenFormat)
+        {
+            TargetAudience = targetAudience.ThrowIfNull(nameof(targetAudience));
+            TokenFormat = Utilities.CheckEnumValue(tokenFormat, nameof(tokenFormat));
+        }
+
+        /// <summary>
+        /// Builds new <see cref="OidcTokenOptions"/> from the given target audience.
+        /// </summary>
+        /// <param name="targetAudience">The target audience to build these options from. Must no be null.</param>
+        /// <returns>A new set of options that can be used with a <see cref="IOidcTokenProvider"/> to obtain an <see cref="OidcToken"/>.</returns>
+        public static OidcTokenOptions FromTargetAudience(string targetAudience) =>
+            new OidcTokenOptions(targetAudience, OidcTokenFormat.Full);
+
+        /// <summary>
+        /// Builds a new set of options with the same options as this one, except for the target audience.
+        /// </summary>
+        /// <param name="targetAudience">The new target audience. Must not be null.</param>
+        /// <returns>A new set of options with the given target audience.</returns>
+        public OidcTokenOptions WithTargetAudience(string targetAudience) =>
+            new OidcTokenOptions(targetAudience, TokenFormat);
+
+        /// <summary>
+        /// Builds a new set of options with the same options as this one, except for the token format.
+        /// </summary>
+        /// <param name="tokenFormat">The new token format.</param>
+        /// <returns>A new set of options with the given token format.</returns>
+        public OidcTokenOptions WithTokenFormat(OidcTokenFormat tokenFormat) =>
+            new OidcTokenOptions(TargetAudience, tokenFormat);
+    }
+}

--- a/Src/Support/Google.Apis.Core/Util/Utilities.cs
+++ b/Src/Support/Google.Apis.Core/Util/Utilities.cs
@@ -69,6 +69,39 @@ namespace Google.Apis.Util
         }
 
         /// <summary>
+        /// Checks that the given value is in fact defined in the enum used as the type argument of the method.
+        /// </summary>
+        /// <typeparam name="T">The enum type to check the value within.</typeparam>
+        /// <param name="value">The value to check.</param>
+        /// <param name="paramName">The name of the parameter whose value is being tested.</param>
+        /// <returns><paramref name="value"/> if it was a defined value</returns>
+        public static T CheckEnumValue<T>(T value, string paramName) where T : struct
+        {
+            CheckArgument(
+                Enum.IsDefined(typeof(T), value),
+                paramName,
+                "Value {0} not defined in enum {1}", value, typeof(T).Name);
+            return value;
+        }
+
+        /// <summary>
+        /// Checks that given argument-based condition is met, throwing an <see cref="ArgumentException"/> otherwise.
+        /// </summary>
+        /// <param name="condition">The (already evaluated) condition to check.</param>
+        /// <param name="paramName">The name of the parameter whose value is being tested.</param>
+        /// <param name="format">The format string to use to create the exception message if the
+        /// condition is not met.</param>
+        /// <param name="arg0">The first argument to the format string.</param>
+        /// <param name="arg1">The second argument to the format string.</param>
+        public static void CheckArgument<T1, T2>(bool condition, string paramName, string format, T1 arg0, T2 arg1)
+        {
+            if (!condition)
+            {
+                throw new ArgumentException(string.Format(format, arg0, arg1), paramName);
+            }
+        }
+
+        /// <summary>
         /// A Google.Apis utility method for returning the first matching custom attribute (or <c>null</c>) of the specified member.
         /// </summary>
         public static T GetCustomAttribute<T>(this MemberInfo info) where T : Attribute


### PR DESCRIPTION
@bshaffer Please confirm that this is what's requiered.

- Is there some way in which I could test that the tokens are as expected?
- For user credentials (4th commit) I got from your document that the same token used for everything else is a valid OIDC token, is this correct?
  - Is target audience then not used for user credentials when generating the OIDC token?
- We still don't support impersonation credentials, but when I get to #1312 I'll make sure they are implementes as an OIDC token provider as well.

@jskeet I think this is the cleanest I could manage, tried several things. Take a look now or wait till we hear from @bshaffer as you prefer.

@salrashid123 FYI.