### PR TITLE
Changes to global.json so that the SDK version rolls forwards at the minor version.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.1.100",
+    "rollForward": "minor"
   }
 }


### PR DESCRIPTION
Hope this is OK, since I unistalled all but one patch of each minor version of the SDK, I've been changing this by hand locally on each branch and reverting after.