### PR TITLE
Marks as Obsolete Google.Apis.Auth.OAuth2.BearerToken.QueryParameterAccessMethod.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/BearerTokenTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/BearerTokenTests.cs
@@ -59,7 +59,9 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public void QueryParameterAccessMethod_Intercept()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com/path"));
+#pragma warning disable CS0618 // Type or member is obsolete
             new BearerToken.QueryParameterAccessMethod().Intercept(request, "abc");
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(new Uri("https://sample.com/path?access_token=abc"), request.RequestUri);
         }
 
@@ -67,7 +69,9 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public void QueryParameterAccessMethod_Intercept_WithQueryParameters()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com/path?a=1"));
+#pragma warning disable CS0618 // Type or member is obsolete
             new BearerToken.QueryParameterAccessMethod().Intercept(request, "abc");
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal(new Uri("https://sample.com/path?a=1&access_token=abc"), request.RequestUri);
         }
 
@@ -76,22 +80,30 @@ namespace Google.Apis.Auth.Tests.OAuth2
         {
             // No query parameter at all.
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com"));
+#pragma warning disable CS0618 // Type or member is obsolete
             var accessToken = new BearerToken.QueryParameterAccessMethod().GetAccessToken(request);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Null(accessToken);
 
             // Different query parameter.
             request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com?a=1"));
+#pragma warning disable CS0618 // Type or member is obsolete
             accessToken = new BearerToken.QueryParameterAccessMethod().GetAccessToken(request);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Null(accessToken);
 
             // One query parameter and it's access_token.
             request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com?a=1&access_token=abc"));
+#pragma warning disable CS0618 // Type or member is obsolete
             accessToken = new BearerToken.QueryParameterAccessMethod().GetAccessToken(request);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal("abc", accessToken);
 
             // 2 query parameters and one of them is access_token.
             request = new HttpRequestMessage(HttpMethod.Get, new Uri("https://sample.com?access_token=abc"));
+#pragma warning disable CS0618 // Type or member is obsolete
             accessToken = new BearerToken.QueryParameterAccessMethod().GetAccessToken(request);
+#pragma warning restore CS0618 // Type or member is obsolete
             Assert.Equal("abc", accessToken);
         }
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/BearerToken.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/BearerToken.cs
@@ -52,9 +52,14 @@ namespace Google.Apis.Auth.OAuth2
         }
 
         /// <summary>
+        /// Obsolete.
         /// Thread-safe OAuth 2.0 method for accessing protected resources using an <c>access_token</c> query parameter
         /// as specified in http://tools.ietf.org/html/rfc6750#section-2.3.
+        /// This access method is being made obsolete. Please read here for more up to date information:
+        /// `https://developers.google.com/identity/protocols/oauth2/index.html#4.-send-the-access-token-to-an-api.`.
+        /// Please use <see cref="AuthorizationHeaderAccessMethod"/> instead.
         /// </summary>
+        [Obsolete("https://developers.google.com/identity/protocols/oauth2/index.html#4.-send-the-access-token-to-an-api.")]
         public class QueryParameterAccessMethod : IAccessMethod
         {
             const string AccessTokenKey = "access_token";

--- a/Src/Support/IntegrationTests/PerCallAuthTests.cs
+++ b/Src/Support/IntegrationTests/PerCallAuthTests.cs
@@ -102,8 +102,10 @@ namespace IntegrationTests
         [Fact]
         public void OverridesServiceCredentialWithPerCallCredential_QueryString()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
             var callCredential = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var request = BuildListBucketsRequest(serviceCredential, callCredential);
 
@@ -122,7 +124,9 @@ namespace IntegrationTests
         public void OverridesServiceCredentialWithPerCallCredential_Mixed_Header_Query()
         {
             var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.AuthorizationHeaderAccessMethod());
+#pragma warning disable CS0618 // Type or member is obsolete
             var callCredential = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var request = BuildListBucketsRequest(serviceCredential, callCredential);
 
@@ -141,7 +145,9 @@ namespace IntegrationTests
         [Fact]
         public void OverridesServiceCredentialWithPerCallCredential_Mixed_Query_Header()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
+#pragma warning restore CS0618 // Type or member is obsolete
             var callCredential = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN", new BearerToken.AuthorizationHeaderAccessMethod());
 
             var request = BuildListBucketsRequest(serviceCredential, callCredential);
@@ -161,9 +167,11 @@ namespace IntegrationTests
         [Fact]
         public void OverridesServiceCredentialWithPerCallCredential_TwoCallCredentials()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var serviceCredential = new RequestInterceptorCredentialWrapper("SERVICE_CREDENTIAL_TOKEN", new BearerToken.QueryParameterAccessMethod());
             var callCredential1 = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN_1", new BearerToken.QueryParameterAccessMethod());
             var callCredential2 = new AccessTokenCredential("CALL_CREDENTIAL_TOKEN_2", new BearerToken.QueryParameterAccessMethod());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var request = BuildListBucketsRequest(serviceCredential, callCredential1);
             request.AddCredential(callCredential2);


### PR DESCRIPTION
Because of https://developers.google.com/identity/protocols/oauth2/index.html#4.-send-the-access-token-to-an-api.