### PR TITLE
Simplify MockClock creation

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/JsonWebSignatureTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/JsonWebSignatureTests.cs
@@ -38,7 +38,7 @@ namespace Google.Apis.Auth.Tests
             var options = new SignedTokenVerificationOptions
             {
                 CertificateCache = new FakeCertificateCache(),
-                Clock = clock ?? new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned }
+                Clock = clock ?? new MockClock(FakeCertificateCache.ValidJwtGoogleSigned)
             };
             foreach (var issuer in trustedIssuers ?? Enumerable.Empty<string>())
             {
@@ -90,13 +90,13 @@ namespace Google.Apis.Auth.Tests
         [Fact]
         public async Task ValidES256Signature() =>
             Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(
-                FakeCertificateCache.Es256ForIap, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+                FakeCertificateCache.Es256ForIap, BuildOptions(new MockClock(FakeCertificateCache.ValidEs256ForIap))));
 #else
         [Fact]
         public async Task ValidES256Signature_Unsupported()
         {
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => JsonWebSignature.VerifySignedTokenAsync(
-                FakeCertificateCache.Es256ForIap, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+                FakeCertificateCache.Es256ForIap, BuildOptions(new MockClock(FakeCertificateCache.ValidEs256ForIap))));
             Assert.Equal("ES256 signed token verification is not supported in this platform.", ex.Message);
         }
 #endif
@@ -129,7 +129,7 @@ namespace Google.Apis.Auth.Tests
             // this test will fail and then we'll have to replace the 4 by an A or any other character.
             var invalidToken = FakeCertificateCache.Es256ForIap.Substring(0, FakeCertificateCache.Es256ForIap.Length - 1) + "4";
             var ex = await Assert.ThrowsAsync<InvalidJwtException>(() =>
-                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions(new MockClock(FakeCertificateCache.ValidEs256ForIap))));
             Assert.Equal("JWT invalid, unable to verify signature.", ex.Message);
         }
 #else
@@ -144,7 +144,7 @@ namespace Google.Apis.Auth.Tests
             // this test will fail and then we'll have to replace the 4 by an A or any other character.
             var invalidToken = FakeCertificateCache.Es256ForIap.Substring(0, FakeCertificateCache.Es256ForIap.Length - 1) + "4";
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions(new MockClock { UtcNow = FakeCertificateCache.ValidEs256ForIap })));
+                JsonWebSignature.VerifySignedTokenAsync(invalidToken, BuildOptions(new MockClock(FakeCertificateCache.ValidEs256ForIap))));
             Assert.Equal("ES256 signed token verification is not supported in this platform.", ex.Message);
         }
 #endif
@@ -170,9 +170,9 @@ namespace Google.Apis.Auth.Tests
         [Fact]
         public async Task Validate_Signature_Time()
         {
-            var clockInvalid1 = new MockClock() { UtcNow = FakeCertificateCache.BeforeValidJwtGoogleSigned };
-            var clockValid1 = new MockClock() { UtcNow = FakeCertificateCache.ValidJwtGoogleSigned };
-            var clockInvalid2 = new MockClock() { UtcNow = FakeCertificateCache.AfterValidJwtGoogleSigned };
+            var clockInvalid1 = new MockClock(FakeCertificateCache.BeforeValidJwtGoogleSigned);
+            var clockValid1 = new MockClock(FakeCertificateCache.ValidJwtGoogleSigned);
+            var clockInvalid2 = new MockClock(FakeCertificateCache.AfterValidJwtGoogleSigned);
 
             // Test with no tolerance
             Assert.NotNull(await JsonWebSignature.VerifySignedTokenAsync(FakeCertificateCache.JwtGoogleSigned, BuildOptions(clockValid1)));

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
@@ -46,7 +46,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public async Task FetchesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcComputeSuccessMessageHandler();
             var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
             {
@@ -73,7 +73,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public async Task RefreshesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcComputeSuccessMessageHandler();
             var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
             {
@@ -100,7 +100,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public async Task FetchesOidcToken_WithDefaultOptions()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcComputeSuccessMessageHandler();
             var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
             {
@@ -122,7 +122,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public async Task FetchesOidcToken_WithOptions(OidcTokenFormat format, string targetAudience, string expectedQueryString)
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcComputeSuccessMessageHandler();
             var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
             {

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
@@ -264,7 +264,7 @@ TOgrHXgWf1cxYf5cB8DfC3NoaYZ4D3Wh9Qjn3cl36CXfSKEnPK49DkrGZz1avAjV
         public async Task FromServiceAccountCredential_FetchesOicdToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcTokenResponseSuccessMessageHandler();
             var initializer = new ServiceAccountCredential.Initializer("MyId", "http://will.be.ignored")
             {
@@ -287,7 +287,7 @@ TOgrHXgWf1cxYf5cB8DfC3NoaYZ4D3Wh9Qjn3cl36CXfSKEnPK49DkrGZz1avAjV
         public async Task FromComputeCredential_FetchesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 21, 9, 20, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcComputeSuccessMessageHandler();
             var initializer = new ComputeCredential.Initializer("http://will.be.ignored", "http://will.be.ignored")
             {
@@ -334,7 +334,7 @@ TOgrHXgWf1cxYf5cB8DfC3NoaYZ4D3Wh9Qjn3cl36CXfSKEnPK49DkrGZz1avAjV
         [Fact]
         public async Task AccessTokenWithHeadersCredential()
         {
-            var mockClock = new MockClock();
+            var mockClock = new MockClock(DateTime.UtcNow);
             var tokenResponse = new TokenResponse
             {
                 AccessToken = "ACCESS_TOKEN",

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenTests.cs
@@ -30,7 +30,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task FetchesAccessToken()
         {
-            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            MockClock clock = new MockClock(new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
 
             TokenRefreshManager refreshManager = null;
             refreshManager = new TokenRefreshManager(RefreshTokenAsync, clock, new NullLogger());
@@ -54,7 +54,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task RefreshesAccessToken()
         {
-            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            MockClock clock = new MockClock(new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
 
             TokenRefreshManager refreshManager = null;
             bool firstToken = true;
@@ -85,7 +85,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task FetchTokenFails()
         {
-            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            MockClock clock = new MockClock(new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
 
             TokenRefreshManager refreshManager = new TokenRefreshManager(ct => Task.FromResult(false), clock, new NullLogger());
             OidcToken token = new OidcToken(refreshManager);
@@ -96,7 +96,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task RefreshTokenFails()
         {
-            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) };
+            MockClock clock = new MockClock(new DateTime(2020, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
 
             TokenRefreshManager refreshManager = null;
             bool firstToken = true;

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
@@ -117,7 +117,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
             string accessToken, string idToken,
             bool expectedExpired, bool expectedEffectiveExpires)
         {
-            var clock = new MockClock { UtcNow = now };
+            var clock = new MockClock(now);
             var token = new TokenResponse
             {
                 IssuedUtc = issuedAt,
@@ -150,7 +150,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
                 Content = new StringContent(serializedToken)
             };
 
-            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc) };
+            MockClock clock = new MockClock(new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc));
             TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
             Assert.Equal("IdToken", token.IdToken);
@@ -172,7 +172,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
                 RequestMessage = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.ComputeOidcTokenUrl)
             };
 
-            MockClock clock = new MockClock { UtcNow = new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc) };
+            MockClock clock = new MockClock(new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc));
             TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
             Assert.Equal(OidcComputeSuccessMessageHandler.FirstCallToken, token.IdToken);
@@ -226,7 +226,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
                 Content = new StringContent(serializedToken)
             };
 
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));
             TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
             Assert.Equal(expectedIdToken, token.IdToken);
@@ -248,7 +248,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
                 Content = new StringContent(serializedToken)
             };
 
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));
             TokenResponse token = await TokenResponse.FromHttpResponseAsync(response, clock, new NullLogger());
 
             Assert.Equal(OidcTokenResponseSuccessMessageHandler.FirstCallToken, token.IdToken);

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
@@ -62,7 +62,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(dummyServiceAccountCredentialFileContents);
             var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail)
             {
-                Clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+                Clock = new MockClock(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc))
             };
             var cred = new ServiceAccountCredential(initializer.FromPrivateKey(credentialParameters.PrivateKey));
 
@@ -124,7 +124,7 @@ lK1DcBvq+IFLucBdi0/9hXE=
             var credentialParameters = NewtonsoftJsonSerializer.Instance.Deserialize<JsonCredentialParameters>(dummyServiceAccountCredentialFileContents);
             var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail)
             {
-                Clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+                Clock = new MockClock(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc))
             };
             initializer.FromPrivateKey(credentialParameters.PrivateKey);
             var ps = initializer.Key.ExportParameters(true);
@@ -218,7 +218,7 @@ AQsFAAOBgQBQ9cMInb2rEcg8TTYq8MjDEegHWLUI9Dq/IvP/FHyKDczza4eX8m+G
 
             var initializer = new ServiceAccountCredential.Initializer("some-id")
             {
-                Clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) }
+                Clock = new MockClock(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc))
             };
             var cred = new ServiceAccountCredential(initializer.FromCertificate(x509Cert));
 
@@ -255,7 +255,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         [Fact]
         public async Task JwtCache_Size()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var initializer = new ServiceAccountCredential.Initializer("some-id")
             {
                 Clock = clock
@@ -280,7 +280,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         [Fact]
         public async Task JwtCache_Expiry()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var initializer = new ServiceAccountCredential.Initializer("some-id")
             {
                 Clock = clock
@@ -313,7 +313,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         {
             var serviceAccountCred = new ServiceAccountCredential(new ServiceAccountCredential.Initializer("MyId", "MyTokenServerUrl")
             {
-                Clock = new MockClock(),
+                Clock = new MockClock(DateTime.UtcNow),
                 AccessMethod = new DummyAccessMethod(),
                 HttpClientFactory = new DummyHttpClientFactory(),
                 DefaultExponentialBackOffPolicy = ExponentialBackOffPolicy.Exception, // This is not the default
@@ -348,7 +348,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         {
             var serviceAccountCred = new ServiceAccountCredential(new ServiceAccountCredential.Initializer("MyId", "MyTokenServerUrl")
             {
-                Clock = new MockClock(),
+                Clock = new MockClock(DateTime.UtcNow),
                 AccessMethod = new DummyAccessMethod(),
                 HttpClientFactory = new DummyHttpClientFactory(),
                 DefaultExponentialBackOffPolicy = ExponentialBackOffPolicy.Exception, // This is not the default
@@ -382,7 +382,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         public async Task FetchesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcTokenResponseSuccessMessageHandler();
             var initializer = new ServiceAccountCredential.Initializer("MyId", "http://will.be.ignored")
             {
@@ -410,7 +410,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         public async Task RefreshesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcTokenResponseSuccessMessageHandler();
             var initializer = new ServiceAccountCredential.Initializer("MyId", "http://will.be.ignored")
             {
@@ -436,7 +436,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         public async Task FetchesOidcToken_CorrectPayloadSent()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
-            var clock = new MockClock { UtcNow = new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));
             var messageHandler = new OidcTokenResponseSuccessMessageHandler();
             var initializer = new ServiceAccountCredential.Initializer("MyId", "http://will.be.ignored")
             {

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/TokenRefreshManagerTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/TokenRefreshManagerTests.cs
@@ -36,7 +36,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         {
             // Test multiple refreshes concurrently and sequentially,
             // where all refreshes return the same token.
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshFnCount = 0;
             TaskCompletionSource<int> delayTask = null;
@@ -81,7 +81,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         {
             // Test multiple refreshes concurrently and sequentially,
             // where the sequential refreshes are after the previous token has completely expired.
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshFnCount = 0;
             TaskCompletionSource<int> delayTask = null;
@@ -129,7 +129,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         {
             // Test multiple refreshes concurrently and sequentially,
             // where the sequential refreshes are after the previous token has completely expired.
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             TaskCompletionSource<int> delayTask = null;
             TokenRefreshManager trm = null;
@@ -172,7 +172,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task ExpiredToken()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshFnCount = 0;
             string accessToken = null;
@@ -203,7 +203,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task CancelDuringRefresh()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshCalled = 0;
             int refreshCompleted = 0;
@@ -231,7 +231,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task RetriesTimeout_Sync()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshCallCount = 0;
             int refreshCompleted = 0;
@@ -255,7 +255,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task RetriesTimeout_Async()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshCallCount = 0;
             int refreshCompleted = 0;
@@ -280,7 +280,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task RetriesError_Sync()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshCallCount = 0;
             int refreshCompleted = 0;
@@ -300,7 +300,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public async Task RetriesError_Async()
         {
-            var clock = new MockClock { UtcNow = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var logger = new NullLogger();
             int refreshCallCount = 0;
             int refreshCompleted = 0;

--- a/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationOptionsTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationOptionsTests.cs
@@ -52,7 +52,7 @@ namespace Google.Apis.Auth.Tests
                 IssuedAtClockTolerance = TimeSpan.FromSeconds(5),
                 ExpiryClockTolerance = TimeSpan.FromSeconds(10),
                 CertificateCache = new FakeCertificateCache(),
-                Clock = new MockClock(),
+                Clock = new MockClock(DateTime.UtcNow),
                 TrustedAudiences = { "audience" },
                 TrustedIssuers = { "issuers" }
             };
@@ -79,7 +79,7 @@ namespace Google.Apis.Auth.Tests
                 IssuedAtClockTolerance = TimeSpan.FromSeconds(5),
                 ExpiryClockTolerance = TimeSpan.FromSeconds(10),
                 CertificateCache = new FakeCertificateCache(),
-                Clock = new MockClock(),
+                Clock = new MockClock(DateTime.UtcNow),
                 TrustedAudiences = { "audience" },
                 TrustedIssuers = { "issuers" }
             };
@@ -91,7 +91,7 @@ namespace Google.Apis.Auth.Tests
             options1.IssuedAtClockTolerance = TimeSpan.Zero;
             options1.ExpiryClockTolerance = TimeSpan.Zero;
             options1.CertificateCache = new FakeCertificateCache();
-            options1.Clock = new MockClock();
+            options1.Clock = new MockClock(DateTime.UtcNow);
             options1.TrustedAudiences.Add("another");
             options1.TrustedIssuers.Add("another");
 

--- a/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/SignedTokenVerificationTests.cs
@@ -28,7 +28,7 @@ namespace Google.Apis.Auth.Tests
         [Fact]
         public async Task CertificateCache_Caches()
         {
-            MockClock clock = new MockClock() { UtcNow = DateTime.UtcNow };
+            MockClock clock = new MockClock(DateTime.UtcNow);
 
             // The fake only fakes the fetching of the certificates from the web.
             // The rest of the code can't be mocked and that's what we are testing here.
@@ -46,7 +46,7 @@ namespace Google.Apis.Auth.Tests
         [Fact]
         public async Task CertificateCache_Refreshes()
         {
-            MockClock clock = new MockClock() { UtcNow = DateTime.UtcNow };
+            MockClock clock = new MockClock(DateTime.UtcNow);
             // The fake only fakes the fetching of the certificates from the web.
             // The rest of the code can't be mocked and that's what we are testing here.
             var certCache = new FakeCertificateCache(clock);
@@ -64,7 +64,7 @@ namespace Google.Apis.Auth.Tests
         [Fact]
         public async Task CertificateCache_ForceRefresh()
         {
-            MockClock clock = new MockClock() { UtcNow = DateTime.UtcNow };
+            MockClock clock = new MockClock(DateTime.UtcNow);
             // The fake only fakes the fetching of the certificates from the web.
             // The rest of the code can't be mocked and that's what we are testing here.
             var certCache = new FakeCertificateCache(clock);

--- a/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
@@ -1062,7 +1062,7 @@ namespace Google.Apis.Tests.Apis.Http
 
         private async Task<IList<string>> LogTest(ConfigurableMessageHandler.LogEventType logEvents, bool errorResponse = false)
         {
-            var clock = new MockClock { UtcNow = new DateTime(2017, 1, 2, 3, 4, 5, DateTimeKind.Utc) };
+            var clock = new MockClock(new DateTime(2017, 1, 2, 3, 4, 5, DateTimeKind.Utc));
             var logger = new MemoryLogger(LogLevel.All, clock: clock);
             HttpMessageHandler handler;
             if (errorResponse)

--- a/Src/Support/Google.Apis.Tests/Mocks/MockClock.cs
+++ b/Src/Support/Google.Apis.Tests/Mocks/MockClock.cs
@@ -28,8 +28,8 @@ namespace Google.Apis.Tests.Mocks
     {
         public DateTime Now
         {
-            get { return UtcNow.ToLocalTime(); }
-            set { UtcNow = value.ToUniversalTime(); }
+            get => throw new NotSupportedException("Our tests shouldn't use IClock.Now");
+            set => throw new NotSupportedException("Our tests shouldn't use IClock.Now");
         }
 
         private object _lock = new object();
@@ -51,6 +51,15 @@ namespace Google.Apis.Tests.Mocks
                     _utcNow = value;
                 }
             }
+        }
+
+        public MockClock(DateTime utcNow)
+        {
+            if (utcNow.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentException("The value should have a Kind of Utc", nameof(utcNow));
+            }
+            UtcNow = utcNow;
         }
     }
 }

--- a/Src/Support/IntegrationTests/StorageApiTests.cs
+++ b/Src/Support/IntegrationTests/StorageApiTests.cs
@@ -42,7 +42,7 @@ namespace IntegrationTests
                 HttpClientInitializer = Helper.GetServiceCredential().CreateScoped(StorageService.Scope.DevstorageFullControl),
                 ApplicationName = "IntegrationTest"
             });
-            var memLog = new MemoryLogger(LogLevel.All, clock: new MockClock());
+            var memLog = new MemoryLogger(LogLevel.All, clock: new MockClock(DateTime.UtcNow));
             client.HttpClient.MessageHandler.InstanceLogger = memLog;
             client.HttpClient.MessageHandler.LogEvents = ConfigurableMessageHandler.LogEventType.ResponseBody;
             var req = client.Buckets.List(Helper.GetProjectId()).Configure(req => req.PrettyPrint = true);


### PR DESCRIPTION
- Accept a DateTime on construction; most code set it immediately anyway
- Don't allow it to be constructed *without* an explicit initial time, so it's always clear what it will be
- Forbid use of the deprecated Now property