### PR TITLE
Makes AccessTokenWithHeaders more usable from outside its package.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/AccessTokenWithHeadersTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/AccessTokenWithHeadersTests.cs
@@ -22,9 +22,20 @@ namespace Google.Apis.Auth.Tests.OAuth2
     public class AccessTokenWithHeadersTests
     {
         [Fact]
+        public void AccessTokenWithHeaders_NullToken()
+        {
+            // This class is being used in GAX in cases where there are no
+            // tokens but there are headers.
+            var token = new AccessTokenWithHeaders.Builder().Build(null);
+
+            Assert.Null(token.AccessToken);
+            Assert.Empty(token.Headers);
+        }
+
+        [Fact]
         public void AccessTokenWithHeaders_NoQuotaProject()
         {
-            var token = new AccessTokenWithHeaders("FAKE_TOKEN");
+            var token = new AccessTokenWithHeaders.Builder().Build("FAKE_TOKEN");
 
             Assert.Equal("FAKE_TOKEN", token.AccessToken);
             Assert.Empty(token.Headers);
@@ -33,7 +44,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
         [Fact]
         public void AccessTokenWithHeaders_WithQuotaProject()
         {
-            var token = new AccessTokenWithHeaders("FAKE_TOKEN", "FAKE_QUOTA_PROJECT");
+            var token = new AccessTokenWithHeaders.Builder { QuotaProject = "FAKE_QUOTA_PROJECT" }.Build("FAKE_TOKEN");
 
             Assert.Equal("FAKE_TOKEN", token.AccessToken);
             Assert.Single(token.Headers);

--- a/Src/Support/Google.Apis.Auth/OAuth2/AccessTokenWithHeaders.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/AccessTokenWithHeaders.cs
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Util;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace Google.Apis.Auth.OAuth2
@@ -42,7 +44,7 @@ namespace Google.Apis.Auth.OAuth2
             Headers = headers ?? s_emptyHeaders;
         }
 
-        internal AccessTokenWithHeaders(string token, string quotaProject = null)
+        private AccessTokenWithHeaders(string token, string quotaProject = null)
             : this (token,
                   quotaProject == null ?
                   null :
@@ -66,12 +68,45 @@ namespace Google.Apis.Auth.OAuth2
         /// </summary>
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Headers { get; }
 
-        internal void AddHeaders(HttpRequestHeaders requestHeaders)
+        /// <summary>
+        ///  Adds the headers in this object to the given header collection.
+        /// </summary>
+        /// <param name="requestHeaders">The header collection to add the headers to.</param>
+        public void AddHeaders(HttpRequestHeaders requestHeaders)
         {
+            requestHeaders.ThrowIfNull(nameof(requestHeaders));
+
             foreach (var header in Headers)
             {
                 requestHeaders.Add(header.Key, header.Value);
             }
+        }
+
+        /// <summary>
+        ///  Adds the headers in this object to the given request.
+        /// </summary>
+        /// <param name="request">The request to add the headers to.</param>
+        public void AddHeaders(HttpRequestMessage request) => 
+            AddHeaders(request.ThrowIfNull(nameof(request)).Headers);
+
+        /// <summary>
+        /// Builder class for <see cref="AccessTokenWithHeaders"/> to simplify common scenarios.
+        /// </summary>
+        public class Builder
+        {
+            /// <summary>
+            /// The GCP project ID used for quota and billing purposes. May be null.
+            /// </summary>
+            public string QuotaProject { get; set; }
+
+            /// <summary>
+            /// Builds and instance of <see cref="AccessTokenWithHeaders"/> with the given
+            /// token and the value set on this builder.
+            /// </summary>
+            /// <param name="token">The token to build the <see cref="AccessTokenWithHeaders"/> for.</param>
+            /// <returns>An <see cref="AccessTokenWithHeaders"/>.</returns>
+            public AccessTokenWithHeaders Build(string token) =>
+                new AccessTokenWithHeaders(token, QuotaProject);
         }
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -210,14 +210,14 @@ namespace Google.Apis.Auth.OAuth2
 
             /// <inheritdoc />
             public Task<AccessTokenWithHeaders> GetAccessTokenWithHeadersForRequestAsync(string authUri = null, CancellationToken cancellationToken = default) =>
-                Task.FromResult(new AccessTokenWithHeaders(_accessToken, QuotaProject));
+                Task.FromResult(new AccessTokenWithHeaders.Builder { QuotaProject = QuotaProject }.Build(_accessToken));
 
             // Only method in IHttpExecuteInterceptor
             public Task InterceptAsync(HttpRequestMessage request, CancellationToken taskCancellationToken)
             {
-                var accessToken = new AccessTokenWithHeaders(_accessToken, QuotaProject);
+                var accessToken = new AccessTokenWithHeaders.Builder { QuotaProject = QuotaProject }.Build(_accessToken);
                 _accessMethod.Intercept(request, accessToken.AccessToken);
-                accessToken.AddHeaders(request.Headers);
+                accessToken.AddHeaders(request);
 
                 return Task.FromResult(true);
             }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -175,7 +175,7 @@ namespace Google.Apis.Auth.OAuth2
         {
             var accessToken = await GetAccessTokenWithHeadersForRequestAsync(request.RequestUri.AbsoluteUri, cancellationToken).ConfigureAwait(false);
             AccessMethod.Intercept(request, accessToken.AccessToken);
-            accessToken.AddHeaders(request.Headers);
+            accessToken.AddHeaders(request);
         }
 
         #endregion
@@ -225,7 +225,7 @@ namespace Google.Apis.Auth.OAuth2
         public async Task<AccessTokenWithHeaders> GetAccessTokenWithHeadersForRequestAsync(string authUri = null, CancellationToken cancellationToken = default)
         {
             string token = await GetAccessTokenForRequestAsync(authUri, cancellationToken).ConfigureAwait(false);
-            return new AccessTokenWithHeaders(token, QuotaProject);
+            return new AccessTokenWithHeaders.Builder { QuotaProject = QuotaProject }.Build(token);
         }
         #endregion
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
@@ -91,7 +91,7 @@ namespace Google.Apis.Auth.OAuth2
         {
             var accessToken = await GetAccessTokenWithHeadersForRequestAsync(request.RequestUri.AbsoluteUri, taskCancellationToken).ConfigureAwait(false);
             Flow.AccessMethod.Intercept(request, accessToken.AccessToken);
-            accessToken.AddHeaders(request.Headers);
+            accessToken.AddHeaders(request);
         }
 
         #endregion
@@ -133,7 +133,7 @@ namespace Google.Apis.Auth.OAuth2
         public async Task<AccessTokenWithHeaders> GetAccessTokenWithHeadersForRequestAsync(string authUri = null, CancellationToken cancellationToken = default)
         {
             string token = await GetAccessTokenForRequestAsync(authUri, cancellationToken).ConfigureAwait(false);
-            return new AccessTokenWithHeaders(token, QuotaProject);
+            return new AccessTokenWithHeaders.Builder { QuotaProject = QuotaProject }.Build(token);
         }
         #endregion
 


### PR DESCRIPTION
So it can be reused from GAX for supporting quota project as an extensible client option.