### PR TITLE
With quota project

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
@@ -20,7 +20,6 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,7 +35,7 @@ namespace Google.Apis.Auth.OAuth2
     /// https://cloud.google.com/compute/docs/authentication.
     /// </para>
     /// </summary>
-    public class ComputeCredential : ServiceCredential, IOidcTokenProvider
+    public class ComputeCredential : ServiceCredential, IOidcTokenProvider, IGoogleCredential
     {
         /// <summary>The metadata server url.</summary>
         public const string MetadataServerUrl = "http://169.254.169.254"; // IP address instead of name to avoid DNS resolution
@@ -90,6 +89,9 @@ namespace Google.Apis.Auth.OAuth2
             /// and OIDC token URL.</summary>
             public Initializer(string tokenUrl, string oidcTokenUrl)
                 : base(tokenUrl) => OidcTokenUrl = oidcTokenUrl;
+
+            internal Initializer(ComputeCredential other)
+                : base(other) => OidcTokenUrl = other.OidcTokenUrl;
         }
 
         /// <summary>Constructs a new Compute credential instance.</summary>
@@ -97,6 +99,10 @@ namespace Google.Apis.Auth.OAuth2
 
         /// <summary>Constructs a new Compute credential instance.</summary>
         public ComputeCredential(Initializer initializer) : base(initializer) => OidcTokenUrl = initializer.OidcTokenUrl;
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithQuotaProject(string quotaProject) =>
+            new ComputeCredential(new Initializer(this) { QuotaProject = quotaProject });
 
         #region ServiceCredential overrides
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
@@ -261,8 +261,11 @@ namespace Google.Apis.Auth.OAuth2
             {
                 throw new InvalidOperationException("JSON data does not represent a valid service account credential.");
             }
-            var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail);
-            initializer.ProjectId = credentialParameters.ProjectId;
+            var initializer = new ServiceAccountCredential.Initializer(credentialParameters.ClientEmail)
+            {
+                ProjectId = credentialParameters.ProjectId,
+                QuotaProject = credentialParameters.QuotaProject
+            };
             return new ServiceAccountCredential(initializer.FromPrivateKey(credentialParameters.PrivateKey));
         }
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/IGoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/IGoogleCredential.cs
@@ -1,0 +1,41 @@
+﻿/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Represents a Google credential. Defines functionality that
+    /// credential types that can be used as an underlying credential in <see cref="GoogleCredential"/>
+    /// should implement in contrast to <see cref="ICredential"/> that defines public functionality.
+    /// </summary>
+    internal interface IGoogleCredential : ICredential, ITokenAccessWithHeaders
+    {
+        /// <summary>
+        /// The ID of the project associated to this credential for the purposes of
+        /// quota calculation and billing. May be null.
+        /// </summary>
+        string QuotaProject { get; }
+
+        /// <summary>
+        /// Returns a new instance of the same type as this but with the
+        /// given quota project value.
+        /// </summary>
+        /// <param name="quotaProject">The quota project value for the new instance.</param>
+        /// <returns>A new instance with the same type as this but with <see cref="QuotaProject"/>
+        /// set to <paramref name="quotaProject"/>.</returns>
+        IGoogleCredential WithQuotaProject(string quotaProject);
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
@@ -54,7 +54,7 @@ namespace Google.Apis.Auth.OAuth2
     /// is used and when regular OAuth2 token is used.
     /// </para>
     /// </summary>
-    public class ServiceAccountCredential : ServiceCredential, IOidcTokenProvider
+    public class ServiceAccountCredential : ServiceCredential, IOidcTokenProvider, IGoogleCredential
     {
         private const string Sha256Oid = "2.16.840.1.101.3.4.2.1";
         /// <summary>An initializer class for the service account credential. </summary>
@@ -192,6 +192,10 @@ namespace Google.Apis.Auth.OAuth2
             }
             return result;
         }
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithQuotaProject(string quotaProject) =>
+            new ServiceAccountCredential(new Initializer(this) { QuotaProject = quotaProject });
 
         /// <summary>
         /// Requests a new token as specified in 


### PR DESCRIPTION
In preparation for having the credential be the source of truth for quota project client options.
Client builders (gRPC and Rest) can now use the credential as a proxy for setting the quota project and can fail if a quota project is set in combination with an already built credential.

I'm uncertain about the second commit though (I have a similar one for the gRPC side). Rigorously speaking it is necessary or else we might end up sending two quota projects. But it seems like a terrible hack, an awful place to fail, and it would be breaking for anyone setting the quota project through interceptors right now, althouhg that is highly unlikely because the backend is not doing much with it. I'm happy to split this PR in two if we want to think more about the second commit.