### PR TITLE
Detect OpenBrowser failures

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/LocalServerCodeReceiver.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/LocalServerCodeReceiver.cs
@@ -473,7 +473,13 @@ namespace Google.Apis.Auth.OAuth2
                 // See https://stackoverflow.com/a/6040946/44360 for why this is required
                 url = System.Text.RegularExpressions.Regex.Replace(url, @"(\\*)" + "\"", @"$1$1\" + "\"");
                 url = System.Text.RegularExpressions.Regex.Replace(url, @"(\\+)$", @"$1$1");
-                Process.Start(new ProcessStartInfo("cmd", $"/c start \"\" \"{url}\"") { CreateNoWindow = true });
+                Process proc = Process.Start(new ProcessStartInfo($"\"{url}\"") { CreateNoWindow = true });
+
+                // check for premature process exit
+                if (proc.WaitForExit(1000))
+                {
+                    return (proc.ExitCode == 0);
+                }
                 return true;
             }
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
Partial fix for https://github.com/googleapis/google-api-dotnet-client/issues/1551

Changes:
* Modify `Process.Start` to open the URL directly, instead of going through `cmd` & `start`, to allow detection of exit codes from the web browser.
* Add a 1sec wait to detect premature process exit. so that the exit code can be checked. I've tried reducing the wait to 500ms locally, but that was not sufficient to detect failure. Therefore proposing 1sec.

Based on suggestions in https://support.microsoft.com/en-us/help/305703 and https://stackoverflow.com/questions/502199/how-to-open-a-web-page-from-my-application