### PR TITLE
Extension method for requests to allow fluent configuration

### DIFF
--- a/Src/Support/Google.Apis.Tests/Apis/Requests/ClientServiceRequestExtensionsTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/ClientServiceRequestExtensionsTest.cs
@@ -1,0 +1,67 @@
+﻿/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Requests;
+using Google.Apis.Services;
+using Google.Apis.Tests.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Google.Apis.Tests.Apis.Requests
+{
+    public class ClientServiceRequestExtensionsTest
+    {
+        [Fact]
+        public void Configure_NullRequest()
+        {
+            TestRequest request = null;
+            Assert.Throws<ArgumentNullException>(() => request.Configure(r => { }));
+        }
+
+        [Fact]
+        public void Configure_NullConfigureAction()
+        {
+            var request = new TestRequest(new MockClientService());
+            Assert.Throws<ArgumentNullException>(() => request.Configure(null));
+        }
+
+        [Fact]
+        public void Configure_Valid()
+        {
+            var request = new TestRequest(new MockClientService());
+            Assert.Null(request.ArbitraryQueryParameter);
+            var result = request.Configure(r => r.ArbitraryQueryParameter = "value");
+            Assert.Same(request, result);
+            Assert.Equal("value", request.ArbitraryQueryParameter);
+        }
+
+        private class TestRequest : ClientServiceRequest<string>
+        {
+            public TestRequest(IClientService service) : base(service)
+            {
+            }
+
+            public override string MethodName => throw new NotImplementedException();
+            public override string RestPath => throw new NotImplementedException();
+            public override string HttpMethod => throw new NotImplementedException();
+            protected override object GetBody() => throw new NotImplementedException();
+
+            public string ArbitraryQueryParameter { get; set; }
+        }
+    }
+}

--- a/Src/Support/Google.Apis/Requests/ClientServiceRequestExtensions.cs
+++ b/Src/Support/Google.Apis/Requests/ClientServiceRequestExtensions.cs
@@ -1,0 +1,45 @@
+﻿/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Util;
+using System;
+
+namespace Google.Apis.Requests
+{
+    /// <summary>
+    /// Extension methods for request objects.
+    /// </summary>
+    public static class ClientServiceRequestExtensions
+    {
+        /// <summary>
+        /// Allows a request to be configured in a fluent manner, where normally separate statements are required
+        /// after the request creation method is called.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of the request to configure.</typeparam>
+        /// <param name="request">The request to configure. Must not be null.</param>
+        /// <param name="configurationAction">The configuration action to apply to the request. This is typically
+        /// setting properties. Must not be null.</param>
+        /// <returns>The value of <paramref name="request"/>, after applying the configuration action.</returns>
+        public static TRequest Configure<TRequest>(this TRequest request, Action<TRequest> configurationAction)
+            where TRequest : ClientServiceRequest
+        {
+            request.ThrowIfNull(nameof(request));
+            configurationAction.ThrowIfNull(nameof(configurationAction));
+            configurationAction(request);
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
I'd want to write a few unit tests and then documentation.
The integration test shows how this can be used, including a
demonstration of "initialize request, set a property, execute the
request" all within a single expression.

It's unfortunate that this has to be an extension method, but that's
the only way to get the type inference working appropriately.

This is an alternative approach to the feature request in #1562.