### PR TITLE
Fixes issues with OIDC token emission and adds support for IAP token verification.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/FakeCertificateCache.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/FakeCertificateCache.cs
@@ -1,0 +1,177 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Util;
+using System;
+using System.Threading.Tasks;
+using static Google.Apis.Auth.SignedTokenVerification;
+
+namespace Google.Apis.Auth.Tests
+{
+    internal sealed class FakeCertificateCache : CertificateCacheBase
+    {
+        // From https://www.googleapis.com/oauth2/v3/certs
+        internal const string GoogleCertsJson = @"
+{
+ ""keys"": [
+  {
+   ""kty"": ""RSA"",
+   ""alg"": ""RS256"",
+   ""use"": ""sig"",
+   ""kid"": ""3c066add5889b989e9c49803c21fa4b29d1f4ead"",
+   ""n"": ""h3oJdAYVp3eUXPb2SGvCvEgm_KiRfFrL3cMEdT3I-uKBptz5LklVrOflDJurCXjIQF-891MF6JSJjYc9csiJbUNb-jFXkEI9toOa0ynF-Q9KHrUknfn-R2UrhqWMZw0Xe2WTWS12tjEGEa3Kzf7mcrHV_ARW9vv75PhOMa0dPjgerNJyfDrdTMxOjEzOALHJwjXwzsZxxBiox6ZIXKSGGgC99OOiKZvg6erHP7lEADm0Ws9H7lue3dkv50rpaJBPIUJlYKrx82MnxMAy2NAGqrghjQ5nRdB1mBn4F260lEOwcYNu8aGZ7NhD7yjS_xkECamTYwLGe-9PH8bR54aSxQ"",
+   ""e"": ""AQAB""
+  },
+  {
+   ""kty"": ""RSA"",
+   ""alg"": ""RS256"",
+   ""use"": ""sig"",
+   ""kid"": ""c9b39c24ed54a2b1aef3e572d4e411fe5ccf697f"",
+   ""n"": ""zQM50VGJeWRq_hLYKM8dZSVWNTVygDoACA7au37sA7tkNoYhGUopS9veabFpt5MB_h-zEAGhnNpjxRvqVvrvHi5KpfzSPUJxMR9K-YQlqObpb31eebxCiAa2ssewCWslZ2BZ2ID839_YBtbaSZymq5aBgjf07PuWUy55piuaTOuDCJOCPGXvBhMTTFcBNC3zDOZXpkbbG6h6mk5LTPyXzJ322cPjotCZXNF3FsWbFDcCtacr8ZSEMcCGFmrawmko7BQ62FDQtOVGNK94xaTTwtjnxZn1sFIeABIoo8N-x4zbSaZVX9PVQUjtVsX4V5hHiZqmIhcR62h8vj9tVDwxqQ"",
+   ""e"": ""AQAB""
+  },
+  {
+   ""kty"": ""RSA"",
+   ""alg"": ""RS256"",
+   ""use"": ""sig"",
+   ""kid"": ""f9079a9ea417bb3c4f5be2805fd9d0aa774609d0"",
+   ""n"": ""lYnlj0CJBnwz_7h5MPUCWpdwXfIxo09_ny2nVEhtZHnaIkpyrtVaUtofs62F8rJAgKN21NrGouIEbiV2i0upO9jffYhSKieZKleM8unuyret3o7Vp3Tme68GEh3ZuSqhyKsia28o5zYy3NzT9Ptt5nZjIk0uTShelHsEV_cGJRUBNmcjJxnKkrSXOABd_CW34GuAZewhfgFWibhulbb6zpNogKB6uv2IIIYF8KaIKyvIwttgyDBSTvgxFxrxWZonTTaB0Ktru2KAyvzoAzZdfnMndHcax6p5D3FnrhNtg4WBxsi8lRO6mz2KrvVYu4wMTD0e4gSPFAhqT8Z-fa7Hcw"",
+   ""e"": ""AQAB""
+  },
+  {
+   ""kty"": ""RSA"",
+   ""alg"": ""RS256"",
+   ""use"": ""sig"",
+   ""kid"": ""bbd2c788a9aaa01b7b8ba763f8fae7f88ef57002"",
+   ""n"": ""4f6HXWnlVHL58_VeBC4SjmWNelqVpmpGGIeYKKuee-rV1Y-tQXRHSXT-gDHovz6ZslE6f73CCrYvJ-7223o6ZLa1VTB_5sS5rtcqYK2I7VN7H1gvRAw6rWcwruVjQXzruArnjL00ousC8pKXqoXYtlTyYY0T7J_W2nn_imwk7fCRwe48CCMKi6iDJxaJzEc0Gu5tNPzQoFHez-1ohF8DRxFN6IVV6TEVUMpn9OG-BP7aWfSi5WxnND1IcVnLuLDatqltDzRHzZNYnRkLIVlDzz2pEledY281kE5eQZ0vLjGJ2OR-cEd9SBjbh9EMvig3k7-Co6EAuzpIDXBeJDJ21w"",
+   ""e"": ""AQAB""
+  }
+ ]
+}";
+        // From https://www.gstatic.com/iap/verify/public_key-jwk
+        internal const string Es256IapCertificates = @"{
+   ""keys"" : [
+      {
+         ""alg"" : ""ES256"",
+         ""crv"" : ""P-256"",
+         ""kid"" : ""LYyP2g"",
+         ""kty"" : ""EC"",
+         ""use"" : ""sig"",
+         ""x"" : ""SlXFFkJ3JxMsXyXNrqzE3ozl_0913PmNbccLLWfeQFU"",
+         ""y"" : ""GLSahrZfBErmMUcHP0MGaeVnJdBwquhrhQ8eP05NfCI""
+      },
+      {
+         ""alg"" : ""ES256"",
+         ""crv"" : ""P-256"",
+         ""kid"" : ""mpf0DA"",
+         ""kty"" : ""EC"",
+         ""use"" : ""sig"",
+         ""x"" : ""fHEdeT3a6KaC1kbwov73ZwB_SiUHEyKQwUUtMCEn0aI"",
+         ""y"" : ""QWOjwPhInNuPlqjxLQyhveXpWqOFcQPhZ3t-koMNbZI""
+      },
+      {
+         ""alg"" : ""ES256"",
+         ""crv"" : ""P-256"",
+         ""kid"" : ""b9vTLA"",
+         ""kty"" : ""EC"",
+         ""use"" : ""sig"",
+         ""x"" : ""qCByTAvci-jRAD7uQSEhTdOs8iA714IbcY2L--YzynI"",
+         ""y"" : ""WQY0uCoQyPSozWKGQ0anmFeOH5JNXiZa9i6SNqOcm7w""
+      },
+      {
+         ""alg"" : ""ES256"",
+         ""crv"" : ""P-256"",
+         ""kid"" : ""0oeLcQ"",
+         ""kty"" : ""EC"",
+         ""use"" : ""sig"",
+         ""x"" : ""MdhRXGEoGJLtBjQEIjnYLPkeci9rXnca2TffkI0Kac0"",
+         ""y"" : ""9BoREHfX7g5OK8ELpA_4RcOnFCGSjfR4SGZpBo7juEY""
+      },
+      {
+         ""alg"" : ""ES256"",
+         ""crv"" : ""P-256"",
+         ""kid"" : ""g5X6ig"",
+         ""kty"" : ""EC"",
+         ""use"" : ""sig"",
+         ""x"" : ""115LSuaFVzVROJiGfdPN1kT14Hv3P4RIjthfslZ010s"",
+         ""y"" : ""-FAaRtO4yvrN4uJ89xwGWOEJcSwpLmFOtb0SDJxEAuc""
+      }
+   ]
+}";
+
+        // From procedure outlined in https://developers.google.com/identity/protocols/OpenIDConnect
+        // This JWT is valid only from 2017-05-31 10:23 until 2017-05-31 11:23 (UTC), so is not usable.
+        internal const string JwtGoogleSigned =
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6ImJiZDJjNzg4YTlhYWEwMWI3YjhiYTc2M2Y4ZmFlN2Y4OGVmNTcwMDIifQ.eyJhenAiOiIy" +
+            "MzM3NzIyODE0MjUtYWIybWNiaXFtdjhraDBtZG5xc3Jrcm9kOTdxazM3aDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJ" +
+            "hdWQiOiIyMzM3NzIyODE0MjUtYWIybWNiaXFtdjhraDBtZG5xc3Jrcm9kOTdxazM3aDAuYXBwcy5nb29nbGV1c2VyY29udGVudC" +
+            "5jb20iLCJzdWIiOiIxMDkwODEwMjMzMDk1NTcxOTcyMTIiLCJoZCI6Imdvb2dsZS5jb20iLCJlbWFpbCI6ImNocmlzYmFjb25AZ" +
+            "29vZ2xlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiNFJHRTFzVko4WXhqRUtUaGhFZDZpdyIsImlzcyI6" +
+            "Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbSIsImlhdCI6MTQ5NjIyNjIzMCwiZXhwIjoxNDk2MjI5ODMwfQ.Opw9C1ma5eww" +
+            "HmLrmT6to41U0Tpt0fN2A3Vw9jqgS72iRFq0SDQ4r182uwIvhSUo5MnifY4JheeHBuRtDpiQYFtnh_JLzxiAkkIGCMkMf_7Pr6Q" +
+            "MWuNsx1ugSFygppvlC_fSEK3LS5P2nUtRFqtR7kR9T1MJN11G5dGjLZnmerot8jdqUo7w_zxaiG-5KK-5z3xGRtcPGvl-04RUU7" +
+            "qsktkVV3AgLuC_TYQGuVH59sfInCEuMZzJJ219MA1c03F0tbDXCMPSWwXgNj4OXaV7QdP7X6sE0AVBK9WVByApI-4CTL7U4G40z" +
+            "yXSOZ4DQWYiYkNf7Hqw9foa87U0sZS6eQ";
+        internal static readonly DateTime ValidJwtGoogleSigned = new DateTime(2017, 5, 31, 10, 24, 0, DateTimeKind.Utc);
+        internal static readonly DateTime BeforeValidJwtGoogleSigned = new DateTime(2017, 5, 31, 10, 22, 0, DateTimeKind.Utc);
+        internal static readonly DateTime AfterValidJwtGoogleSigned = new DateTime(2017, 5, 31, 11, 24, 0, DateTimeKind.Utc);
+
+        // A valid JWT, with a valid signature, but not signed by Google.
+        // This JWT is valid only from 2017-05-29 19:02 until 2017-05-29 20:02 (UTC), so is not usable.
+        internal const string JwtNonGoogleSigned =
+            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmb3J0ZXN0aW5nQGNocmlzYmFjb24tdGVzdGluZy5pYW0uZ3Nlcn" +
+            "ZpY2VhY2NvdW50LmNvbSIsInN1YiI6ImZvcnRlc3RpbmdAY2hyaXNiYWNvbi10ZXN0aW5nLmlhbS5nc2VydmljZWFjY291bnQuY" +
+            "29tIiwiYXVkIjoiaHR0cHM6Ly93d3cuZXhhbXBsZS5jb20vIiwiZXhwIjoxNDk2MDg4MTYwLCJpYXQiOjE0OTYwODQ1NjB9.UE0" +
+            "oO1QC90rQSmjrWouxUcLV-jay9lnzDraPFbqpcoLcZRyXzG7vUSUVqoipzHweyRyR9bazn_bWCuLuTm9sD-UmokDQGBxqpkGwHJ" +
+            "vjZ9R6B25vlB5Dqk5QJsPz8Cy_N1wsmeFi41Mn0UsVH1OoQmZHmFgwq61QP1nfzVLlz92sRcEgArJEEM3jwxfFEZVJVckeTqpvA" +
+            "IMAj-lTi0ysjiKnd7OJwG_HnNqF-nWTU7z0JbZm_l6_Zfyp_wra78YIbDY-VmxBjiz32RDugLqilfhH4o--GThjhdlyHZENMtk-" +
+            "pO3CE8RfNI5fGnmfUgtf6tcdhk2MiA1Quy8BgB_F5Q";
+        internal static readonly DateTime ValidJwtNonGoogleSigned = new DateTime(2017, 5, 29, 19, 3, 20, DateTimeKind.Utc);
+        internal static readonly DateTime BeforeValidJwtNonGoogleSigned = new DateTime(2017, 5, 29, 19, 1, 20, DateTimeKind.Utc);
+        internal static readonly DateTime AfterValidJwtNonGoogleSigned = new DateTime(2017, 5, 29, 20, 3, 20, DateTimeKind.Utc);
+
+        // A valid Es256 JWT.
+        // Valind on March 12, 2020 9:03:37 PM UTC and for 10 minutes.
+        internal const string Es256ForIap =
+            "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Im1wZjBEQSJ9.eyJhdWQiOiIvcHJvamVjdHMvNjUyNTYyNzc2Nzk4L2" +
+            "FwcHMvY2xvdWQtc2FtcGxlcy10ZXN0cy1waHAtaWFwIiwiZW1haWwiOiJjaGluZ29yQGdvb2dsZS5jb20iLCJleHAiOjE1ODQwN" +
+            "Dc2MTcsImdvb2dsZSI6eyJhY2Nlc3NfbGV2ZWxzIjpbImFjY2Vzc1BvbGljaWVzLzUxODU1MTI4MDkyNC9hY2Nlc3NMZXZlbHMv" +
+            "cmVjZW50U2VjdXJlQ29ubmVjdERhdGEiLCJhY2Nlc3NQb2xpY2llcy81MTg1NTEyODA5MjQvYWNjZXNzTGV2ZWxzL3Rlc3ROb09" +
+            "wIiwiYWNjZXNzUG9saWNpZXMvNTE4NTUxMjgwOTI0L2FjY2Vzc0xldmVscy9ldmFwb3JhdGlvblFhRGF0YUZ1bGx5VHJ1c3RlZC" +
+            "JdfSwiaGQiOiJnb29nbGUuY29tIiwiaWF0IjoxNTg0MDQ3MDE3LCJpc3MiOiJodHRwczovL2Nsb3VkLmdvb2dsZS5jb20vaWFwI" +
+            "iwic3ViIjoiYWNjb3VudHMuZ29vZ2xlLmNvbToxMTIxODE3MTI3NzEyMDE5NzI4OTEifQ.yKNtdFY5EKkRboYNexBdfugzLhC3V" +
+            "uGyFcuFYA8kgpxMqfyxa41zkML68hYKrWu2kOBTUW95UnbGpsIi_u1fiA";
+        internal static readonly DateTime ValidEs256ForIap = new DateTime(2020, 3, 12, 21, 4, 20, DateTimeKind.Utc);
+        internal static readonly DateTime BeforeValidEs256ForIap = new DateTime(2020, 3, 12, 21, 2, 20, DateTimeKind.Utc);
+        internal static readonly DateTime AfterValidEs256ForIap = new DateTime(2020, 3, 12, 21, 14, 20, DateTimeKind.Utc);
+
+        public FakeCertificateCache(IClock clock = null)
+            : base(clock)
+        { }
+
+        protected async override Task<string> FetchCertificatesAsync(string certificatesLocation)
+        {
+            await Task.Delay(100);
+            return certificatesLocation switch
+            {
+                GoogleAuthConsts.JsonWebKeySetUrl => GoogleCertsJson,
+                GoogleAuthConsts.IapKeySetUrl => Es256IapCertificates,
+                _ => throw new ArgumentOutOfRangeException(nameof(certificatesLocation))
+            };
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -8,6 +8,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\google.apis.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Support/Google.Apis.Auth.Tests/GoogleJsonWebSignatureTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/GoogleJsonWebSignatureTests.cs
@@ -14,81 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.Tests.Mocks;
 using Google.Apis.Util;
 using System;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using static Google.Apis.Auth.SignedTokenVerification;
+using static Google.Apis.Auth.TokenEncodingHelpers;
 
 namespace Google.Apis.Auth.Tests
 {
     public class GoogleJsonWebSignatureTests
     {
-        // From https://www.googleapis.com/oauth2/v3/certs
-        const string GoogleCertsJson = @"
-{
- ""keys"": [
-  {
-   ""kty"": ""RSA"",
-   ""alg"": ""RS256"",
-   ""use"": ""sig"",
-   ""kid"": ""3c066add5889b989e9c49803c21fa4b29d1f4ead"",
-   ""n"": ""h3oJdAYVp3eUXPb2SGvCvEgm_KiRfFrL3cMEdT3I-uKBptz5LklVrOflDJurCXjIQF-891MF6JSJjYc9csiJbUNb-jFXkEI9toOa0ynF-Q9KHrUknfn-R2UrhqWMZw0Xe2WTWS12tjEGEa3Kzf7mcrHV_ARW9vv75PhOMa0dPjgerNJyfDrdTMxOjEzOALHJwjXwzsZxxBiox6ZIXKSGGgC99OOiKZvg6erHP7lEADm0Ws9H7lue3dkv50rpaJBPIUJlYKrx82MnxMAy2NAGqrghjQ5nRdB1mBn4F260lEOwcYNu8aGZ7NhD7yjS_xkECamTYwLGe-9PH8bR54aSxQ"",
-   ""e"": ""AQAB""
-  },
-  {
-   ""kty"": ""RSA"",
-   ""alg"": ""RS256"",
-   ""use"": ""sig"",
-   ""kid"": ""c9b39c24ed54a2b1aef3e572d4e411fe5ccf697f"",
-   ""n"": ""zQM50VGJeWRq_hLYKM8dZSVWNTVygDoACA7au37sA7tkNoYhGUopS9veabFpt5MB_h-zEAGhnNpjxRvqVvrvHi5KpfzSPUJxMR9K-YQlqObpb31eebxCiAa2ssewCWslZ2BZ2ID839_YBtbaSZymq5aBgjf07PuWUy55piuaTOuDCJOCPGXvBhMTTFcBNC3zDOZXpkbbG6h6mk5LTPyXzJ322cPjotCZXNF3FsWbFDcCtacr8ZSEMcCGFmrawmko7BQ62FDQtOVGNK94xaTTwtjnxZn1sFIeABIoo8N-x4zbSaZVX9PVQUjtVsX4V5hHiZqmIhcR62h8vj9tVDwxqQ"",
-   ""e"": ""AQAB""
-  },
-  {
-   ""kty"": ""RSA"",
-   ""alg"": ""RS256"",
-   ""use"": ""sig"",
-   ""kid"": ""f9079a9ea417bb3c4f5be2805fd9d0aa774609d0"",
-   ""n"": ""lYnlj0CJBnwz_7h5MPUCWpdwXfIxo09_ny2nVEhtZHnaIkpyrtVaUtofs62F8rJAgKN21NrGouIEbiV2i0upO9jffYhSKieZKleM8unuyret3o7Vp3Tme68GEh3ZuSqhyKsia28o5zYy3NzT9Ptt5nZjIk0uTShelHsEV_cGJRUBNmcjJxnKkrSXOABd_CW34GuAZewhfgFWibhulbb6zpNogKB6uv2IIIYF8KaIKyvIwttgyDBSTvgxFxrxWZonTTaB0Ktru2KAyvzoAzZdfnMndHcax6p5D3FnrhNtg4WBxsi8lRO6mz2KrvVYu4wMTD0e4gSPFAhqT8Z-fa7Hcw"",
-   ""e"": ""AQAB""
-  },
-  {
-   ""kty"": ""RSA"",
-   ""alg"": ""RS256"",
-   ""use"": ""sig"",
-   ""kid"": ""bbd2c788a9aaa01b7b8ba763f8fae7f88ef57002"",
-   ""n"": ""4f6HXWnlVHL58_VeBC4SjmWNelqVpmpGGIeYKKuee-rV1Y-tQXRHSXT-gDHovz6ZslE6f73CCrYvJ-7223o6ZLa1VTB_5sS5rtcqYK2I7VN7H1gvRAw6rWcwruVjQXzruArnjL00ousC8pKXqoXYtlTyYY0T7J_W2nn_imwk7fCRwe48CCMKi6iDJxaJzEc0Gu5tNPzQoFHez-1ohF8DRxFN6IVV6TEVUMpn9OG-BP7aWfSi5WxnND1IcVnLuLDatqltDzRHzZNYnRkLIVlDzz2pEledY281kE5eQZ0vLjGJ2OR-cEd9SBjbh9EMvig3k7-Co6EAuzpIDXBeJDJ21w"",
-   ""e"": ""AQAB""
-  }
- ]
-}";
-
-        // From procedure outlined in https://developers.google.com/identity/protocols/OpenIDConnect
-        // This JWT is valid only from 2017-05-31 10:23 until 2017-05-31 11:23 (UTC), so is not usable.
-        const string JwtGoogleSigned =
-            "eyJhbGciOiJSUzI1NiIsImtpZCI6ImJiZDJjNzg4YTlhYWEwMWI3YjhiYTc2M2Y4ZmFlN2Y4OGVmNTcwMDIifQ.eyJhenAiOiIy" +
-            "MzM3NzIyODE0MjUtYWIybWNiaXFtdjhraDBtZG5xc3Jrcm9kOTdxazM3aDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJ" +
-            "hdWQiOiIyMzM3NzIyODE0MjUtYWIybWNiaXFtdjhraDBtZG5xc3Jrcm9kOTdxazM3aDAuYXBwcy5nb29nbGV1c2VyY29udGVudC" +
-            "5jb20iLCJzdWIiOiIxMDkwODEwMjMzMDk1NTcxOTcyMTIiLCJoZCI6Imdvb2dsZS5jb20iLCJlbWFpbCI6ImNocmlzYmFjb25AZ" +
-            "29vZ2xlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiNFJHRTFzVko4WXhqRUtUaGhFZDZpdyIsImlzcyI6" +
-            "Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbSIsImlhdCI6MTQ5NjIyNjIzMCwiZXhwIjoxNDk2MjI5ODMwfQ.Opw9C1ma5eww" +
-            "HmLrmT6to41U0Tpt0fN2A3Vw9jqgS72iRFq0SDQ4r182uwIvhSUo5MnifY4JheeHBuRtDpiQYFtnh_JLzxiAkkIGCMkMf_7Pr6Q" +
-            "MWuNsx1ugSFygppvlC_fSEK3LS5P2nUtRFqtR7kR9T1MJN11G5dGjLZnmerot8jdqUo7w_zxaiG-5KK-5z3xGRtcPGvl-04RUU7" +
-            "qsktkVV3AgLuC_TYQGuVH59sfInCEuMZzJJ219MA1c03F0tbDXCMPSWwXgNj4OXaV7QdP7X6sE0AVBK9WVByApI-4CTL7U4G40z" +
-            "yXSOZ4DQWYiYkNf7Hqw9foa87U0sZS6eQ";
-        // A valid JWT, with a valid signature, but not signed by Google.
-        // This JWT is valid only from 2017-05-29 19:02 until 2017-05-29 20:02 (UTC), so is not usable.
-        const string JwtNonGoogleSigned =
-            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJmb3J0ZXN0aW5nQGNocmlzYmFjb24tdGVzdGluZy5pYW0uZ3Nlcn" +
-            "ZpY2VhY2NvdW50LmNvbSIsInN1YiI6ImZvcnRlc3RpbmdAY2hyaXNiYWNvbi10ZXN0aW5nLmlhbS5nc2VydmljZWFjY291bnQuY" +
-            "29tIiwiYXVkIjoiaHR0cHM6Ly93d3cuZXhhbXBsZS5jb20vIiwiZXhwIjoxNDk2MDg4MTYwLCJpYXQiOjE0OTYwODQ1NjB9.UE0" +
-            "oO1QC90rQSmjrWouxUcLV-jay9lnzDraPFbqpcoLcZRyXzG7vUSUVqoipzHweyRyR9bazn_bWCuLuTm9sD-UmokDQGBxqpkGwHJ" +
-            "vjZ9R6B25vlB5Dqk5QJsPz8Cy_N1wsmeFi41Mn0UsVH1OoQmZHmFgwq61QP1nfzVLlz92sRcEgArJEEM3jwxfFEZVJVckeTqpvA" +
-            "IMAj-lTi0ysjiKnd7OJwG_HnNqF-nWTU7z0JbZm_l6_Zfyp_wra78YIbDY-VmxBjiz32RDugLqilfhH4o--GThjhdlyHZENMtk-" +
-            "pO3CE8RfNI5fGnmfUgtf6tcdhk2MiA1Quy8BgB_F5Q";
-
-        private GoogleJsonWebSignature.ValidationSettings MakeSettings(IClock clock, string aud = null, string hd = null, double clockToleranceSeconds = 0.0) =>
+        private GoogleJsonWebSignature.ValidationSettings MakeSettings(
+            IClock clock,
+            string aud = null,
+            string hd = null,
+            double clockToleranceSeconds = 0.0,
+            CertificateCacheBase certificateCache = null) =>
             new GoogleJsonWebSignature.ValidationSettings
             {
                 Clock = clock,
@@ -96,123 +41,138 @@ namespace Google.Apis.Auth.Tests
                 HostedDomain = hd,
                 IssuedAtClockTolerance = TimeSpan.FromSeconds(clockToleranceSeconds),
                 ExpirationTimeClockTolerance = TimeSpan.FromSeconds(clockToleranceSeconds),
+                CertificateCache = certificateCache ?? new FakeCertificateCache()
             };
 
-        private string B64(string t) =>
-            Convert.ToBase64String(Encoding.UTF8.GetBytes(t)).Replace("=", "");
+        [Fact]
+        public void ValidationSettingsToSignedTokenVerificationOptions()
+        {
+            MockClock clock = new MockClock();
+            FakeCertificateCache cache = new FakeCertificateCache();
+            var options = new GoogleJsonWebSignature.ValidationSettings
+            {
+                Clock = clock,
+                Audience = new[] { "audience" },
+                HostedDomain = "hosted_domain",
+                IssuedAtClockTolerance = TimeSpan.FromSeconds(5),
+                ExpirationTimeClockTolerance = TimeSpan.FromSeconds(10),
+                CertificateCache = cache,
+                ForceGoogleCertRefresh = true
+            }.ToVerificationOptions();
+
+            Assert.Same(clock, options.Clock);
+            Assert.Single(options.TrustedAudiences, "audience");
+            Assert.Equal(TimeSpan.FromSeconds(5), options.IssuedAtClockTolerance);
+            Assert.Equal(TimeSpan.FromSeconds(10), options.ExpiryClockTolerance);
+            Assert.Same(cache, options.CertificateCache);
+            Assert.True(options.ForceCertificateRefresh);
+            Assert.Equal(GoogleAuthConsts.JsonWebKeySetUrl, options.CertificatesUrl);
+            Assert.Equal(GoogleJsonWebSignature.ValidJwtIssuers.Count(), options.TrustedIssuers.Count);
+        }
 
         [Fact]
         public async Task Validate_BadJwt()
         {
-            var settings = MakeSettings(new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 22, 0, DateTimeKind.Utc) });
+            // The date is irrelevant here since we are not passing any actual valid token for verification.
+            // In any case we are using a fixed date (any fixed date would do) so that the test always runs the same.
+            var settings = MakeSettings(new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned});
             // Null JWT
-            await Assert.ThrowsAsync<ArgumentNullException>(() => GoogleJsonWebSignature.ValidateInternalAsync(null, settings, GoogleCertsJson, false));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => GoogleJsonWebSignature.ValidateInternalAsync(null, settings));
             // Empty JWT
-            await Assert.ThrowsAsync<ArgumentException>(() => GoogleJsonWebSignature.ValidateInternalAsync("", settings, GoogleCertsJson, false));
+            await Assert.ThrowsAsync<ArgumentException>(() => GoogleJsonWebSignature.ValidateInternalAsync("", settings));
             // Too long JWT
             await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(new string('a', GoogleJsonWebSignature.MaxJwtLength + 1), settings, GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync(new string('a', GoogleJsonWebSignature.MaxJwtLength + 1), settings));
             // JWT with incorrect top-level structure; missing signature
             await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync("header.payload", settings, GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync("header.payload", settings));
         }
 
         [Fact]
         public async Task WrongAlgorithm()
         {
-            var settings = MakeSettings(new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 22, 0, DateTimeKind.Utc) });
-            string jwt = $"{B64("{\"alg\":\"HS256\"}")}.{B64("{}")}.";
+            var settings = MakeSettings(new MockClock() { UtcNow = DateTime.UtcNow });
+            string jwt = $"{UrlSafeBase64Encode("{\"alg\":\"HS256\"}")}.{UrlSafeBase64Encode("{}")}.";
             var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(jwt, settings, null, true));
+                GoogleJsonWebSignature.ValidateInternalAsync(jwt, settings));
             Assert.Equal("JWT algorithm must be 'RS256'", ex.Message);
         }
 
         [Fact]
-        public async Task Validate_Signature()
+        public async Task ValidateInternalAsync_Valid()
         {
-            var clockValid1 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 24, 0, DateTimeKind.Utc) };
-            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockValid1), GoogleCertsJson, false));
+            var clockValid = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
+            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockValid)));
+        }
 
-            var clockValid2 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 24, 0, DateTimeKind.Utc) };
+        [Fact]
+        public async Task ValidateInternalAsync_Invalid()
+        {
+            var clockValid = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
+            // Lets just change the last character of the Google signed token to break the signature.
+            // But Headers and Payload are still valid for a Google token so we guarantee that the only
+            // failure comes from the signature being invalid.
+            // The last character was a Q, changing for a 4. If at some point the token used in tests changes
+            // and the new token ends in anything but a 4, this test will still be valid. If the new token ends in a 4
+            // this test will fail and then we'll have to replace the 4 by a Q or any other character.
+            var invalidToken = FakeCertificateCache.JwtGoogleSigned.Substring(0, FakeCertificateCache.JwtGoogleSigned.Length - 1) + "4";
             var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtNonGoogleSigned, MakeSettings(clockValid2), GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync(invalidToken, MakeSettings(clockValid)));
             Assert.Equal("JWT invalid, unable to verify signature.", ex.Message);
         }
 
         [Fact]
         public async Task Invalid_Iss()
         {
-            var clock = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 22, 0, DateTimeKind.Utc) };
+            var clock = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtNonGoogleSigned };
             var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtNonGoogleSigned, MakeSettings(clock), GoogleCertsJson, true));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtNonGoogleSigned, MakeSettings(clock)));
             Assert.Equal("JWT issuer incorrect. Must be one of: 'https://accounts.google.com', 'accounts.google.com'", ex.Message);
         }
 
         [Fact]
         public async Task Invalid_Aud()
         {
-            var clock = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 22, 0, DateTimeKind.Utc) };
+            var clock = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
             var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clock, "bad_aud"), GoogleCertsJson, true));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clock, "bad_aud")));
             Assert.Equal("JWT contains untrusted 'aud' claim.", ex.Message);
         }
 
         [Fact]
         public async Task Validate_Signature_Time()
         {
+            var clockInvalid1 = new MockClock() { UtcNow = FakeCertificateCache.BeforeValidJwtGoogleSigned };
+            var clockValid1 = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
+            var clockInvalid2 = new MockClock() { UtcNow = FakeCertificateCache.AfterValidJwtGoogleSigned };
 
-            var clockInvalid1 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 22, 0, DateTimeKind.Utc) };
-            var clockValid1 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 24, 0, DateTimeKind.Utc) };
-            var clockValid2 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 11, 22, 0, DateTimeKind.Utc) };
-            var clockInvalid2 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 11, 24, 0, DateTimeKind.Utc) };
-
-            // JwtGoogleSigned is valid from 2017-05-31 10:23:50 until 2017-05-31 11:23:50 (UTC)
             // Test with no tolerance
-            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockValid1), GoogleCertsJson, false));
-            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockValid2), GoogleCertsJson, false));
+            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockValid1)));
 
             var ex1 = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockInvalid1), GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockInvalid1)));
             Assert.Equal("JWT is not yet valid.", ex1.Message);
 
             var ex2 = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockInvalid2), GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockInvalid2)));
             Assert.Equal("JWT has expired.", ex2.Message);
 
             // Test with tolerance
             await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockInvalid1, clockToleranceSeconds: 109), GoogleCertsJson, false));
-            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockInvalid1, clockToleranceSeconds: 111), GoogleCertsJson, false));
-            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockInvalid2, clockToleranceSeconds: 11), GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockInvalid1, clockToleranceSeconds: 109)));
+            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockInvalid1, clockToleranceSeconds: 111)));
+            Assert.NotNull(await GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockInvalid2, clockToleranceSeconds: 11)));
             await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clockInvalid2, clockToleranceSeconds: 9), GoogleCertsJson, false));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clockInvalid2, clockToleranceSeconds: 9)));
         }
 
         [Fact]
         public async Task Invalid_HostedDomain()
         {
-            var clock = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 10, 24, 0, DateTimeKind.Utc) };
+            var clock = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
             var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                GoogleJsonWebSignature.ValidateInternalAsync(JwtGoogleSigned, MakeSettings(clock, hd: "hd"), GoogleCertsJson, true));
+                GoogleJsonWebSignature.ValidateInternalAsync(FakeCertificateCache.JwtGoogleSigned, MakeSettings(clock, hd: "hd")));
             Assert.Equal("JWT contains invalid 'hd' claim.", ex.Message);
-        }
-
-        [Fact]
-        public async Task Validate_CertCache()
-        {
-            var clock1 = new MockClock() { UtcNow = new DateTime(2017, 5, 31, 11, 24, 0, DateTimeKind.Utc) };
-            var clock2Cached = new MockClock() { UtcNow = clock1.UtcNow + GoogleJsonWebSignature.CertCacheRefreshInterval - TimeSpan.FromSeconds(1) };
-            var clock3Uncached = new MockClock() { UtcNow = clock1.UtcNow + GoogleJsonWebSignature.CertCacheRefreshInterval + TimeSpan.FromSeconds(1) };
-
-            var rsas1 = await GoogleJsonWebSignature.GetGoogleCertsAsync(clock1, false, GoogleCertsJson);
-            var rsas2Cached = await GoogleJsonWebSignature.GetGoogleCertsAsync(clock2Cached, false, GoogleCertsJson);
-            var rsas3Refreshed = await GoogleJsonWebSignature.GetGoogleCertsAsync(clock3Uncached, false, GoogleCertsJson);
-            var rsas4Forced = await GoogleJsonWebSignature.GetGoogleCertsAsync(clock3Uncached, true, GoogleCertsJson);
-
-            Assert.NotNull(rsas1);
-            Assert.Same(rsas1, rsas2Cached);
-            Assert.NotSame(rsas1, rsas3Refreshed);
-            Assert.NotSame(rsas3Refreshed, rsas4Forced);
         }
     }
 }

--- a/Src/Support/Google.Apis.Auth.Tests/JsonWebSignatureTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/JsonWebSignatureTests.cs
@@ -1,0 +1,197 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#if NETCOREAPP2_0 || NET452 || NET46
+#define ES256_SUPPORTED
+#elif !NETCOREAPP1_0 && !NETCOREAPP1_1
+#error Unsupported platform
+#endif
+
+using Google.Apis.Tests.Mocks;
+using Google.Apis.Util;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Apis.Auth.TokenEncodingHelpers;
+
+namespace Google.Apis.Auth.Tests
+{
+    public class JsonWebSignatureTests
+    {
+        private SignedTokenVerificationOptions BuildOptions(
+            IClock clock = null, string[] trustedIssuers = null, string[] trustedAudiences = null, TimeSpan? clockTolerance = null)
+        {
+            var options = new SignedTokenVerificationOptions
+            {
+                CertificateCache = new FakeCertificateCache(),
+                Clock = clock ?? new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned }
+            };
+            foreach (var issuer in trustedIssuers ?? Enumerable.Empty<string>())
+            {
+                options.TrustedIssuers.Add(issuer);
+            }
+            foreach (var audience in trustedAudiences ?? Enumerable.Empty<string>())
+            {
+                options.TrustedAudiences.Add(audience);
+            }
+            if (clockTolerance.HasValue)
+            {
+                options.IssuedAtClockTolerance = clockTolerance.Value;
+                options.ExpiryClockTolerance = clockTolerance.Value;
+            }
+
+            return options;
+        }
+
+        [Fact]
+        public async Task NullToken() =>
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(null, BuildOptions()));
+
+        [Fact]
+        public async Task EmptyToken() =>
+            await Assert.ThrowsAsync<ArgumentException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync("", BuildOptions()));
+
+        [Fact]
+        public async Task TwoPartToken() =>
+            await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync("header.payload", BuildOptions()));
+
+        [Fact]
+        public async Task WrongAlgorithm()
+        {
+            string jwt = $"{UrlSafeBase64Encode("{\"alg\":\"HS256\"}")}.{UrlSafeBase64Encode("{}")}.";
+            var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(jwt, BuildOptions()));
+            Assert.Equal("Signing algorithm must be either RS256 or ES256.", ex.Message);
+        }
+
+        [Fact]
+        public async Task ValidRS256Signature() =>
+            Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(
+                FakeCertificateCache.JwtGoogleSigned, BuildOptions()));
+
+#if ES256_SUPPORTED
+        [Fact]
+        public async Task ValidES256Signature() =>
+            Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(
+                FakeCertificateCache.Es256ForIap, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+#else
+        [Fact]
+        public async Task ValidES256Signature_Unsupported()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => JsonWebSignature.VerifySignedTokenAsync(
+                FakeCertificateCache.Es256ForIap, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+            Assert.Equal("ES256 signed token verification is not supported in this platform.", ex.Message);
+        }
+#endif
+
+
+        [Fact]
+        public async Task InvalidRS256Signature()
+        {
+            // Lets just change the last character of the Google signed token to break the signature.
+            // But Headers and Payload are still valid for a Google token so we guarantee that the only
+            // failure comes from the signature being invalid.
+            // The last character was a Q, changing for a 4. If at some point the token used in tests changes
+            // and the new token ends in anything but a 4, this test will still be valid. If the new token ends in a 4
+            // this test will fail and then we'll have to replace the 4 by a Q or any other character.
+            var invalidToken = FakeCertificateCache.JwtGoogleSigned.Substring(0, FakeCertificateCache.JwtGoogleSigned.Length - 1) + "4";
+            var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions()));
+            Assert.Equal("JWT invalid, unable to verify signature.", ex.Message);
+        }
+
+#if ES256_SUPPORTED
+        [Fact]
+        public async Task InvalidES256Signature()
+        {
+            // Lets just change the last character of the signed token to break the signature.
+            // But Headers and Payload are still valid so we guarantee that the only
+            // failure comes from the signature being invalid.
+            // The last character was an A, changing for a 4. If at some point the token used in tests changes
+            // and the new token ends in anything but a 4, this test will still be valid. If the new token ends in a 4
+            // this test will fail and then we'll have to replace the 4 by an A or any other character.
+            var invalidToken = FakeCertificateCache.Es256ForIap.Substring(0, FakeCertificateCache.Es256ForIap.Length - 1) + "4";
+            var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+            Assert.Equal("JWT invalid, unable to verify signature.", ex.Message);
+        }
+#else
+        [Fact]
+        public async Task InvalidES256Signature_Unsupported()
+        {
+            // Lets just change the last character of the signed token to break the signature.
+            // But Headers and Payload are still valid so we guarantee that the only
+            // failure comes from the signature being invalid.
+            // The last character was an A, changing for a 4. If at some point the token used in tests changes
+            // and the new token ends in anything but a 4, this test will still be valid. If the new token ends in a 4
+            // this test will fail and then we'll have to replace the 4 by an A or any other character.
+            var invalidToken = FakeCertificateCache.Es256ForIap.Substring(0, FakeCertificateCache.Es256ForIap.Length - 1) + "4";
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+            Assert.Equal("ES256 signed token verification is not supported in this platform.", ex.Message);
+        }
+#endif
+
+        [Fact]
+        public async Task InvalidIssuer()
+        {
+            var options = BuildOptions(trustedIssuers: new string[] { "issuer1", "issuer2" });
+            var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, options));
+            Assert.Equal("JWT issuer incorrect. Must be one of: 'issuer1', 'issuer2'", ex.Message);
+        }
+
+        [Fact]
+        public async Task InvalidAudience()
+        {
+            var options = BuildOptions(trustedAudiences: new string[] { "audience1", "audience2" });
+            var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, options));
+            Assert.Equal("JWT contains untrusted 'aud' claim.", ex.Message);
+        }
+
+        [Fact]
+        public async Task Validate_Signature_Time()
+        {
+            var clockInvalid1 = new MockClock() { UtcNow = FakeCertificateCache.BeforeValidJwtGoogleSigned };
+            var clockValid1 = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
+            var clockInvalid2 = new MockClock() { UtcNow = FakeCertificateCache.AfterValidJwtGoogleSigned };
+
+            // Test with no tolerance
+            Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockValid1)));
+
+            var ex1 = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockInvalid1)));
+            Assert.Equal("JWT is not yet valid.", ex1.Message);
+
+            var ex2 = await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockInvalid2)));
+            Assert.Equal("JWT has expired.", ex2.Message);
+
+            // Test with tolerance
+            await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockInvalid1, clockTolerance: TimeSpan.FromSeconds(109))));
+            Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockInvalid1, clockTolerance: TimeSpan.FromSeconds(111))));
+            Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockInvalid2, clockTolerance: TimeSpan.FromSeconds(11))));
+            await Assert.ThrowsAsync<InvalidJwtException>(() =>
+                JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockInvalid2, clockTolerance: TimeSpan.FromSeconds(9))));
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenFakes.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenFakes.cs
@@ -14,28 +14,52 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Json;
 using Google.Apis.Tests.Mocks;
-using Google.Apis.Util;
 using System;
-using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Apis.Auth.Tests.OAuth2
 {
-    internal class OidcTokenSuccessMessageHandler : CountableMessageHandler
+    internal class OidcTokenResponseSuccessMessageHandler : CountableMessageHandler
     {
-        private readonly IClock _clock;
+        // Token with audience https://first_call.test
+        // Unusable, it was usable on May 13, 2020 from 2:54pm UTC and for 1 hour.
+        internal const string FirstCallToken = 
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6ImMxNzcxODE0YmE2YTcwNjkzZmI5NDEyZGEzYzZlOTBjMmJmNWI5Mj"+
+            "ciLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2ZpcnN0X2NhbGwudGVzdCIsImF6cCI6ImludGVnc"+
+            "mF0aW9uLXRlc3RpbmdAYXRhcmFmYW1hcy1pbnRlZ3JhdGlvbi10ZXN0cy5pYW0uZ3NlcnZpY2VhY2NvdW5"+
+            "0LmNvbSIsImVtYWlsIjoiaW50ZWdyYXRpb24tdGVzdGluZ0BhdGFyYWZhbWFzLWludGVncmF0aW9uLXRlc"+
+            "3RzLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImV4cCI6MTU4OTM"+
+            "4NTI2MywiaWF0IjoxNTg5MzgxNjYzLCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJzd"+
+            "WIiOiIxMTE2MTEyMjAyOTc3NjczMTkzODkifQ.mjqOsfsH01rHip0AMWKrrx13Gjx5ryiD9K4a2UrrrXxX"+
+            "dT05j7uqCu7fifMmuCmbvUfZAbVIjHl4Cp9eX4oqj5IX3sqCoOCEFDRQ2nz0HZ_yyYf1ZEmERTAekKtDbG"+
+            "Ji20gqLyk-KRKnal-Ay0ySb2zhvMzFA7mrNmpDlhhNI_VDgtxoDwNWhye57hy-9cbNqYNCpPKiCgixLmcL"+
+            "BkFN-X7KLNNJCogix6zwqWeKdkWhO78Hec0JepGuA-1lJ3XQBvzpjVSvuRjKpagybNXp6YDkfg8ca2jMWB"+
+            "F905Ht0ANUAniSq8CyN5QJAxlr0IbmPRCkJM4jzx1aNFjzjSUFTw";
+
+        // Token with audience https://subsequent_calls.test
+        // Unusable, it was usable on May 13, 2020 from 2:56pm UTC and for 1 hour.
+        internal const string SubsequentCallsToken = 
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6ImMxNzcxODE0YmE2YTcwNjkzZmI5NDEyZGEzYzZlOTBjMmJmNWI5Mj"+
+            "ciLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL3N1YnNlcXVlbnRfY2FsbHMudGVzdCIsImF6cCI6I"+
+            "mludGVncmF0aW9uLXRlc3RpbmdAYXRhcmFmYW1hcy1pbnRlZ3JhdGlvbi10ZXN0cy5pYW0uZ3NlcnZpY2V"+
+            "hY2NvdW50LmNvbSIsImVtYWlsIjoiaW50ZWdyYXRpb24tdGVzdGluZ0BhdGFyYWZhbWFzLWludGVncmF0a"+
+            "W9uLXRlc3RzLmlhbS5nc2VydmljZWFjY291bnQuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImV4cCI"+
+            "6MTU4OTM4NTM3NSwiaWF0IjoxNTg5MzgxNzc1LCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb"+
+            "20iLCJzdWIiOiIxMTE2MTEyMjAyOTc3NjczMTkzODkifQ.Aaumn3oXOe48Or8oN2U8_8_KWdRYaR8p1SzT"+
+            "mhvWHc9_4AZSodKmZQMyzttwkNrA17HRXGNygVtSi4ocf8aYjHPJWjjqIDIUNAo9Wf3ha_nyqpqkFKq76i"+
+            "OtaMoClLDmBva44m9qUUSIe__evNBSHb8aKrzW1gt2ClYzpquFQKxhL0oiRrPYZ2LSBfLvIZb0j9Lz357a"+
+            "VGYfXkGIVuXBrl9FBWYn93Qa0eHEgf1AVFR1vuX6vcGaDcTKbjo41bu_QEEytXDDsCn4ab2tZTnVwLIZht"+
+            "Y9HxxNMq_nA1m8GKX_CMEIVZ5WBrSe7N7aTZ8dCqo8nHZlM96sUB8WA5pDcA";
 
         public HttpRequestMessage LatestRequest { get; private set; }
         public string LatestRequestContent { get; private set; }
-
-        public OidcTokenSuccessMessageHandler(IClock clock) => _clock = clock;
 
         protected override async Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -47,14 +71,66 @@ namespace Google.Apis.Auth.Tests.OAuth2
             }
             TokenResponse token = new TokenResponse
             {
-                AccessToken = $"very_fake_access_token_{Calls}",
-                ExpiresInSeconds = (long)TimeSpan.FromHours(1).TotalSeconds,
-                IssuedUtc = _clock.UtcNow
+                IdToken = Calls == 1 ? FirstCallToken : SubsequentCallsToken,
             };
             var serializedToken = NewtonsoftJsonSerializer.Instance.Serialize(token);
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(serializedToken),
+                RequestMessage = request
+            };
+            return response;
+        }
+    }
+
+    internal class OidcComputeSuccessMessageHandler : CountableMessageHandler
+    {
+        // Token with audience https://first_call.test
+        // Unusable, it was usable on May 21, 2020 from 9:15am UTC and for 1 hour.
+        internal const string FirstCallToken =
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijk2MGE3ZThlODM0MWVkNzUyZjEyYjE4NmZhMT" +
+            "I5NzMxZmUwYjA0YzAiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2ZpcnN0X" +
+            "2NhbGwudGVzdCIsImF6cCI6IjExNDkxMTI3MjU1NzUxODc4MDU4MSIsImV4cCI6MTU" +
+            "5MDA1NjE0NiwiaWF0IjoxNTkwMDUyNTQ2LCJpc3MiOiJodHRwczovL2FjY291bnRzL" +
+            "mdvb2dsZS5jb20iLCJzdWIiOiIxMTQ5MTEyNzI1NTc1MTg3ODA1ODEifQ.USxkyjNQ" +
+            "X9PzVZSEJNaiLdmZldvTC7DTJfdhrlIHSK3LV9DLKDCtEw07o1glA5lqELMCq7I6wq" +
+            "QAHls8lqDtShDIz7ouYudMV9ABnN-SFmcrG1wiPnDJt4N0oCyXbtMksrujgkyDCsrw" +
+            "sCxUV3YdhIEwUYVUnBUnk_Tf6MjzFXJK9UQiOGYFYeN9vFg38HoYpwFq0wHkFXq-Uw" +
+            "1gvmi46PfnwV3Ow67ehJQSFJd9cS2_Nh0u2j83h6KBNW1q0UzL_eNiXSlFA8YiXpwV" +
+            "Zw1-YHV5Q7nrILJQlB1X0T6pEZkvMmkNBoswFPXCFy444BihLcdrHDhZHiAfIDN7X1sZVA";
+
+        // Token with audience https://subsequent_calls.test
+        // Unusable, it was usable on May 21, 2020 from 9:15am UTC and for 1 hour.
+        internal const string SubsequentCallsToken =
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6Ijk2MGE3ZThlODM0MWVkNzUyZjEyYjE4NmZhMT" +
+            "I5NzMxZmUwYjA0YzAiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL3N1YnNlc" +
+            "XVlbnRfY2FsbHMudGVzdCIsImF6cCI6IjExNDkxMTI3MjU1NzUxODc4MDU4MSIsImV" +
+            "4cCI6MTU5MDA1NjIzNCwiaWF0IjoxNTkwMDUyNjM0LCJpc3MiOiJodHRwczovL2FjY" +
+            "291bnRzLmdvb2dsZS5jb20iLCJzdWIiOiIxMTQ5MTEyNzI1NTc1MTg3ODA1ODEifQ." +
+            "dRiegvwAyv8O96REghtPA83oDDgWhIcleeG8EmBpxdFu-k7W9pF5J-DERAR7s-VzqJ" +
+            "fNoWGX8-7HZJTvZ_ye0wgPPAvrhlFOrO6ySxMLrJPWiGOmiPNh5BKHd6mevMAhHE3Q" +
+            "t0r0wNk3oWHPtTx5D9cJhcgw4WflDHt1Ci0OPpZKOlO4SuV9WD_0KhvygMjC04tr1e" +
+            "qWHglCxzu5-sq5_nEYYQJjI8GmWyrCZ9ZivyoOVZ8vfAR7TEMgNg6pmkkN-kLKhRJ1" +
+            "d16z7juYZm6_FsaUp7Cml7vbHmFW4XiRC0gAm6lUECd-KNYSoQRceeLj3fW0LDnNWljfNZXlOkbghA";
+
+        public HttpRequestMessage LatestRequest { get; private set; }
+        public string LatestRequestContent { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LatestRequest = request;
+            // We need this because by the time we are back on test code this stream is closed.
+            if (request.Content != null)
+            {
+                LatestRequestContent = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+            // The way we have for identifying that a response came from the compute metadata server identity endpoint
+            // is through the request URI, and that's how we know to not build a TokenResponse, so we need to set that here.
+            request.RequestUri = new Uri(GoogleAuthConsts.ComputeOidcTokenUrl + request.RequestUri.Query);
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                // The Compute metadata server identity endpoint only sends the raw id_token in the response.
+                Content = new StringContent(Calls == 1 ? FirstCallToken : SubsequentCallsToken),
                 RequestMessage = request
             };
             return response;

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
@@ -14,10 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Json;
+using Google.Apis.Logging;
 using Google.Apis.Tests.Mocks;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Apis.Auth.Tests.OAuth2.Responses
@@ -32,6 +39,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
         {
             var response = new TokenResponse();
             Assert.Null(response.AccessToken);
+            Assert.Null(response.IdToken);
             Assert.Null(response.ExpiresInSeconds);
             Assert.Null(response.RefreshToken);
             Assert.Null(response.Scope);
@@ -44,57 +52,207 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
             var tokenResponse = JsonConvert.DeserializeObject<TokenResponse>(
                 @"{
                  'access_token': '123',
+                 'id_token': '321',
                  'expires_in': 1000,
                  'refresh_token': '456',
                  'scope': '789'
                 }");
             Assert.Equal("123", tokenResponse.AccessToken);
+            Assert.Equal("321", tokenResponse.IdToken);
             Assert.Equal("456", tokenResponse.RefreshToken);
             Assert.Equal("789", tokenResponse.Scope);
             Assert.Equal(1000, tokenResponse.ExpiresInSeconds);
         }
 
-        [Fact]
-        public void IsExpired()
+        // Test data for testing TokenResponse expiry.
+        // Although we could use InlineData for some of these, we would
+        // have to have a separate test for the newly construted test case.
+        public static IEnumerable<object[]> ExpiresData
         {
-            var issued = DateTime.UtcNow;
-            var newNow = DateTime.UtcNow.AddSeconds(100);
-
-            var mockClock = new MockClock
+            get
             {
-                UtcNow = newNow
+                // IsExpired will be true 6 minutes before actual expiry.
+                // IsEffectivelyExpired will be true 5 minutes before actual expiry.
+
+                DateTime issued = DateTime.UtcNow;
+                // Now is ten minutes after issuance.
+                DateTime now = DateTime.UtcNow.AddSeconds(60 * 10);
+                // If it expires 20 minutes after issuance,
+                // it's not expired now.
+                long isNotExpiredSeconds = 60 * 20;
+                // If it expires 16 minutes after issuance,
+                // it's soft expired now, but not hard expired.
+                long isSoftExpiredSeconds = 60 * 16;
+                // If it expires 15 minutes after issuance,
+                // it's expired now.
+                long isHardExpiredSeconds = 60 * 15;
+
+                // As newly constructed.
+                yield return new object[] { now, DateTime.MinValue.ToUniversalTime(), null, null, null, true, true };
+                // Expiry not set.
+                yield return new object[] { now, issued, null, "access", "id", true, true };
+                // Neither AccessToken nor IdToken set.
+                yield return new object[] { now, issued, isNotExpiredSeconds, null, null, true, true };
+                // AccessToken set.
+                yield return new object[] { now, issued, isNotExpiredSeconds, "access", null, false, false };
+                // IdToken set.
+                yield return new object[] { now, issued, isNotExpiredSeconds, null, "id", false, false };
+                // Both AccessToken and IdToken set.
+                yield return new object[] { now, issued, isNotExpiredSeconds, "access", "id", false, false };
+                // Soft expired.
+                yield return new object[] { now, issued, isSoftExpiredSeconds, "access", "id", true, false };
+                // Soft expired boundary.
+                yield return new object[] { now, issued, isSoftExpiredSeconds + 1, "access", "id", false, false };
+                // Hard expired.
+                yield return new object[] { now, issued, isHardExpiredSeconds, "access", "id", true, true };
+                // Hard expired boundary.
+                yield return new object[] { now, issued, isHardExpiredSeconds + 1, "access", "id", true, false };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ExpiresData))]
+        public void Expiry(
+            DateTime now, DateTime issuedAt, long? expiresInSeconds,
+            string accessToken, string idToken,
+            bool expectedExpired, bool expectedEffectiveExpires)
+        {
+            var clock = new MockClock { UtcNow = now };
+            var token = new TokenResponse
+            {
+                IssuedUtc = issuedAt,
+                ExpiresInSeconds = expiresInSeconds,
+                AccessToken = accessToken,
+                IdToken = idToken
+            };
+            Assert.Equal(expectedExpired, token.IsExpired(clock));
+            Assert.Equal(expectedEffectiveExpires, token.IsEffectivelyExpired(clock));
+        }
+
+        [Fact]
+        public async Task FromResponse_TokenResponse()
+        {
+            TokenResponse sentToken = new TokenResponse
+            {
+                IdToken = "IdToken",
+                AccessToken = "AccessToken",
+                RefreshToken = "RefreshToken",
+                Scope = "Scope",
+                TokenType = "TokenType",
+                ExpiresInSeconds = 100,
+                // It really doesn't matter, we always set it to now when the token is received
+                // because that's the recommendation.
+                IssuedUtc = new DateTime(2000, 01, 01, 0, 0, 0, DateTimeKind.Utc),
+            };
+            var serializedToken = NewtonsoftJsonSerializer.Instance.Serialize(sentToken);
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(serializedToken)
             };
 
-            const int ExpectedRefreshTimeSeconds = 6 * 60;
+            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc) };
+            TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
-            // Issued not set.
-            var response = new TokenResponse();
-            Assert.True(response.IsExpired(mockClock));
+            Assert.Equal("IdToken", token.IdToken);
+            Assert.Equal("AccessToken", token.AccessToken);
+            Assert.Equal("RefreshToken", token.RefreshToken);
+            Assert.Equal("Scope", token.Scope);
+            Assert.Equal("TokenType", token.TokenType);
+            Assert.Equal(100, token.ExpiresInSeconds);
+            // The date should be our mock now, not the one set on the sent token.
+            Assert.Equal(new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc), token.IssuedUtc);
+        }
 
-            // ExpiresInSeconds is not set.
-            response = new TokenResponse() { IssuedUtc = issued };
-            Assert.True(response.IsExpired(mockClock));
+        [Fact]
+        public async Task FromResponse_RawIdToken()
+        {
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(OidcComputeSuccessMessageHandler.FirstCallToken),
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.ComputeOidcTokenUrl)
+            };
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 1, IssuedUtc = issued };
-            Assert.True(response.IsExpired(mockClock));
+            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc) };
+            TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100, IssuedUtc = issued };
-            Assert.True(response.IsExpired(mockClock));
+            Assert.Equal(OidcComputeSuccessMessageHandler.FirstCallToken, token.IdToken);
+            Assert.Equal(OidcComputeSuccessMessageHandler.FirstCallToken, token.AccessToken);
+            Assert.Null(token.RefreshToken);
+            Assert.Null(token.Scope);
+            Assert.Null(token.TokenType);
+            Assert.NotNull(token.ExpiresInSeconds);
+            // The date should be our mock now, not the one set on the sent token.
+            Assert.Equal(new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc), token.IssuedUtc);
+        }
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds - 2, IssuedUtc = issued };
-            Assert.True(response.IsExpired(mockClock));
+        public static IEnumerable<object[]> AccessAndIdTokenData
+        {
+            get
+            {
+                // None are set.
+                yield return new object[] { null, null, null, null };
+                // Both are set, none is overriden.
+                yield return new object[] 
+                { 
+                    OidcTokenResponseSuccessMessageHandler.FirstCallToken,
+                    "AccessToken",
+                    OidcTokenResponseSuccessMessageHandler.FirstCallToken,
+                    "AccessToken" };
+                // Only AccessToken is set, IdToken is not overriden.
+                yield return new object[] { null, "AccessToken", null, "AccessToken" };
+                // Only IdToken is set, AccessToken is overriden.
+                yield return new object[] 
+                {
+                    OidcTokenResponseSuccessMessageHandler.FirstCallToken,
+                    null,
+                    OidcTokenResponseSuccessMessageHandler.FirstCallToken,
+                    OidcTokenResponseSuccessMessageHandler.FirstCallToken 
+                };
+            }
+        }
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds - 1, IssuedUtc = issued };
-            Assert.True(response.IsExpired(mockClock));
+        [Theory]
+        [MemberData(nameof(AccessAndIdTokenData))]
+        public async Task FromResponse_AccessAndIdTokens(string idToken, string accessToken, string expectedIdToken, string expectedAccessToken)
+        {
+            TokenResponse sentToken = new TokenResponse
+            {
+                IdToken = idToken,
+                AccessToken = accessToken,
+            };
+            var serializedToken = NewtonsoftJsonSerializer.Instance.Serialize(sentToken);
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(serializedToken)
+            };
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds, IssuedUtc = issued };
-            Assert.True(response.IsExpired(mockClock));
+            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds + 1, IssuedUtc = issued };
-            Assert.False(response.IsExpired(mockClock));
+            Assert.Equal(expectedIdToken, token.IdToken);
+            Assert.Equal(expectedAccessToken, token.AccessToken);
+        }
 
-            response = new TokenResponse() { AccessToken = "a", ExpiresInSeconds = 100 + ExpectedRefreshTimeSeconds + 2, IssuedUtc = issued };
-            Assert.False(response.IsExpired(mockClock));
+        [Fact]
+        public async Task FromResponse_Expiry()
+        {
+            // For OIDC token endpoint, we only get and IdToken.
+            // We get the expiry from there.
+            TokenResponse sentToken = new TokenResponse
+            {
+                IdToken = OidcTokenResponseSuccessMessageHandler.FirstCallToken
+            };
+            var serializedToken = NewtonsoftJsonSerializer.Instance.Serialize(sentToken);
+            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(serializedToken)
+            };
+
+            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
+
+            Assert.Equal(OidcTokenResponseSuccessMessageHandler.FirstCallToken, token.IdToken);
+            Assert.NotNull(token.ExpiresInSeconds);
         }
 
         [Fact]

--- a/Src/Support/Google.Apis.Auth.Tests/SignedTokenTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/SignedTokenTests.cs
@@ -1,0 +1,113 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using System;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests
+{
+    public class SignedTokenTests
+    {
+        [Fact]
+        public void FromGoogleSigned()
+        {
+            var signedToken = SignedToken<GoogleJsonWebSignature.Header, GoogleJsonWebSignature.Payload>.FromSignedToken(FakeCertificateCache.JwtGoogleSigned);
+            // Just a small test that everything got correctly unpacked.
+            Assert.Contains("google.com", signedToken.Payload.Issuer);
+            // And that we have some Google specific info on the payload.
+            Assert.NotNull(signedToken.Payload.HostedDomain);
+        }
+
+        [Fact]
+        public void FromNonGoogleSigned()
+        {
+            var signedToken = SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(FakeCertificateCache.JwtNonGoogleSigned);
+            // Just a small test that everything got correctly unpacked.
+            Assert.DoesNotContain("google.com", signedToken.Payload.Issuer);
+        }
+
+        [Fact]
+        public void FromGoogleSigned_ToJsonWebSignatureTypes()
+        {
+            // This works, we just don't get the specific fields that we can get with
+            // GoogleJsonWebSignature.Header and GoogleJsonWebSignature.Payload.
+            var signedToken = SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(FakeCertificateCache.JwtGoogleSigned);
+            // Just a small test that everything got correctly unpacked.
+            Assert.Contains("google.com", signedToken.Payload.Issuer);
+        }
+
+        [Fact]
+        public void FromNonGoogleSigned_ToGoogleJsonWebSignatureTypes()
+        {
+            // This works, because JSON deserialization will just leave unassigned
+            // any of the Google specific fields since they are not present on the JSON.
+            // Validation of this token as a Google signed token won't work though.
+            var signedToken = SignedToken<GoogleJsonWebSignature.Header, GoogleJsonWebSignature.Payload>.FromSignedToken(FakeCertificateCache.JwtNonGoogleSigned);
+            // Just a small test that everything got correctly unpacked.
+            Assert.DoesNotContain("google.com", signedToken.Payload.Issuer);
+            // But we don't have info for any of the specific Google fields.
+            Assert.Null(signedToken.Payload.Scope);
+            Assert.Null(signedToken.Payload.Prn);
+            Assert.Null(signedToken.Payload.HostedDomain);
+            Assert.Null(signedToken.Payload.Email);
+            Assert.Null(signedToken.Payload.Name);
+            Assert.Null(signedToken.Payload.GivenName);
+            Assert.Null(signedToken.Payload.FamilyName);
+            Assert.Null(signedToken.Payload.Picture);
+            Assert.Null(signedToken.Payload.Locale);
+        }
+
+        [Fact]
+        public void FromSignedToken_ThrowsIfNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(null));
+        }
+
+        [Fact]
+        public void FromSignedToken_ThrowsIfEmpty()
+        {
+            Assert.Throws<ArgumentException>(
+                () => SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(string.Empty));
+        }
+
+        [Theory]
+        [InlineData("header.payload")]
+        [InlineData("header.payload.signature.somethingelse")]
+        public void FromSignedToken_ThrowsIfIncorrectPartCount(string jwt)
+        {
+            Assert.Throws<InvalidJwtException>(
+                () => SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(jwt));
+        }
+
+        [Fact]
+        public void FromSignedToken_ThrowsIfNotBase64()
+        {
+            Assert.Throws<FormatException>(
+                () => SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(
+                    "not_base64_header.not_base64_serialized_payload.signature"));
+        }
+
+        [Fact]
+        public void FromSignedToken_ThrowsIfNotValidJson()
+        {
+            Assert.Throws<JsonReaderException>(
+                () => SignedToken<JsonWebSignature.Header, JsonWebSignature.Payload>.FromSignedToken(
+                    "YmFzZV82NF9oZWFkZXJfbm9fanNvbg==.YmFzZV82NF9wYXlsb2FkX25vX2pzb24=.c2lnbmF0dXJl"));
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationOptionsTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationOptionsTests.cs
@@ -1,0 +1,108 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Tests.Mocks;
+using Google.Apis.Util;
+using System;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests
+{
+    public class SignedTokenVerificationOptionsTests
+    {
+        [Fact]
+        public void Default()
+        {
+            var options = new SignedTokenVerificationOptions();
+
+            Assert.Null(options.CertificatesUrl);
+            Assert.Null(options.CertificateCache);
+            Assert.Empty(options.TrustedAudiences);
+            Assert.Empty(options.TrustedIssuers);
+            Assert.False(options.ForceCertificateRefresh);
+            Assert.Equal(TimeSpan.Zero, options.IssuedAtClockTolerance);
+            Assert.Equal(TimeSpan.Zero, options.ExpiryClockTolerance);
+            Assert.Same(SystemClock.Default, options.Clock);
+        }
+
+        [Fact]
+        public void ClockCannotBeNull() =>
+            Assert.Throws<ArgumentNullException>(() => new SignedTokenVerificationOptions { Clock = null });
+
+        [Fact]
+        public void FromAnother_EqualValuesAfterCreation()
+        {
+            var options1 = new SignedTokenVerificationOptions
+            {
+                CertificatesUrl = "http://dummy.url",
+                ForceCertificateRefresh = true,
+                IssuedAtClockTolerance = TimeSpan.FromSeconds(5),
+                ExpiryClockTolerance = TimeSpan.FromSeconds(10),
+                CertificateCache = new FakeCertificateCache(),
+                Clock = new MockClock(),
+                TrustedAudiences = { "audience" },
+                TrustedIssuers = { "issuers" }
+            };
+
+            var options2 = new SignedTokenVerificationOptions(options1);
+
+            Assert.Equal("http://dummy.url", options2.CertificatesUrl);
+            Assert.Single(options2.TrustedAudiences, "audience");
+            Assert.Single(options2.TrustedIssuers, "issuers");
+            Assert.True(options2.ForceCertificateRefresh);
+            Assert.Equal(TimeSpan.FromSeconds(5), options2.IssuedAtClockTolerance);
+            Assert.Equal(TimeSpan.FromSeconds(10), options2.ExpiryClockTolerance);
+            Assert.IsType<FakeCertificateCache>(options2.CertificateCache);
+            Assert.IsType<MockClock>(options2.Clock);
+        }
+
+        [Fact]
+        public void FromAnother_DifferentValueAfterModification()
+        {
+            var options1 = new SignedTokenVerificationOptions
+            {
+                CertificatesUrl = "http://dummy.url",
+                ForceCertificateRefresh = true,
+                IssuedAtClockTolerance = TimeSpan.FromSeconds(5),
+                ExpiryClockTolerance = TimeSpan.FromSeconds(10),
+                CertificateCache = new FakeCertificateCache(),
+                Clock = new MockClock(),
+                TrustedAudiences = { "audience" },
+                TrustedIssuers = { "issuers" }
+            };
+
+            var options2 = new SignedTokenVerificationOptions(options1);
+
+            options1.CertificatesUrl = "";
+            options1.ForceCertificateRefresh = false;
+            options1.IssuedAtClockTolerance = TimeSpan.Zero;
+            options1.ExpiryClockTolerance = TimeSpan.Zero;
+            options1.CertificateCache = new FakeCertificateCache();
+            options1.Clock = new MockClock();
+            options1.TrustedAudiences.Add("another");
+            options1.TrustedIssuers.Add("another");
+
+            Assert.Equal("http://dummy.url", options2.CertificatesUrl);
+            Assert.Single(options2.TrustedAudiences, "audience");
+            Assert.Single(options2.TrustedIssuers, "issuers");
+            Assert.True(options2.ForceCertificateRefresh);
+            Assert.Equal(TimeSpan.FromSeconds(5), options2.IssuedAtClockTolerance);
+            Assert.Equal(TimeSpan.FromSeconds(10), options2.ExpiryClockTolerance);
+            Assert.NotSame(options1.CertificateCache, options2.CertificateCache);
+            Assert.NotSame(options1.Clock, options2.Clock);
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationTests.cs
@@ -1,0 +1,83 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Tests.Mocks;
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests
+{
+    public class SignedTokenVerificationTests
+    {
+        [Fact]
+        public async Task CertificateCache_Caches()
+        {
+            MockClock clock = new MockClock() { UtcNow = DateTime.UtcNow };
+
+            // The fake only fakes the fetching of the certificates from the web.
+            // The rest of the code can't be mocked and that's what we are testing here.
+            var certCache = new FakeCertificateCache(clock);
+
+            var firstCall = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), false, default);
+            // Move the clock a little, but not enough to invalidate the cache, which lasts for 1 hour.
+            clock.UtcNow = clock.UtcNow.AddMinutes(30);
+            var secondCallCached = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), false, default);
+
+            Assert.NotNull(firstCall);
+            Assert.Same(firstCall, secondCallCached);
+        }
+
+        [Fact]
+        public async Task CertificateCache_Refreshes()
+        {
+            MockClock clock = new MockClock() { UtcNow = DateTime.UtcNow };
+            // The fake only fakes the fetching of the certificates from the web.
+            // The rest of the code can't be mocked and that's what we are testing here.
+            var certCache = new FakeCertificateCache(clock);
+
+            var firstCall = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), false, default);
+            // Move the clock so the cache expires
+            clock.UtcNow = clock.UtcNow.AddMinutes(61);
+            var secondCall = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), false, default);
+
+            Assert.NotNull(firstCall);
+            Assert.NotNull(secondCall);
+            Assert.NotSame(firstCall, secondCall);
+        }
+
+        [Fact]
+        public async Task CertificateCache_ForceRefresh()
+        {
+            MockClock clock = new MockClock() { UtcNow = DateTime.UtcNow };
+            // The fake only fakes the fetching of the certificates from the web.
+            // The rest of the code can't be mocked and that's what we are testing here.
+            var certCache = new FakeCertificateCache(clock);
+
+            var firstCall = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), false, default);
+            // Move the clock some so that the cache doesn't expire.
+            clock.UtcNow = clock.UtcNow.AddMinutes(30);
+            var secondCall = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), true, default);
+
+            Assert.NotNull(firstCall);
+            Assert.NotNull(secondCall);
+            // Still they are different because we forced refreshed the cache.
+            Assert.NotSame(firstCall, secondCall);
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
+++ b/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <!-- nupkg information -->

--- a/Src/Support/Google.Apis.Auth/JsonWebSignature.cs
+++ b/Src/Support/Google.Apis.Auth/JsonWebSignature.cs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Apis.Auth
 {
@@ -24,8 +26,22 @@ namespace Google.Apis.Auth
     /// </summary>
     public class JsonWebSignature
     {
-        // TODO(peleyal): Implement some verify method:
-        // http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-08#section-7
+        /// <summary>
+        /// Verifies that the given token is a valid, not expired, signed token.
+        /// </summary>
+        /// <param name="signedJwt">The token to verify.</param>
+        /// <param name="options">The options to use for verification.
+        /// May be null in which case default options will be used.</param>
+        /// <param name="cancellationToken">The cancellation token for the operation.</param>
+        /// <returns>The payload contained by the token.</returns>
+        /// <exception cref="InvalidJwtException">If the token is invalid or expired.</exception>
+        public async static Task<Payload> VerifySignedTokenAsync(
+            string signedJwt, SignedTokenVerificationOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var signedToken = SignedToken<Header, Payload>.FromSignedToken(signedJwt);
+            await SignedTokenVerification.VerifySignedTokenAsync(signedToken, options, cancellationToken).ConfigureAwait(false);
+            return signedToken.Payload;
+        }
 
         /// <summary>
         /// Header as specified in http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-11#section-4.1.

--- a/Src/Support/Google.Apis.Auth/JsonWebToken.cs
+++ b/Src/Support/Google.Apis.Auth/JsonWebToken.cs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Google.Apis.Auth
@@ -24,6 +26,8 @@ namespace Google.Apis.Auth
     /// </summary>
     public class JsonWebToken
     {
+        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         /// <summary>
         /// JWT Header as specified in http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-08#section-5.
         /// </summary>
@@ -32,14 +36,14 @@ namespace Google.Apis.Auth
             /// <summary>
             /// Gets or sets type header parameter used to declare the type of this object or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("typ")]
+            [JsonProperty("typ")]
             public string Type { get; set; }
 
             /// <summary>
             /// Gets or sets content type header parameter used to declare structural information about the JWT or 
             /// <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("cty")]
+            [JsonProperty("cty")]
             public string ContentType { get; set; }
         }
 
@@ -51,20 +55,20 @@ namespace Google.Apis.Auth
             /// <summary>
             /// Gets or sets issuer claim that identifies the principal that issued the JWT or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("iss")]
+            [JsonProperty("iss")]
             public string Issuer { get; set; }
 
             /// <summary>
             /// Gets or sets subject claim identifying the principal that is the subject of the JWT or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("sub")]
+            [JsonProperty("sub")]
             public string Subject { get; set; }
 
             /// <summary>
             /// Gets or sets audience claim that identifies the audience that the JWT is intended for (should either be
             /// a string or list) or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("aud")]
+            [JsonProperty("aud")]
             public object Audience { get; set; }
 
             /// <summary>
@@ -72,52 +76,52 @@ namespace Google.Apis.Auth
             /// this JWT is intended for. Maybe be null. Multiple target audiences are not supported.
             /// <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("target_audience")]
+            [JsonProperty("target_audience")]
             public string TargetAudience { get; set; }
 
             /// <summary>
             /// Gets or sets expiration time claim that identifies the expiration time (in seconds) on or after which 
             /// the token MUST NOT be accepted for processing or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("exp")]
+            [JsonProperty("exp")]
             public long? ExpirationTimeSeconds { get; set; }
 
             /// <summary>
             /// Gets or sets not before claim that identifies the time (in seconds) before which the token MUST NOT be
             /// accepted for processing or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("nbf")]
+            [JsonProperty("nbf")]
             public long? NotBeforeTimeSeconds { get; set; }
 
             /// <summary>
             /// Gets or sets issued at claim that identifies the time (in seconds) at which the JWT was issued or 
             /// <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("iat")]
+            [JsonProperty("iat")]
             public long? IssuedAtTimeSeconds { get; set; }
 
             /// <summary>
             /// Gets or sets JWT ID claim that provides a unique identifier for the JWT or <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("jti")]
+            [JsonProperty("jti")]
             public string JwtId { get; set; }
 
             /// <summary>
             /// The nonce value specified by the client during the authorization request.
             /// Must be present if a nonce was specified in the authorization request, otherwise this will not be present.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("nonce")]
+            [JsonProperty("nonce")]
             public string Nonce { get; set; }
 
             /// <summary>
             /// Gets or sets type claim that is used to declare a type for the contents of this JWT Claims Set or 
             /// <c>null</c>.
             /// </summary>
-            [Newtonsoft.Json.JsonPropertyAttribute("typ")]
+            [JsonProperty("typ")]
             public string Type { get; set; }
 
             /// <summary>Gets the audience property as a list.</summary>
-            [Newtonsoft.Json.JsonIgnoreAttribute]
+            [JsonIgnore]
             public IEnumerable<string> AudienceAsList
             {
                 get
@@ -137,6 +141,14 @@ namespace Google.Apis.Auth
                     return list;
                 }
             }
+
+            [JsonIgnore]
+            internal DateTimeOffset? IssuedAt =>
+                IssuedAtTimeSeconds is null ? (DateTimeOffset?)null : UnixEpoch.AddSeconds(IssuedAtTimeSeconds.Value);
+
+            [JsonIgnore]
+            internal DateTimeOffset? ExpiresAt =>
+                ExpirationTimeSeconds is null ? (DateTimeOffset?)null : UnixEpoch.AddSeconds(ExpirationTimeSeconds.Value);
         }
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
@@ -84,7 +84,7 @@ namespace Google.Apis.Auth.OAuth2
             /// <summary>Constructs a new initializer using the given token URL
             /// and the default OIDC token URL.</summary>
             public Initializer(string tokenUrl)
-                : this(tokenUrl, GoogleAuthConsts.OidcTokenUrl) {}
+                : this(tokenUrl, GoogleAuthConsts.ComputeOidcTokenUrl) {}
 
             /// <summary>Constructs a new initializer using the given token URL
             /// and OIDC token URL.</summary>

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/AuthorizationCodeFlow.cs
@@ -14,21 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Google.Apis.Auth.OAuth2.Requests;
 using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Http;
 using Google.Apis.Logging;
+using Google.Apis.Testing;
 using Google.Apis.Util;
 using Google.Apis.Util.Store;
-using Google.Apis.Testing;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Google.Apis.Auth.OAuth2.Flows
 {
@@ -313,7 +311,7 @@ namespace Google.Apis.Auth.OAuth2.Flows
             try
             {
                 var tokenResponse = await request.ExecuteAsync
-                    (httpClient, TokenServerUrl, taskCancellationToken, Clock).ConfigureAwait(false);
+                    (httpClient, TokenServerUrl, taskCancellationToken, Clock, Logger).ConfigureAwait(false);
                 return tokenResponse;
             }
             catch (TokenResponseException ex)

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleAuthConsts.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleAuthConsts.cs
@@ -63,6 +63,9 @@ namespace Google.Apis.Auth.OAuth2
         /// <summary>The OpenID Connect Json Web Key Set (jwks) URL.</summary>
         public const string JsonWebKeySetUrl = "https://www.googleapis.com/oauth2/v3/certs";
 
+        /// <summary>The IAP Json Web Key Set (jwks) URL.</summary>
+        public const string IapKeySetUrl = "https://www.gstatic.com/iap/verify/public_key-jwk";
+
         /// <summary>Installed application redirect URI.</summary>
         public const string InstalledAppRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/OIdCToken.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/OIdCToken.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Util;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,6 +27,11 @@ namespace Google.Apis.Auth.OAuth2
     public sealed class OidcToken
     {
         private readonly TokenRefreshManager _refreshManager;
+
+        /// <summary>
+        /// The <see cref="TokenResponse"/> this OIDC token is built from.
+        /// </summary>
+        internal TokenResponse TokenResponse { get => _refreshManager.Token; }
 
         internal OidcToken(TokenRefreshManager refreshManager) =>
             _refreshManager = refreshManager.ThrowIfNull(nameof(refreshManager));

--- a/Src/Support/Google.Apis.Auth/SignedToken.cs
+++ b/Src/Support/Google.Apis.Auth/SignedToken.cs
@@ -1,0 +1,92 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Json;
+using Google.Apis.Util;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Google.Apis.Auth
+{
+    // Note: The code here would have probably made more sense in JsonWebSignatura
+    // and GoogleJsonWebSignature, but those classes are effectively static classes,
+    // they only define specific payload and header types and have a few static helper
+    // methods, but yet, they are not marked as static, or sealed, and are public.
+    // And although the payload and header classes defined in GoogleJsonWebSignature do
+    // inherit from the ones defined in JsonWebSignature, GoogleJsonWebSignature itseld does not
+    // inherit from JsonWebSignature, which would be desirable for verification.
+    /// <summary>
+    /// Represents a signed token, could be a <see cref="JsonWebSignature"/> or
+    /// a <see cref="GoogleJsonWebSignature"/> but this not only holds the payload
+    /// and headers, but also the signature itself. It's meant to help with signed
+    /// token verification and with obtaining token information.
+    /// </summary>
+    internal class SignedToken<TJwsHeader, TJwsPayload>
+        where TJwsHeader : JsonWebSignature.Header
+        where TJwsPayload : JsonWebSignature.Payload
+    {
+        private readonly Lazy<byte[]> _sha256;
+
+        internal string EncodedHeader { get; }
+        internal string EncodedPayload { get; }
+        internal TJwsHeader Header { get; }
+        internal TJwsPayload Payload { get; }
+        internal byte[] Signature { get; }
+        internal byte[] Sha256Hash => _sha256.Value;
+
+        private SignedToken(string encodedHeader, string encodedPayload, TJwsHeader header, TJwsPayload payload, byte[] signature)
+        {
+            EncodedHeader = encodedHeader.ThrowIfNullOrEmpty(nameof(encodedHeader));
+            EncodedPayload = encodedPayload.ThrowIfNullOrEmpty(nameof(encodedPayload));
+            Header = header.ThrowIfNull(nameof(header));
+            Payload = payload.ThrowIfNull(nameof(payload));
+            Signature = signature;
+            _sha256 = new Lazy<byte[]>(InitSha256);
+        }
+
+        internal static SignedToken<TJwsHeader, TJwsPayload> FromSignedToken(string signedToken)
+        {
+            // The first one throws ArgumentNullException and the second one ArgumenException.
+            // Just calling ThrowIfNullOrEmpty would then be breaking, and there's actually a test
+            // that breaks.
+            signedToken.ThrowIfNull(nameof(signedToken));
+            signedToken.ThrowIfNullOrEmpty(nameof(signedToken));
+
+            var parts = signedToken.Split('.');
+            if (parts.Length != 3)
+            {
+                throw new InvalidJwtException($"JWT must consist of Header, Payload, and Signature");
+            }
+
+            var encodedHeader = parts[0];
+            var encodedPayload = parts[1];
+
+            // Decode the three parts of the JWT: header.payload.signature
+            var headerValue = NewtonsoftJsonSerializer.Instance.Deserialize<TJwsHeader>(TokenEncodingHelpers.Base64UrlToString(encodedHeader));
+            var payloadValue = NewtonsoftJsonSerializer.Instance.Deserialize<TJwsPayload>(TokenEncodingHelpers.Base64UrlToString(encodedPayload));
+            var signature = TokenEncodingHelpers.Base64UrlDecode(parts[2]);
+
+            return new SignedToken<TJwsHeader, TJwsPayload>(encodedHeader, encodedPayload, headerValue, payloadValue, signature);
+        }
+
+        private byte[] InitSha256()
+        {
+            using var hashAlg = SHA256.Create();
+            return hashAlg.ComputeHash(Encoding.ASCII.GetBytes($"{EncodedHeader}.{EncodedPayload}"));
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/SignedTokenVerification.cs
+++ b/Src/Support/Google.Apis.Auth/SignedTokenVerification.cs
@@ -1,0 +1,291 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#if NETSTANDARD2_0 || NET45
+#define ES256_SUPPORTED
+#elif !NETSTANDARD1_3
+#error Unsupported Platform
+#endif
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Util;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Apis.Auth.JsonWebSignature;
+
+namespace Google.Apis.Auth
+{
+    internal static class SignedTokenVerification
+    {
+#if NET45
+        // See http://oid-info.com/get/2.16.840.1.101.3.4.2.1
+        private const string Sha256Oid = "2.16.840.1.101.3.4.2.1";
+        // In net45 We don't have the handy ECParameters class so we need to pass the X and Y
+        // in the expected format.
+        // See here for the format of the key: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_ecckey_blob
+        // And here for the correct prefix for ECDsa: https://stackoverflow.com/a/44527439/1122643
+        private static readonly byte[] s_cngBlobPrefix = { 0x45, 0x43, 0x53, 0x31, 0x20, 0, 0, 0 };
+#endif
+
+        private static readonly CertificateCache s_certificateCache = new CertificateCache();
+
+        internal async static Task VerifySignedTokenAsync<TJswHeader, TJswPayload>(
+            SignedToken<TJswHeader, TJswPayload> signedToken, SignedTokenVerificationOptions options, CancellationToken cancellationToken)
+            where TJswHeader : Header
+            where TJswPayload : Payload
+        {
+            signedToken.ThrowIfNull(nameof(signedToken));
+            options = options == null ? new SignedTokenVerificationOptions() : new SignedTokenVerificationOptions(options);
+            options.CertificateCache ??= s_certificateCache;
+
+            // Start the signature validation task...
+            Task signatureVerificationTask = signedToken.Header.Algorithm switch
+            {
+                "RS256" => VerifyRS256TokenAsync(signedToken, options, cancellationToken),
+#if ES256_SUPPORTED
+                "ES256" => VerifyES256TokenAsync(signedToken, options, cancellationToken),
+#else
+                "ES256" => throw new InvalidOperationException("ES256 signed token verification is not supported in this platform."),
+#endif
+                _ => throw new InvalidJwtException("Signing algorithm must be either RS256 or ES256.")
+            };
+
+            // ... let's validate everything else while we wait for signature validation...
+
+            // The signed token issuer should be one of the trusted issuers.
+            if (options.TrustedIssuers.Count > 0 && !options.TrustedIssuers.Contains(signedToken.Payload.Issuer))
+            {
+                var validList = string.Join(", ", options.TrustedIssuers.Select(x => $"'{x}'"));
+                throw new InvalidJwtException($"JWT issuer incorrect. Must be one of: {validList}");
+            }
+            // All audiences on the signed token should be trusted audiences.
+            if (options.TrustedAudiences.Count > 0 && signedToken.Payload.AudienceAsList.Except(options.TrustedAudiences).Any())
+            {
+                throw new InvalidJwtException("JWT contains untrusted 'aud' claim.");
+            }
+            // Issued at and expiration are present. Save them for time related validity checks.
+            DateTimeOffset issuedAt = signedToken.Payload.IssuedAt ?? throw new InvalidJwtException("JWT must contain 'iat' and 'exp' claims");
+            DateTimeOffset expiresAt = signedToken.Payload.ExpiresAt ?? throw new InvalidJwtException("JWT must contain 'iat' and 'exp' claims");
+
+            // Check that the token was issued in the past.
+            var utcNow = options.Clock.UtcNow;
+            if (utcNow + options.IssuedAtClockTolerance < issuedAt)
+            {
+                throw new InvalidJwtException("JWT is not yet valid.");
+            }
+            // Check that the token is not yet expired.
+            if (utcNow - options.ExpiryClockTolerance > expiresAt)
+            {
+                throw new InvalidJwtException("JWT has expired.");
+            }
+
+            // ... and finally let's wait for signature validation to be done.
+            await signatureVerificationTask.ConfigureAwait(false);
+        }
+
+        private async static Task VerifyRS256TokenAsync<TJswHeader, TJswPayload>(
+            SignedToken<TJswHeader, TJswPayload> signedToken, SignedTokenVerificationOptions options, CancellationToken cancellationToken)
+            where TJswHeader : Header
+            where TJswPayload : Payload
+        {
+            var certificates = await GetCertificatesAsync(
+                options, GoogleAuthConsts.JsonWebKeySetUrl, FromKeyToRsa, cancellationToken).ConfigureAwait(false);
+
+            foreach (RSA certificate in certificates)
+            {
+#if NET45
+                if (((RSACryptoServiceProvider)certificate).VerifyHash(signedToken.Sha256Hash, Sha256Oid, signedToken.Signature))
+#elif NETSTANDARD1_3 || NETSTANDARD2_0
+                if (certificate.VerifyHash(signedToken.Sha256Hash, signedToken.Signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1))
+#else
+#error Unsupported platform
+#endif
+                {
+                    return;
+                }
+            }
+            throw new InvalidJwtException("JWT invalid, unable to verify signature.");
+
+            static RSA FromKeyToRsa(JToken key)
+            {
+                var rsa = RSA.Create();
+                rsa.ImportParameters(new RSAParameters
+                {
+                    Modulus = TokenEncodingHelpers.Base64UrlDecode((string)key["n"]),
+                    Exponent = TokenEncodingHelpers.Base64UrlDecode((string)key["e"]),
+                });
+                return rsa;
+            }
+        }
+
+#if ES256_SUPPORTED
+        private async static Task VerifyES256TokenAsync<TJswHeader, TJswPayload>(
+            SignedToken<TJswHeader, TJswPayload> signedToken, SignedTokenVerificationOptions options, CancellationToken cancellationToken)
+            where TJswHeader : Header
+            where TJswPayload : Payload
+        {
+            var certificates = await GetCertificatesAsync(
+                options, GoogleAuthConsts.IapKeySetUrl, FromKeyToECDsa, cancellationToken).ConfigureAwait(false);
+
+            foreach (ECDsa certificate in certificates)
+            {
+                if (certificate.VerifyHash(signedToken.Sha256Hash, signedToken.Signature))
+                {
+                    return;
+                }
+            }
+            throw new InvalidJwtException("JWT invalid, unable to verify signature.");
+
+            static ECDsa FromKeyToECDsa(JToken key)
+            {
+                if ((string)key["kty"] != "EC" && (string)key["crv"] != "P-256")
+                {
+                    throw new ArgumentException(
+                        $"For ES256 verification only certificates with kty='EC' and crv='P-256' are supported. Encountered: kty={(string)key["kty"]} and crv={(string)key["crv"]}.");
+                }
+                byte[] x = TokenEncodingHelpers.Base64UrlDecode((string)key["x"]);
+                byte[] y = TokenEncodingHelpers.Base64UrlDecode((string)key["y"]);
+                return BuildEcdsa(x, y);
+            }
+#if NETSTANDARD2_0
+            static ECDsa BuildEcdsa(byte[] x, byte[] y)
+            {
+                var ecdsa = ECDsa.Create();
+                ecdsa.ImportParameters(new ECParameters
+                {
+                    // Curve used in ES256
+                    Curve = ECCurve.NamedCurves.nistP256,
+                    Q = new ECPoint { X = x, Y = y }
+                });
+                return ecdsa;
+            }
+#elif NET45
+            static ECDsa BuildEcdsa(byte[] x, byte[] y)
+            {
+                // In net45 We don't have the handy ECParameters class so we need to pass the X and Y
+                // in the expected format.
+                // See here for the format of the key: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/ns-bcrypt-bcrypt_ecckey_blob
+                // And here for the correct prefix for ECDsa: https://stackoverflow.com/a/44527439/1122643
+                byte[] publicKey = new byte[s_cngBlobPrefix.Length + 64];
+                Buffer.BlockCopy(s_cngBlobPrefix, 0, publicKey, 0, s_cngBlobPrefix.Length);
+                Buffer.BlockCopy(x, 0, publicKey, s_cngBlobPrefix.Length, x.Length);
+                Buffer.BlockCopy(y, 0, publicKey, s_cngBlobPrefix.Length + x.Length, y.Length);
+                return new ECDsaCng(CngKey.Import(publicKey, CngKeyBlobFormat.EccPublicBlob));
+            }
+#endif
+        }
+#endif
+
+        private static async Task<IEnumerable<AsymmetricAlgorithm>> GetCertificatesAsync(
+            SignedTokenVerificationOptions options,
+            string defaultCertificateLocation,
+            Func<JToken, AsymmetricAlgorithm> certificateFactory,
+            CancellationToken cancellationToken) =>
+            await options.CertificateCache.GetCertificatesAsync(
+                options.CertificatesUrl ?? defaultCertificateLocation,
+                certificateFactory,
+                options.ForceCertificateRefresh,
+                cancellationToken).ConfigureAwait(false);
+
+        // Abstract base class for testing purposes.
+        internal abstract class CertificateCacheBase
+        {
+            internal static readonly TimeSpan DefaultCacheValidity = TimeSpan.FromHours(1);
+
+            private readonly IDictionary<string, CachedCertificates> _cache = new Dictionary<string, CachedCertificates>();
+            private readonly SemaphoreSlim _cacheLock = new SemaphoreSlim(1);
+            // For testing purposes only.
+            // Note that this won't match the clock sent in for each verification request.
+            // The cache is global and the clock is specified on a per verification request basis,
+            // and changing that would be breaking.
+            // Therefor, in production code, we always use the system clock for calculating certificate
+            // caching expiry because we cannot get the certificates at a specific point in time,
+            // but just at the real now.
+            // That is, certificate validity is relative to real time and not to faked time.
+            // This clock is just for use in unit testing and have a deterministic way of making the
+            // cache invalid.
+            private readonly IClock _clock;
+
+            // For testing purposes.
+            // See the note on CacheExpired to know why we don't have a clock here.
+            protected CertificateCacheBase(IClock clock) =>
+                _clock = clock ?? SystemClock.Default;
+
+            public async Task<IEnumerable<AsymmetricAlgorithm>> GetCertificatesAsync(string certificatesLocation, Func<JToken, AsymmetricAlgorithm> certificateFactory, bool forceCertificateRefresh, CancellationToken cancellationToken)
+            {
+                certificatesLocation.ThrowIfNullOrEmpty(nameof(certificatesLocation));
+                certificateFactory.ThrowIfNull(nameof(certificateFactory));
+
+                await _cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    if (forceCertificateRefresh ||
+                        !_cache.TryGetValue(certificatesLocation, out CachedCertificates cachedCerts) ||
+                        cachedCerts.Expired(_clock.UtcNow))
+                    {
+                        string certificatesJson = await FetchCertificatesAsync(certificatesLocation).ConfigureAwait(false);
+                        cachedCerts = new CachedCertificates(
+                            JToken.Parse(certificatesJson)["keys"]
+                            .AsEnumerable()
+                            .Select(key => certificateFactory(key)).ToList(),
+                            _clock.UtcNow);
+                        _cache[certificatesLocation] = cachedCerts;
+                    }
+                    return cachedCerts.Certificates;
+                }
+                finally
+                {
+                    _cacheLock.Release();
+                }
+            }
+
+            // Abstract for testing purposes.
+            protected abstract Task<string> FetchCertificatesAsync(string certificatesLocation);
+
+            internal struct CachedCertificates
+            {
+                private readonly DateTimeOffset _cachedSince;
+                public IEnumerable<AsymmetricAlgorithm> Certificates { get; }
+
+                public CachedCertificates(IEnumerable<AsymmetricAlgorithm> certificates, DateTimeOffset cachedSince)
+                {
+                    _cachedSince = cachedSince;
+                    Certificates = certificates;
+                }
+
+                public bool Expired(DateTimeOffset now) => _cachedSince + DefaultCacheValidity <= now;
+            }
+        }
+
+        internal sealed class CertificateCache : CertificateCacheBase
+        {
+            public CertificateCache() : base(SystemClock.Default)
+            { }
+
+            protected override async Task<string> FetchCertificatesAsync(string certificatesLocation)
+            {
+                using var httpClient = new HttpClient();
+                return await httpClient.GetStringAsync(certificatesLocation).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/SignedTokenVerificationOptions.cs
+++ b/Src/Support/Google.Apis.Auth/SignedTokenVerificationOptions.cs
@@ -1,0 +1,126 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Util;
+using System;
+using System.Collections.Generic;
+using static Google.Apis.Auth.SignedTokenVerification;
+
+namespace Google.Apis.Auth
+{
+    /// <summary>
+    /// Options to use when verifying signed JWTs.
+    /// </summary>
+    public sealed class SignedTokenVerificationOptions
+    {
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SignedTokenVerificationOptions"/>
+        /// with default values for all options (or null for those whose default is unset).
+        /// </summary>
+        public SignedTokenVerificationOptions() { }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SignedTokenVerificationOptions"/>
+        /// by copying over all the values from <paramref name="other"/>.
+        /// </summary>
+        /// <param name="other">The option set to build this instance from.</param>
+        public SignedTokenVerificationOptions(SignedTokenVerificationOptions other)
+        {
+            other.ThrowIfNull(nameof(other));
+            foreach (var audience in other.TrustedAudiences)
+            {
+                TrustedAudiences.Add(audience);
+            }
+            foreach (var issuer in other.TrustedIssuers)
+            {
+                TrustedIssuers.Add(issuer);
+            }
+            CertificatesUrl = other.CertificatesUrl;
+            ForceCertificateRefresh = other.ForceCertificateRefresh;
+            IssuedAtClockTolerance = other.IssuedAtClockTolerance;
+            ExpiryClockTolerance = other.ExpiryClockTolerance;
+            CertificateCache = other.CertificateCache;
+            Clock = other.Clock;
+        }
+
+        /// <summary>
+        /// Trusted audiences for the token.
+        /// All the audiences the token is intended for should be in the
+        /// trusted audiences list.
+        /// If the list is empty, the token audience won't be verified.
+        /// </summary>
+        public IList<string> TrustedAudiences { get; } = new List<string>();
+
+        /// <summary>
+        /// The URL from where to obtain certificates from.
+        /// May be null, in which case, default certificate locations will be used:
+        /// <list type="bullet">
+        /// <item>For RS256 signed certificates, https://www.googleapis.com/oauth2/v3/certs will be used.</item>
+        /// <item>For ES256 signed certificates, https://www.gstatic.com/iap/verify/public_key-jwk will be used.</item>
+        /// </list>
+        /// </summary>
+        public string CertificatesUrl { get; set; }
+
+        /// <summary>
+        /// List of trusted issuers to verify the token issuer against.
+        /// The token issuer must be contained in this list.
+        /// May be null, in which case the token issuer won't be verified.
+        /// </summary>
+        public IList<string> TrustedIssuers { get; } = new List<string>();
+
+        /// <summary>
+        /// Forces certificate refresh.
+        /// Internal to be used only for backward compatibility.
+        /// </summary>
+        internal bool ForceCertificateRefresh { get; set; }
+
+        /// <summary>
+        /// Clock tolerance for the issued-at check.
+        /// Causes a JWT to pass validation up to this duration before it is really valid;
+        /// this is to allow for possible local-client clock skew.
+        /// Defaults to zero.
+        /// Internal to be used only for backward compatibility.
+        /// </summary>
+        public TimeSpan IssuedAtClockTolerance { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Clock tolerance for the expiration check.
+        /// Causes a JWT to pass validation up to this duration after it really expired;
+        /// this is to allow for possible local-client clock skew.
+        /// Defaults to zero.
+        /// Internal to be used only for backward compatibility.
+        /// </summary>
+        public TimeSpan ExpiryClockTolerance { get; set; } = TimeSpan.Zero;
+
+        private IClock _clock = SystemClock.Default;
+        /// <summary>
+        /// Clock for testing purposes. Defaults to <see cref="SystemClock.Default"/>.
+        /// Must not be null.
+        /// </summary>
+        internal IClock Clock
+        {
+            get => _clock;
+            set => _clock = value ?? throw new ArgumentNullException(nameof(Clock));
+        }
+
+        /// <summary>
+        /// CertificateCache for testing purposes.
+        /// If null, the true CertificateCache will be used.
+        /// </summary>
+        internal CertificateCacheBase CertificateCache { get; set; }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/TokenEncodingHelpers.cs
+++ b/Src/Support/Google.Apis.Auth/TokenEncodingHelpers.cs
@@ -1,0 +1,67 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.Text;
+
+namespace Google.Apis.Auth
+{
+    internal static class TokenEncodingHelpers
+    {
+        /// <summary>
+        /// Decodes the provided URL safe base 64 string.
+        /// </summary>
+        /// <param name="base64Url">The URL safe base 64 string to decode.</param>
+        /// <returns>The UTF8 decoded string.</returns>
+        internal static string Base64UrlToString(string base64Url) =>
+            Encoding.UTF8.GetString(Base64UrlDecode(base64Url));
+
+        /// <summary>
+        /// Decodes the provided URL safe base 64 string.
+        /// </summary>
+        /// <param name="base64Url">The URL safe base 64 string to decode.</param>
+        /// <returns>The UTF8 byte representation of the decoded string.</returns>
+        internal static byte[] Base64UrlDecode(string base64Url)
+        {
+            var base64 = base64Url.Replace('-', '+').Replace('_', '/');
+            switch (base64.Length % 4)
+            {
+                case 2: base64 += "=="; break;
+                case 3: base64 += "="; break;
+            }
+            return Convert.FromBase64String(base64);
+        }
+
+        /// <summary>Encodes the provided UTF8 string into an URL safe base64 string.</summary>
+        /// <param name="value">Value to encode.</param>
+        /// <returns>The URL safe base64 string.</returns>
+        internal static string UrlSafeBase64Encode(string value) =>
+            UrlSafeBase64Encode(Encoding.UTF8.GetBytes(value));
+
+        /// <summary>Encodes the byte array into an URL safe base64 string.</summary>
+        /// <param name="bytes">Byte array to encode.</param>
+        /// <returns>The URL safe base64 string.</returns>
+        internal static string UrlSafeBase64Encode(byte[] bytes) =>
+            UrlSafeEncode(Convert.ToBase64String(bytes));
+
+
+        /// <summary>Encodes the base64 string into an URL safe string.</summary>
+        /// <param name="base64Value">The base64 string to make URL safe.</param>
+        /// <returns>The URL safe base64 string.</returns>
+        internal static string UrlSafeEncode(string base64Value) =>
+            base64Value.Replace("=", String.Empty).Replace('+', '-').Replace('/', '_');
+    }
+}

--- a/Src/Support/IntegrationTests/GoogleJsonWebSignatureTests.cs
+++ b/Src/Support/IntegrationTests/GoogleJsonWebSignatureTests.cs
@@ -18,12 +18,8 @@ using Google.Apis.Auth;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Auth.OAuth2.Requests;
-using Google.Apis.Util;
-using Google.Apis.Util.Store;
 using IntegrationTests.Utils;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -35,14 +31,6 @@ namespace IntegrationTests
 {
     public class GoogleJsonWebSignatureTests
     {
-        [Fact]
-        public async Task GetGoogleCerts()
-        {
-            // Verifies certs are downloaded and loaded into RSAs
-            var certs = await GoogleJsonWebSignature.GetGoogleCertsAsync(SystemClock.Default, false, null);
-            Assert.NotEmpty(certs);
-        }
-
         [Fact]
         public async Task GetAndValidateJwt()
         {

--- a/Src/Support/IntegrationTests/IntegrationTests.Utils/OnGceFactAttribute.cs
+++ b/Src/Support/IntegrationTests/IntegrationTests.Utils/OnGceFactAttribute.cs
@@ -1,0 +1,33 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Xunit;
+
+namespace IntegrationTests.IntegrationTests.Utils
+{
+    public class OnGceFactAttribute : FactAttribute
+    {
+        public OnGceFactAttribute()
+        {
+            // Ugly, but this is for tests.
+            if (!ComputeCredential.IsRunningOnComputeEngine().GetAwaiter().GetResult())
+            {
+                Skip = "Not running on GCE";
+            }
+        }
+    }
+}

--- a/Src/Support/IntegrationTests/OidcTests.cs
+++ b/Src/Support/IntegrationTests/OidcTests.cs
@@ -1,0 +1,79 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth;
+using Google.Apis.Auth.OAuth2;
+using IntegrationTests.IntegrationTests.Utils;
+using IntegrationTests.Utils;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IntegrationTests
+{
+    public class OidcTests
+    {
+        [Fact]
+        public async Task OidcTokenProvider_ServiceAccountCredential()
+        {
+            GoogleCredential credential = Helper.GetServiceCredential();
+
+            OidcToken token = await credential.GetOidcTokenAsync(
+                OidcTokenOptions.FromTargetAudience("https://this.is.a.test"));
+
+            // Check an access token (really id_token) is available.
+            Assert.NotNull(await token.GetAccessTokenAsync());
+            // If IdToken is set and AccessToken is not, AccessToken is set to
+            // IdToken, so we can always check here that AccessToken is not null.
+            Assert.NotNull(token.TokenResponse.AccessToken);
+            // The enpoint does not send an expiry, bu we set it to the id_token
+            // expiry.
+            Assert.NotNull(token.TokenResponse.ExpiresInSeconds);
+
+            var verificationOptions = new SignedTokenVerificationOptions();
+            verificationOptions.TrustedAudiences.Add("https://this.is.a.test");
+
+            var payload = await JsonWebSignature.VerifySignedTokenAsync(await token.GetAccessTokenAsync());
+            Assert.NotNull(payload);
+            Assert.Contains("https://this.is.a.test", payload.AudienceAsList);
+        }
+
+        [OnGceFact]
+        public async Task OidcTokenProvider_ComputeCredential()
+        {
+            // This test only executes on GCE so we are certain to have a ComputeCredential.
+            GoogleCredential credential = GoogleCredential.FromComputeCredential();
+
+            OidcToken token = await credential.GetOidcTokenAsync(
+                OidcTokenOptions.FromTargetAudience("https://this.is.a.test"));
+
+            // Check an access token (really id_token) is available.
+            Assert.NotNull(await token.GetAccessTokenAsync());
+            // If IdToken is set and AccessToken is not, AccessToken is set to
+            // IdToken, so we can always check here that AccessToken is not null.
+            Assert.NotNull(token.TokenResponse.AccessToken);
+            // The enpoint does not send an expiry, bu we set it to the id_token
+            // expiry.
+            Assert.NotNull(token.TokenResponse.ExpiresInSeconds);
+
+            var verificationOptions = new SignedTokenVerificationOptions();
+            verificationOptions.TrustedAudiences.Add("https://this.is.a.test");
+
+            var payload = await JsonWebSignature.VerifySignedTokenAsync(await token.GetAccessTokenAsync());
+            Assert.NotNull(payload);
+            Assert.Contains("https://this.is.a.test", payload.AudienceAsList);
+        }
+    }
+}

--- a/Src/Support/IntegrationTests/SignedTokenVerificationTests.cs
+++ b/Src/Support/IntegrationTests/SignedTokenVerificationTests.cs
@@ -1,0 +1,38 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Xunit;
+using static Google.Apis.Auth.SignedTokenVerification;
+
+namespace IntegrationTests
+{
+    public class SignedTokenVerificationTests
+    {
+        [Fact]
+        public async Task CertificateCache()
+        {
+            var certCache = new CertificateCache();
+
+            // We don't care about cert transformation here, that'll be tested when verifying.
+            var certificates = await certCache.GetCertificatesAsync(GoogleAuthConsts.JsonWebKeySetUrl, json => RSA.Create(), false, default);
+
+            Assert.NotEmpty(certificates);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1557.  
  * Sets the correct audience in the JWT used to request the OIDC token.
  * The OIDC token exposes the id_token instead of the access_token.

Adds support for IAP token verification.

FYI @salrashid123.