### PR TITLE
Allow post-generation tweaks on a per-API basis

### DIFF
--- a/BuildGenerated.sh
+++ b/BuildGenerated.sh
@@ -85,14 +85,19 @@ if [ -z ${SKIPGENERATE+x} ]; then
   export PYTHONPATH=$(pwd)/ClientGenerator/src
   for jsonfile in $DISCOVERY_DOC_DIR/*.json; do
     IFS='/'; names=($jsonfile); unset IFS
-    name=${names[-1]}
+    name=$(echo ${names[-1]} | sed 's/.json//g')
     case $name in
-      identitytoolkit_v3.json|oauth2_v1.json)
+      identitytoolkit_v3|oauth2_v1)
         echo Ignoring: \'$name\'
         ;;
       *)
         echo Generating: \'$name\'
         python -uR $(pwd)/ClientGenerator/src/googleapis/codegen/generate_library.py --input="$jsonfile" --language=csharp --output_dir="$CODE_GENERATION_DIR"
+        if [[ -f $(pwd)/PostGeneration/$name.sh ]]
+        then
+          echo "Running post-generation step for $name"
+          $(pwd)/PostGeneration/$name.sh
+        fi
         ;;
     esac
   done

--- a/PostGeneration/admob_v1.sh
+++ b/PostGeneration/admob_v1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# GenerateMediationReport and GenerateNetworkReport are actually streaming APIs, so
+# the response type is effectively an array.
+sed -i 's/AdMobBaseServiceRequest<Google.Apis.AdMob.v1.Data.GenerateMediationReportResponse>/AdMobBaseServiceRequest<Google.Apis.AdMob.v1.Data.GenerateMediationReportResponse[]>/g' \
+  Src/Generated/Google.Apis.AdMob.v1/Google.Apis.AdMob.v1.cs
+sed -i 's/AdMobBaseServiceRequest<Google.Apis.AdMob.v1.Data.GenerateNetworkReportResponse>/AdMobBaseServiceRequest<Google.Apis.AdMob.v1.Data.GenerateNetworkReportResponse[]>/g' \
+  Src/Generated/Google.Apis.AdMob.v1/Google.Apis.AdMob.v1.cs  


### PR DESCRIPTION
The first API to need this is AdMob V1.

This fixes #1507 - or at least, will when the API is next published.
(That will be either when the minor version is bumped, or when the
API discovery doc changes. It would be relatively tricky to "force"
a change here.)

We don't want to do much per-API work, but tiny little tweaks like
this provide a lot of value for little work.