### PR TITLE
Improvements and fixes to LocalServerCodeReceiver.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/LimitedLocalhostHttpServerTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/LimitedLocalhostHttpServerTests.cs
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// LimitedLocalhostHttpServer only used in .NET Core.
-#if NETCOREAPP1_0 || NETCOREAPP1_1 || NETCOREAPP2_0
+// LimitedLocalhostHttpServer only used in .NET Core 1*
+#if NETCOREAPP1_0 || NETCOREAPP1_1
 
 using Google.Apis.Auth.OAuth2;
 using System;

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/LimitedLocalhostHttpServerTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/LimitedLocalhostHttpServerTests.cs
@@ -58,7 +58,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
             using (var client = new HttpClient())
             {
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                var url = string.Format(LocalServerCodeReceiver.CallbackUriTemplate127001, server.Port) + "?a=b&c=d";
+                var url = string.Format(LocalServerCodeReceiver.CallbackUriChooser.CallbackUriTemplate127001, server.Port) + "?a=b&c=d";
                 var responseMsgTask = client.GetAsync(url, cts.Token);
 
                 var queryParams = await server.GetQueryParamsAsync(cts.Token);
@@ -79,7 +79,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
             using (var client = new HttpClient())
             {
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                var url = string.Format(LocalServerCodeReceiver.CallbackUriTemplate127001, server.Port);
+                var url = string.Format(LocalServerCodeReceiver.CallbackUriChooser.CallbackUriTemplate127001, server.Port);
                 var responseMsgTask = client.GetAsync(url, cts.Token);
 
                 var queryParams = await server.GetQueryParamsAsync(cts.Token);
@@ -148,7 +148,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
             using (var client = new HttpClient())
             {
                 var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                var url = string.Format(LocalServerCodeReceiver.CallbackUriTemplate127001, server.Port);
+                var url = string.Format(LocalServerCodeReceiver.CallbackUriChooser.CallbackUriTemplate127001, server.Port);
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 // Adding a single header >64k causes the test to hang.
                 request.Headers.Add("X-Test1", new string('X', 35_000));

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/LocalServerCodeReceiverTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/LocalServerCodeReceiverTests.cs
@@ -1,0 +1,255 @@
+﻿/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Tests.Mocks;
+using System;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    public class LocalServerCodeReceiverTests
+    {
+        private const string CallbackUriTemplateLocalhost = "http://localhost:{0}/authorize/";
+        private const string CallbackUriTemplate127001 = "http://127.0.0.1:{0}/authorize/";
+
+        [Fact]
+        public void CallbackUri_PrefersLoopback()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            var uri = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            Assert.Equal(CallbackUriTemplate127001, uri);
+        }
+
+        [Fact]
+        public void CallbackUri_PrefersLoopback_SecondRequest()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+            chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            Assert.Equal(CallbackUriTemplate127001, uri2);
+        }
+
+        [Fact]
+        public void CallbackUri_LoopbackListenerFails()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            Func<string, bool> listenerFails = u => u == CallbackUriTemplate127001;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            var uri = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            Assert.Equal(CallbackUriTemplateLocalhost, uri);
+        }
+
+        [Fact]
+        public void CallbackUri_LoopbackTimesOut()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            // This one should be loopback.
+            var uri = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            // Move the clock so that loopback times out.
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            Assert.Equal(CallbackUriTemplateLocalhost, uri2);
+        }
+
+        [Fact]
+        public void CallbackUri_LoopbackReportedFailure()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            // This one should be loopback.
+            var uri = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            chooser.ReportFailure(CallbackUriTemplate127001);
+
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            Assert.Equal(CallbackUriTemplateLocalhost, uri2);
+        }
+
+        [Fact]
+        public void CallbackUri_LoopbackReportedSuccess()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            var uri = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            chooser.ReportSuccess(CallbackUriTemplate127001);
+
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            Assert.Equal(CallbackUriTemplate127001, uri2);
+
+            // Even after time out
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+
+            uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            Assert.Equal(CallbackUriTemplate127001, uri2);
+
+            // Even if a failure is reported, it succeeded at least once
+            // so the failure is transient.
+            chooser.ReportFailure(CallbackUriTemplate127001);
+
+            uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            Assert.Equal(CallbackUriTemplate127001, uri2);
+        }
+
+        [Fact]
+        public void CallbackUri_BothFail()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            // They should alternate based on the amount of reuse.
+            var uri1 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            chooser.ReportFailure(uri1);
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            chooser.ReportFailure(uri2);
+            var uri3 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            chooser.ReportFailure(uri3);
+            var uri4 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            chooser.ReportFailure(uri4);
+
+            Assert.Equal(CallbackUriTemplate127001, uri1);
+            Assert.Equal(CallbackUriTemplate127001, uri3);
+
+            Assert.Equal(CallbackUriTemplateLocalhost, uri2);
+            Assert.Equal(CallbackUriTemplateLocalhost, uri4);
+        }
+
+        [Fact]
+        public void CallbackUri_BothTimeout()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // All uris are good.
+            Func<string, bool> listenerFails = u => false;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            // They should alternate based on the amount of reuse.
+            var uri1 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+            var uri3 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+            var uri4 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+
+            Assert.Equal(CallbackUriTemplate127001, uri1);
+            Assert.Equal(CallbackUriTemplate127001, uri3);
+
+            Assert.Equal(CallbackUriTemplateLocalhost, uri2);
+            Assert.Equal(CallbackUriTemplateLocalhost, uri4);
+        }
+
+        [Fact]
+        public void CallbackUri_TimeoutPreferredForRetries()
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            Func<string, bool> listenerFails = u => u == CallbackUriTemplate127001;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            // Loopback IP failed so this one is localhost.
+            var uri1 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            // Make localhost time out.
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+            // This one should still be localhost, which was timed out
+            // vs loopback which was failed. And they have the same amount of reuses.
+            var uri2 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+            // Make it time out again.
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+            // And now this should be loopback, it had less reuse.
+            var uri3 = chooser.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            Assert.Equal(CallbackUriTemplateLocalhost, uri1);
+            Assert.Equal(CallbackUriTemplateLocalhost, uri2);
+
+            Assert.Equal(CallbackUriTemplate127001, uri3);
+        }
+
+        [Theory]
+        [InlineData(LocalServerCodeReceiver.CallbackUriChooserStrategy.ForceLoopbackIp, CallbackUriTemplate127001)]
+        [InlineData(LocalServerCodeReceiver.CallbackUriChooserStrategy.ForceLocalhost, CallbackUriTemplateLocalhost)]
+        public void CallbackUri_ForcesStrategy(LocalServerCodeReceiver.CallbackUriChooserStrategy strategy, string expectedTemplate)
+        {
+            MockClock clock = new MockClock(DateTime.UtcNow);
+            TimeSpan timeout = TimeSpan.FromMinutes(1);
+            // Make the template that should be forced, fail on the listener check.
+            Func<string, bool> listenerFails = u => u == expectedTemplate;
+
+            var chooser = new LocalServerCodeReceiver.CallbackUriChooser(clock, timeout, listenerFails);
+
+            var uri1 = chooser.GetUriTemplate(strategy);
+
+            // Even after time out
+            clock.UtcNow = clock.UtcNow.AddMinutes(2);
+
+            var uri2 = chooser.GetUriTemplate(strategy);
+
+            // Even if a failure is reported, it succeeded at least once
+            // so the failure is transient.
+            chooser.ReportFailure(expectedTemplate);
+
+            var uri3 = chooser.GetUriTemplate(strategy);
+
+            Assert.Equal(expectedTemplate, uri1);
+            Assert.Equal(expectedTemplate, uri2);
+            Assert.Equal(expectedTemplate, uri3);
+        }
+    }
+}

--- a/Src/Support/IntegrationTests/LocalServerCodeReceiverTests.cs
+++ b/Src/Support/IntegrationTests/LocalServerCodeReceiverTests.cs
@@ -1,0 +1,50 @@
+﻿/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Xunit;
+
+namespace IntegrationTests
+{
+    public class LocalServerCodeReceiverTests
+    {
+        private const string CallbackUriTemplateLocalhost = "http://localhost:{0}/authorize/";
+        private const string CallbackUriTemplate127001 = "http://127.0.0.1:{0}/authorize/";
+
+        [Fact]
+        public void CallbackUri()
+        {
+            string uri = LocalServerCodeReceiver.CallbackUriChooser.Default.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            // We don't know on which platform we are running, but let's check we get one of the
+            // valid templates. This is more of a sanity check test.
+            Assert.Contains(uri, new string[] { CallbackUriTemplate127001, CallbackUriTemplateLocalhost });
+        }
+
+        [Fact]
+        public void CallbackUri_SecondRequest_SuccessReported()
+        {
+            string firstUri = LocalServerCodeReceiver.CallbackUriChooser.Default.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            // Report success, which means the template above worked, so it will be used for all
+            // subsequent requests.
+            LocalServerCodeReceiver.CallbackUriChooser.Default.ReportSuccess(firstUri);
+            string uriAfterSuccess = LocalServerCodeReceiver.CallbackUriChooser.Default.GetUriTemplate(LocalServerCodeReceiver.CallbackUriChooserStrategy.Default);
+
+            Assert.Equal(firstUri, uriAfterSuccess);
+        }
+    }
+}


### PR DESCRIPTION
As always, one commit at a time is best.

  * One of the tests on the first commit shows a couple of issues with the existing implementation and why our current tests didn't catch #1596 at least on affected environments.
  * The first 3 commits fix those issues, after those, our integration tests catch #1596 
  * The 4th commit makes the choosing of the local callback URL configurable as agreed offline.
  * The 5th commit fixes #1596