### PR TITLE
Make discovery-doc patcher a little more robust

### DIFF
--- a/Src/Tools/DiscoveryDocPatcher/Patcher.cs
+++ b/Src/Tools/DiscoveryDocPatcher/Patcher.cs
@@ -39,7 +39,13 @@ namespace DiscoveryDocPatcher
         {
             if (changed)
             {
-                File.Move(_path, _path + ".original");
+                var destFilename = _path + ".original";
+                try
+                {
+                    File.Delete(destFilename);
+                }
+                catch (FileNotFoundException) { }
+                File.Move(_path, destFilename);
                 string json = _json.ToString();
                 File.WriteAllText(_path, json);
             }


### PR DESCRIPTION
Required because `admin_directory_v1.json` no longer exists.
Making this change, rather than simply removing the relevant patch, just in case it re-appears at some point.