### PR TITLE
Remove mis-placed comments from XML docs

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/_parameter.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/_parameter.tmpl
@@ -1,7 +1,4 @@
-{% noblank %}{% doc_comment_if parameter.description %}
-{% if parameter.default %}{% eol %}/// [default: {{ parameter.default }}]{% endif %}
-{% if parameter.minimum %}{% eol %}/// [minimum: {{ parameter.minimum }}]{% endif %}
-{% if parameter.maximum %}{% eol %}/// [maximum: {{ parameter.maximum }}]{% endif %} {% endnoblank %}
+{% noblank %}{% doc_comment_if parameter.description %}{% endnoblank %}
 [Google.Apis.Util.RequestParameterAttribute({% literal parameter.wireName %}, Google.Apis.Util.RequestParameterType.{% camel_case parameter.location %})]
 {% noeol %}
 public virtual

--- a/Src/Generated/Google.Apis.AbusiveExperienceReport.v1/Google.Apis.AbusiveExperienceReport.v1.cs
+++ b/Src/Generated/Google.Apis.AbusiveExperienceReport.v1/Google.Apis.AbusiveExperienceReport.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.AbusiveExperienceReport.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.AbusiveExperienceReport.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Acceleratedmobilepageurl.v1/Google.Apis.Acceleratedmobilepageurl.v1.cs
+++ b/Src/Generated/Google.Apis.Acceleratedmobilepageurl.v1/Google.Apis.Acceleratedmobilepageurl.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.Acceleratedmobilepageurl.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.Acceleratedmobilepageurl.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AccessApproval.v1/Google.Apis.AccessApproval.v1.cs
+++ b/Src/Generated/Google.Apis.AccessApproval.v1/Google.Apis.AccessApproval.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.AccessApproval.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.AccessApproval.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AccessContextManager.v1/Google.Apis.AccessContextManager.v1.cs
+++ b/Src/Generated/Google.Apis.AccessContextManager.v1/Google.Apis.AccessContextManager.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.AccessContextManager.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.AccessContextManager.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AccessContextManager.v1beta/Google.Apis.AccessContextManager.v1beta.cs
+++ b/Src/Generated/Google.Apis.AccessContextManager.v1beta/Google.Apis.AccessContextManager.v1beta.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.AccessContextManager.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.AccessContextManager.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AdExchangeBuyer.v1_2/Google.Apis.AdExchangeBuyer.v1_2.cs
+++ b/Src/Generated/Google.Apis.AdExchangeBuyer.v1_2/Google.Apis.AdExchangeBuyer.v1_2.cs
@@ -94,7 +94,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_2
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -120,7 +119,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -576,8 +574,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_2
 
             /// <summary>Maximum number of entries returned on one result page. If not set, the default is 100.
             /// Optional.</summary>
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.AdExchangeBuyer.v1_3/Google.Apis.AdExchangeBuyer.v1_3.cs
+++ b/Src/Generated/Google.Apis.AdExchangeBuyer.v1_3/Google.Apis.AdExchangeBuyer.v1_3.cs
@@ -114,7 +114,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_3
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -140,7 +139,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -946,8 +944,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_3
 
             /// <summary>Maximum number of entries returned on one result page. If not set, the default is 100.
             /// Optional.</summary>
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1198,8 +1194,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_3
 
             /// <summary>Maximum number of entries returned on one result page. If not set, the default is 100.
             /// Optional.</summary>
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.AdExchangeBuyer.v1_4/Google.Apis.AdExchangeBuyer.v1_4.cs
+++ b/Src/Generated/Google.Apis.AdExchangeBuyer.v1_4/Google.Apis.AdExchangeBuyer.v1_4.cs
@@ -134,7 +134,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_4
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -160,7 +159,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1096,8 +1094,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_4
 
             /// <summary>Maximum number of entries returned on one result page. If not set, the default is 100.
             /// Optional.</summary>
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1885,8 +1881,6 @@ namespace Google.Apis.AdExchangeBuyer.v1_4
 
             /// <summary>Maximum number of entries returned on one result page. If not set, the default is 100.
             /// Optional.</summary>
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.AdExchangeBuyerII.v2beta1/Google.Apis.AdExchangeBuyerII.v2beta1.cs
+++ b/Src/Generated/Google.Apis.AdExchangeBuyerII.v2beta1/Google.Apis.AdExchangeBuyerII.v2beta1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.AdExchangeBuyerII.v2beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.AdExchangeBuyerII.v2beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AdExperienceReport.v1/Google.Apis.AdExperienceReport.v1.cs
+++ b/Src/Generated/Google.Apis.AdExperienceReport.v1/Google.Apis.AdExperienceReport.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.AdExperienceReport.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.AdExperienceReport.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AdMob.v1/Google.Apis.AdMob.v1.cs
+++ b/Src/Generated/Google.Apis.AdMob.v1/Google.Apis.AdMob.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.AdMob.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.AdMob.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AdSense.v1_4/Google.Apis.AdSense.v1_4.cs
+++ b/Src/Generated/Google.Apis.AdSense.v1_4/Google.Apis.AdSense.v1_4.cs
@@ -132,7 +132,6 @@ namespace Google.Apis.AdSense.v1_4
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.AdSense.v1_4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -378,8 +376,6 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual string AccountId { get; private set; }
 
                 /// <summary>The maximum number of ad clients to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -511,8 +507,6 @@ namespace Google.Apis.AdSense.v1_4
 
                     /// <summary>The maximum number of custom channels to include in the response, used for
                     /// paging.</summary>
-                    /// [minimum: 0]
-                    /// [maximum: 10000]
                     [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -785,8 +779,6 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual System.Nullable<bool> IncludeInactive { get; set; }
 
                 /// <summary>The maximum number of ad units to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1091,8 +1083,6 @@ namespace Google.Apis.AdSense.v1_4
                     public virtual System.Nullable<bool> IncludeInactive { get; set; }
 
                     /// <summary>The maximum number of ad units to include in the response, used for paging.</summary>
-                    /// [minimum: 0]
-                    /// [maximum: 10000]
                     [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1292,8 +1282,6 @@ namespace Google.Apis.AdSense.v1_4
 
                 /// <summary>The maximum number of custom channels to include in the response, used for
                 /// paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1503,14 +1491,10 @@ namespace Google.Apis.AdSense.v1_4
                     public virtual string Locale { get; set; }
 
                     /// <summary>The maximum number of rows of report data to return.</summary>
-                    /// [minimum: 0]
-                    /// [maximum: 50000]
                     [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<int> MaxResults { get; set; }
 
                     /// <summary>Index of the first row of report data to return.</summary>
-                    /// [minimum: 0]
-                    /// [maximum: 5000]
                     [Google.Apis.Util.RequestParameterAttribute("startIndex", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -1603,8 +1587,6 @@ namespace Google.Apis.AdSense.v1_4
 
                     /// <summary>The maximum number of saved reports to include in the response, used for
                     /// paging.</summary>
-                    /// [minimum: 0]
-                    /// [maximum: 100]
                     [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1719,8 +1701,6 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual string Locale { get; set; }
 
                 /// <summary>The maximum number of rows of report data to return.</summary>
-                /// [minimum: 0]
-                /// [maximum: 50000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1735,8 +1715,6 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual Google.Apis.Util.Repeatable<string> Sort { get; set; }
 
                 /// <summary>Index of the first row of report data to return.</summary>
-                /// [minimum: 0]
-                /// [maximum: 5000]
                 [Google.Apis.Util.RequestParameterAttribute("startIndex", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -2035,8 +2013,6 @@ namespace Google.Apis.AdSense.v1_4
 
                 /// <summary>The maximum number of saved ad styles to include in the response, used for
                 /// paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2141,8 +2117,6 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual string AdClientId { get; private set; }
 
                 /// <summary>The maximum number of URL channels to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2289,8 +2263,6 @@ namespace Google.Apis.AdSense.v1_4
 
 
             /// <summary>The maximum number of accounts to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2371,8 +2343,6 @@ namespace Google.Apis.AdSense.v1_4
 
 
             /// <summary>The maximum number of ad clients to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2486,8 +2456,6 @@ namespace Google.Apis.AdSense.v1_4
 
                 /// <summary>The maximum number of custom channels to include in the response, used for
                 /// paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2714,8 +2682,6 @@ namespace Google.Apis.AdSense.v1_4
             public virtual System.Nullable<bool> IncludeInactive { get; set; }
 
             /// <summary>The maximum number of ad units to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2969,8 +2935,6 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual System.Nullable<bool> IncludeInactive { get; set; }
 
                 /// <summary>The maximum number of ad units to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3135,8 +3099,6 @@ namespace Google.Apis.AdSense.v1_4
             public virtual string AdClientId { get; private set; }
 
             /// <summary>The maximum number of custom channels to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3438,14 +3400,10 @@ namespace Google.Apis.AdSense.v1_4
                 public virtual string Locale { get; set; }
 
                 /// <summary>The maximum number of rows of report data to return.</summary>
-                /// [minimum: 0]
-                /// [maximum: 50000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
                 /// <summary>Index of the first row of report data to return.</summary>
-                /// [minimum: 0]
-                /// [maximum: 5000]
                 [Google.Apis.Util.RequestParameterAttribute("startIndex", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -3522,8 +3480,6 @@ namespace Google.Apis.AdSense.v1_4
 
 
                 /// <summary>The maximum number of saved reports to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 100]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3626,8 +3582,6 @@ namespace Google.Apis.AdSense.v1_4
             public virtual string Locale { get; set; }
 
             /// <summary>The maximum number of rows of report data to return.</summary>
-            /// [minimum: 0]
-            /// [maximum: 50000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3642,8 +3596,6 @@ namespace Google.Apis.AdSense.v1_4
             public virtual Google.Apis.Util.Repeatable<string> Sort { get; set; }
 
             /// <summary>Index of the first row of report data to return.</summary>
-            /// [minimum: 0]
-            /// [maximum: 5000]
             [Google.Apis.Util.RequestParameterAttribute("startIndex", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -3917,8 +3869,6 @@ namespace Google.Apis.AdSense.v1_4
 
 
             /// <summary>The maximum number of saved ad styles to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4005,8 +3955,6 @@ namespace Google.Apis.AdSense.v1_4
             public virtual string AdClientId { get; private set; }
 
             /// <summary>The maximum number of URL channels to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.AdSenseHost.v4_1/Google.Apis.AdSenseHost.v4_1.cs
+++ b/Src/Generated/Google.Apis.AdSenseHost.v4_1/Google.Apis.AdSenseHost.v4_1.cs
@@ -110,7 +110,6 @@ namespace Google.Apis.AdSenseHost.v4_1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -139,7 +138,6 @@ namespace Google.Apis.AdSenseHost.v4_1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -353,8 +351,6 @@ namespace Google.Apis.AdSenseHost.v4_1
                 public virtual string AccountId { get; private set; }
 
                 /// <summary>The maximum number of ad clients to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -797,8 +793,6 @@ namespace Google.Apis.AdSenseHost.v4_1
                 public virtual System.Nullable<bool> IncludeInactive { get; set; }
 
                 /// <summary>The maximum number of ad units to include in the response, used for paging.</summary>
-                /// [minimum: 0]
-                /// [maximum: 10000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1110,8 +1104,6 @@ namespace Google.Apis.AdSenseHost.v4_1
                 public virtual string Locale { get; set; }
 
                 /// <summary>The maximum number of rows of report data to return.</summary>
-                /// [minimum: 0]
-                /// [maximum: 50000]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1126,8 +1118,6 @@ namespace Google.Apis.AdSenseHost.v4_1
                 public virtual Google.Apis.Util.Repeatable<string> Sort { get; set; }
 
                 /// <summary>Index of the first row of report data to return.</summary>
-                /// [minimum: 0]
-                /// [maximum: 5000]
                 [Google.Apis.Util.RequestParameterAttribute("startIndex", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> StartIndex { get; set; }
 
@@ -1429,8 +1419,6 @@ namespace Google.Apis.AdSenseHost.v4_1
 
 
             /// <summary>The maximum number of ad clients to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1905,8 +1893,6 @@ namespace Google.Apis.AdSenseHost.v4_1
             public virtual string AdClientId { get; private set; }
 
             /// <summary>The maximum number of custom channels to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2160,8 +2146,6 @@ namespace Google.Apis.AdSenseHost.v4_1
             public virtual string Locale { get; set; }
 
             /// <summary>The maximum number of rows of report data to return.</summary>
-            /// [minimum: 0]
-            /// [maximum: 50000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2176,8 +2160,6 @@ namespace Google.Apis.AdSenseHost.v4_1
             public virtual Google.Apis.Util.Repeatable<string> Sort { get; set; }
 
             /// <summary>Index of the first row of report data to return.</summary>
-            /// [minimum: 0]
-            /// [maximum: 5000]
             [Google.Apis.Util.RequestParameterAttribute("startIndex", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> StartIndex { get; set; }
 
@@ -2448,8 +2430,6 @@ namespace Google.Apis.AdSenseHost.v4_1
             public virtual string AdClientId { get; private set; }
 
             /// <summary>The maximum number of URL channels to include in the response, used for paging.</summary>
-            /// [minimum: 0]
-            /// [maximum: 10000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.Admin.DataTransfer.datatransfer_v1/Google.Apis.Admin.DataTransfer.datatransfer_v1.cs
+++ b/Src/Generated/Google.Apis.Admin.DataTransfer.datatransfer_v1/Google.Apis.Admin.DataTransfer.datatransfer_v1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.Admin.DataTransfer.datatransfer_v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.Admin.DataTransfer.datatransfer_v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -368,8 +366,6 @@ namespace Google.Apis.Admin.DataTransfer.datatransfer_v1
             public virtual string CustomerId { get; set; }
 
             /// <summary>Maximum number of results to return. Default is 100.</summary>
-            /// [minimum: 1]
-            /// [maximum: 500]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -559,8 +555,6 @@ namespace Google.Apis.Admin.DataTransfer.datatransfer_v1
             public virtual string CustomerId { get; set; }
 
             /// <summary>Maximum number of results to return. Default is 100.</summary>
-            /// [minimum: 1]
-            /// [maximum: 500]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.Admin.Directory.directory_v1/Google.Apis.Admin.Directory.directory_v1.cs
+++ b/Src/Generated/Google.Apis.Admin.Directory.directory_v1/Google.Apis.Admin.Directory.directory_v1.cs
@@ -333,7 +333,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -369,7 +368,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -970,8 +968,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string CustomerId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2536,8 +2532,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string Domain { get; set; }
 
             /// <summary>Maximum number of results to return. Max allowed value is 200.</summary>
-            /// [default: 200]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3109,8 +3103,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual System.Nullable<bool> IncludeDerivedMembership { get; set; }
 
             /// <summary>Maximum number of results to return. Max allowed value is 200.</summary>
-            /// [default: 200]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3615,9 +3607,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string CustomerId { get; private set; }
 
             /// <summary>Maximum number of results to return. Max allowed value is 100.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4506,7 +4495,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
                 public virtual string Customer { get; private set; }
 
                 /// <summary>Source from which Building.coordinates are derived.</summary>
-                /// [default: SOURCE_UNSPECIFIED]
                 [Google.Apis.Util.RequestParameterAttribute("coordinatesSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<CoordinatesSourceEnum> CoordinatesSource { get; set; }
 
@@ -4596,8 +4584,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
                 public virtual string Customer { get; private set; }
 
                 /// <summary>Maximum number of results to return.</summary>
-                /// [minimum: 1]
-                /// [maximum: 500]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4686,7 +4672,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
                 public virtual string BuildingId { get; private set; }
 
                 /// <summary>Source from which Building.coordinates are derived.</summary>
-                /// [default: SOURCE_UNSPECIFIED]
                 [Google.Apis.Util.RequestParameterAttribute("coordinatesSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<CoordinatesSourceEnum> CoordinatesSource { get; set; }
 
@@ -4794,7 +4779,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
                 public virtual string BuildingId { get; private set; }
 
                 /// <summary>Source from which Building.coordinates are derived.</summary>
-                /// [default: SOURCE_UNSPECIFIED]
                 [Google.Apis.Util.RequestParameterAttribute("coordinatesSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<CoordinatesSourceEnum> CoordinatesSource { get; set; }
 
@@ -5111,8 +5095,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
                 public virtual string Customer { get; private set; }
 
                 /// <summary>Maximum number of results to return.</summary>
-                /// [minimum: 1]
-                /// [maximum: 500]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -5604,8 +5586,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
                 public virtual string Customer { get; private set; }
 
                 /// <summary>Maximum number of results to return.</summary>
-                /// [minimum: 1]
-                /// [maximum: 500]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -6125,8 +6105,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string Customer { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [minimum: 1]
-            /// [maximum: 200]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -6442,8 +6420,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string Customer { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -7885,7 +7861,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string CustomFieldMask { get; set; }
 
             /// <summary>What subset of fields to fetch for this user.</summary>
-            /// [default: basic]
             [Google.Apis.Util.RequestParameterAttribute("projection", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ProjectionEnum> Projection { get; set; }
 
@@ -7906,7 +7881,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             }
 
             /// <summary>Whether to fetch the ADMIN_VIEW or DOMAIN_PUBLIC view of the user.</summary>
-            /// [default: admin_view]
             [Google.Apis.Util.RequestParameterAttribute("viewType", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ViewTypeEnum> ViewType { get; set; }
 
@@ -8055,9 +8029,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string Domain { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 500]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8086,7 +8057,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             public virtual string PageToken { get; set; }
 
             /// <summary>What subset of fields to fetch for this user.</summary>
-            /// [default: basic]
             [Google.Apis.Util.RequestParameterAttribute("projection", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ProjectionEnum> Projection { get; set; }
 
@@ -8133,7 +8103,6 @@ namespace Google.Apis.Admin.Directory.directory_v1
             }
 
             /// <summary>Whether to fetch the ADMIN_VIEW or DOMAIN_PUBLIC view of the user.</summary>
-            /// [default: admin_view]
             [Google.Apis.Util.RequestParameterAttribute("viewType", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ViewTypeEnum> ViewType { get; set; }
 

--- a/Src/Generated/Google.Apis.Admin.Reports.reports_v1/Google.Apis.Admin.Reports.reports_v1.cs
+++ b/Src/Generated/Google.Apis.Admin.Reports.reports_v1/Google.Apis.Admin.Reports.reports_v1.cs
@@ -131,7 +131,6 @@ namespace Google.Apis.Admin.Reports.reports_v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -167,7 +166,6 @@ namespace Google.Apis.Admin.Reports.reports_v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -493,9 +491,6 @@ namespace Google.Apis.Admin.Reports.reports_v1
             /// request sets maxResults=1 and the report has two activities, the report has two pages. The response's
             /// nextPageToken property has the token to the second page. The maxResults query string is optional in the
             /// request. The default value is 1000.</summary>
-            /// [default: 1000]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -820,9 +815,6 @@ namespace Google.Apis.Admin.Reports.reports_v1
             /// request sets maxResults=1 and the report has two activities, the report has two pages. The response's
             /// nextPageToken property has the token to the second page. The maxResults query string is optional in the
             /// request. The default value is 1000.</summary>
-            /// [default: 1000]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1260,9 +1252,6 @@ namespace Google.Apis.Admin.Reports.reports_v1
             /// <summary>Determines how many activity records are shown on each response page. For example, if the
             /// request sets maxResults=1 and the report has two activities, the report has two pages. The response's
             /// nextPageToken property has the token to the second page.</summary>
-            /// [default: 1000]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1453,9 +1442,6 @@ namespace Google.Apis.Admin.Reports.reports_v1
             /// request sets maxResults=1 and the report has two activities, the report has two pages. The response's
             /// nextPageToken property has the token to the second page. The maxResults query string is
             /// optional.</summary>
-            /// [default: 1000]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.AlertCenter.v1beta1/Google.Apis.AlertCenter.v1beta1.cs
+++ b/Src/Generated/Google.Apis.AlertCenter.v1beta1/Google.Apis.AlertCenter.v1beta1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.AlertCenter.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.AlertCenter.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Analytics.v3/Google.Apis.Analytics.v3.cs
+++ b/Src/Generated/Google.Apis.Analytics.v3/Google.Apis.Analytics.v3.cs
@@ -142,7 +142,6 @@ namespace Google.Apis.Analytics.v3
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -168,7 +167,6 @@ namespace Google.Apis.Analytics.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: false]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -406,7 +404,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -659,7 +656,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -997,7 +993,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -1212,7 +1207,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first account-user link to retrieve. Use this parameter as a pagination
                 /// mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -1379,7 +1373,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first account to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -1533,13 +1526,11 @@ namespace Google.Apis.Analytics.v3
                 public virtual string WebPropertyId { get; private set; }
 
                 /// <summary>The maximum number of custom data sources to include in this response.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("max-results", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
                 /// <summary>A 1-based index of the first custom data source to retrieve. Use this parameter as a
                 /// pagination mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -1811,7 +1802,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -1911,7 +1901,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>Force the update and ignore any warnings related to the custom dimension being linked to a
                 /// custom data source / data set.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("ignoreCustomDataSourceLinks", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IgnoreCustomDataSourceLinks { get; set; }
 
@@ -2017,7 +2006,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>Force the update and ignore any warnings related to the custom dimension being linked to a
                 /// custom data source / data set.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("ignoreCustomDataSourceLinks", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IgnoreCustomDataSourceLinks { get; set; }
 
@@ -2295,7 +2283,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -2395,7 +2382,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>Force the update and ignore any warnings related to the custom metric being linked to a
                 /// custom data source / data set.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("ignoreCustomDataSourceLinks", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IgnoreCustomDataSourceLinks { get; set; }
 
@@ -2501,7 +2487,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>Force the update and ignore any warnings related to the custom metric being linked to a
                 /// custom data source / data set.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("ignoreCustomDataSourceLinks", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IgnoreCustomDataSourceLinks { get; set; }
 
@@ -2916,7 +2901,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first experiment to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -3437,7 +3421,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -3893,7 +3876,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first goal to retrieve. Use this parameter as a pagination mechanism along
                 /// with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -4528,7 +4510,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -5065,7 +5046,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first profile-user link to retrieve. Use this parameter as a pagination
                 /// mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -5539,7 +5519,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -6076,12 +6055,10 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
 
-                /// [default: all]
                 [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual string Type { get; set; }
 
@@ -6373,7 +6350,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first segment to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -6769,7 +6745,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first unsampled report to retrieve. Use this parameter as a pagination
                 /// mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -7083,13 +7058,11 @@ namespace Google.Apis.Analytics.v3
                 public virtual string CustomDataSourceId { get; private set; }
 
                 /// <summary>The maximum number of uploads to include in this response.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("max-results", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
                 /// <summary>A 1-based index of the first upload to retrieve. Use this parameter as a pagination
                 /// mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -7276,7 +7249,6 @@ namespace Google.Apis.Analytics.v3
             {
 
                 /// <summary>Data format for the response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -7302,7 +7274,6 @@ namespace Google.Apis.Analytics.v3
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -7654,7 +7625,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first webProperty-Google Ads link to retrieve. Use this parameter as a
                 /// pagination mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -8075,7 +8045,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first entity to retrieve. Use this parameter as a pagination mechanism
                 /// along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 
@@ -8490,7 +8459,6 @@ namespace Google.Apis.Analytics.v3
 
                 /// <summary>An index of the first webProperty-user link to retrieve. Use this parameter as a pagination
                 /// mechanism along with the max-results parameter.</summary>
-                /// [minimum: 1]
                 [Google.Apis.Util.RequestParameterAttribute("start-index", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> StartIndex { get; set; }
 

--- a/Src/Generated/Google.Apis.AnalyticsReporting.v4/Google.Apis.AnalyticsReporting.v4.cs
+++ b/Src/Generated/Google.Apis.AnalyticsReporting.v4/Google.Apis.AnalyticsReporting.v4.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.AnalyticsReporting.v4
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.AnalyticsReporting.v4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AndroidEnterprise.v1/Google.Apis.AndroidEnterprise.v1.cs
+++ b/Src/Generated/Google.Apis.AndroidEnterprise.v1/Google.Apis.AndroidEnterprise.v1.cs
@@ -169,7 +169,6 @@ namespace Google.Apis.AndroidEnterprise.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -205,7 +204,6 @@ namespace Google.Apis.AndroidEnterprise.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AndroidManagement.v1/Google.Apis.AndroidManagement.v1.cs
+++ b/Src/Generated/Google.Apis.AndroidManagement.v1/Google.Apis.AndroidManagement.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.AndroidManagement.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.AndroidManagement.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AndroidProvisioningPartner.v1/Google.Apis.AndroidProvisioningPartner.v1.cs
+++ b/Src/Generated/Google.Apis.AndroidProvisioningPartner.v1/Google.Apis.AndroidProvisioningPartner.v1.cs
@@ -103,7 +103,6 @@ namespace Google.Apis.AndroidProvisioningPartner.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -139,7 +138,6 @@ namespace Google.Apis.AndroidProvisioningPartner.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.AndroidPublisher.v3/Google.Apis.AndroidPublisher.v3.cs
+++ b/Src/Generated/Google.Apis.AndroidPublisher.v3/Google.Apis.AndroidPublisher.v3.cs
@@ -133,7 +133,6 @@ namespace Google.Apis.AndroidPublisher.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -169,7 +168,6 @@ namespace Google.Apis.AndroidPublisher.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -602,7 +600,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -638,7 +635,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -921,7 +917,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -957,7 +952,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1205,7 +1199,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -1241,7 +1234,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2109,7 +2101,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -2145,7 +2136,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2862,7 +2852,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -2898,7 +2887,6 @@ namespace Google.Apis.AndroidPublisher.v3
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -5085,7 +5073,6 @@ namespace Google.Apis.AndroidPublisher.v3
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -5121,7 +5108,6 @@ namespace Google.Apis.AndroidPublisher.v3
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -5280,7 +5266,6 @@ namespace Google.Apis.AndroidPublisher.v3
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -5316,7 +5301,6 @@ namespace Google.Apis.AndroidPublisher.v3
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Appengine.v1/Google.Apis.Appengine.v1.cs
+++ b/Src/Generated/Google.Apis.Appengine.v1/Google.Apis.Appengine.v1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.Appengine.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.Appengine.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Appengine.v1alpha/Google.Apis.Appengine.v1alpha.cs
+++ b/Src/Generated/Google.Apis.Appengine.v1alpha/Google.Apis.Appengine.v1alpha.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.Appengine.v1alpha
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.Appengine.v1alpha
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Appengine.v1beta/Google.Apis.Appengine.v1beta.cs
+++ b/Src/Generated/Google.Apis.Appengine.v1beta/Google.Apis.Appengine.v1beta.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.Appengine.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.Appengine.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Appsactivity.v1/Google.Apis.Appsactivity.v1.cs
+++ b/Src/Generated/Google.Apis.Appsactivity.v1/Google.Apis.Appsactivity.v1.cs
@@ -90,7 +90,6 @@ namespace Google.Apis.Appsactivity.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -116,7 +115,6 @@ namespace Google.Apis.Appsactivity.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -249,7 +247,6 @@ namespace Google.Apis.Appsactivity.v1
 
             /// <summary>Indicates the strategy to use when grouping singleEvents items in the associated combinedEvent
             /// object.</summary>
-            /// [default: driveUi]
             [Google.Apis.Util.RequestParameterAttribute("groupingStrategy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<GroupingStrategyEnum> GroupingStrategy { get; set; }
 
@@ -265,7 +262,6 @@ namespace Google.Apis.Appsactivity.v1
 
             /// <summary>The maximum number of events to return on a page. The response includes a continuation token if
             /// there are more events.</summary>
-            /// [default: 50]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -280,7 +276,6 @@ namespace Google.Apis.Appsactivity.v1
 
             /// <summary>The ID used for ACL checks (does not filter the resulting event list by the assigned value).
             /// Use the special value me to indicate the currently authenticated user.</summary>
-            /// [default: me]
             [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string UserId { get; set; }
 

--- a/Src/Generated/Google.Apis.ArtifactRegistry.v1beta1/Google.Apis.ArtifactRegistry.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ArtifactRegistry.v1beta1/Google.Apis.ArtifactRegistry.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.ArtifactRegistry.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.ArtifactRegistry.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BIGQUERYDATATRANSFER.v1/Google.Apis.BIGQUERYDATATRANSFER.v1.cs
+++ b/Src/Generated/Google.Apis.BIGQUERYDATATRANSFER.v1/Google.Apis.BIGQUERYDATATRANSFER.v1.cs
@@ -127,7 +127,6 @@ namespace Google.Apis.BigQueryDataTransfer.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -163,7 +162,6 @@ namespace Google.Apis.BigQueryDataTransfer.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BigQueryConnectionService.v1beta1/Google.Apis.BigQueryConnectionService.v1beta1.cs
+++ b/Src/Generated/Google.Apis.BigQueryConnectionService.v1beta1/Google.Apis.BigQueryConnectionService.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.BigQueryConnectionService.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.BigQueryConnectionService.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BigQueryReservation.v1/Google.Apis.BigQueryReservation.v1.cs
+++ b/Src/Generated/Google.Apis.BigQueryReservation.v1/Google.Apis.BigQueryReservation.v1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.BigQueryReservation.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.BigQueryReservation.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BigQueryReservation.v1alpha2/Google.Apis.BigQueryReservation.v1alpha2.cs
+++ b/Src/Generated/Google.Apis.BigQueryReservation.v1alpha2/Google.Apis.BigQueryReservation.v1alpha2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.BigQueryReservation.v1alpha2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.BigQueryReservation.v1alpha2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BigQueryReservation.v1beta1/Google.Apis.BigQueryReservation.v1beta1.cs
+++ b/Src/Generated/Google.Apis.BigQueryReservation.v1beta1/Google.Apis.BigQueryReservation.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.BigQueryReservation.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.BigQueryReservation.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Bigquery.v2/Google.Apis.Bigquery.v2.cs
+++ b/Src/Generated/Google.Apis.Bigquery.v2/Google.Apis.Bigquery.v2.cs
@@ -156,7 +156,6 @@ namespace Google.Apis.Bigquery.v2
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -182,7 +181,6 @@ namespace Google.Apis.Bigquery.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1167,7 +1165,6 @@ namespace Google.Apis.Bigquery.v2
         {
 
             /// <summary>Data format for the response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -1193,7 +1190,6 @@ namespace Google.Apis.Bigquery.v2
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BigtableAdmin.v1/Google.Apis.BigtableAdmin.v1.cs
+++ b/Src/Generated/Google.Apis.BigtableAdmin.v1/Google.Apis.BigtableAdmin.v1.cs
@@ -92,7 +92,6 @@ namespace Google.Apis.BigtableAdmin.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -128,7 +127,6 @@ namespace Google.Apis.BigtableAdmin.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BigtableAdmin.v2/Google.Apis.BigtableAdmin.v2.cs
+++ b/Src/Generated/Google.Apis.BigtableAdmin.v2/Google.Apis.BigtableAdmin.v2.cs
@@ -161,7 +161,6 @@ namespace Google.Apis.BigtableAdmin.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -197,7 +196,6 @@ namespace Google.Apis.BigtableAdmin.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BinaryAuthorization.v1/Google.Apis.BinaryAuthorization.v1.cs
+++ b/Src/Generated/Google.Apis.BinaryAuthorization.v1/Google.Apis.BinaryAuthorization.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.BinaryAuthorization.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.BinaryAuthorization.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.BinaryAuthorization.v1beta1/Google.Apis.BinaryAuthorization.v1beta1.cs
+++ b/Src/Generated/Google.Apis.BinaryAuthorization.v1beta1/Google.Apis.BinaryAuthorization.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.BinaryAuthorization.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.BinaryAuthorization.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Blogger.v2/Google.Apis.Blogger.v2.cs
+++ b/Src/Generated/Google.Apis.Blogger.v2/Google.Apis.Blogger.v2.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.Blogger.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.Blogger.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Blogger.v3/Google.Apis.Blogger.v3.cs
+++ b/Src/Generated/Google.Apis.Blogger.v3/Google.Apis.Blogger.v3.cs
@@ -143,7 +143,6 @@ namespace Google.Apis.Blogger.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -179,7 +178,6 @@ namespace Google.Apis.Blogger.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2447,7 +2445,6 @@ namespace Google.Apis.Blogger.v3
             public virtual string EndDate { get; set; }
 
 
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("fetchBodies", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBodies { get; set; }
 
@@ -2460,7 +2457,6 @@ namespace Google.Apis.Blogger.v3
             public virtual System.Nullable<long> MaxResults { get; set; }
 
 
-            /// [default: PUBLISHED]
             [Google.Apis.Util.RequestParameterAttribute("orderBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<OrderByEnum> OrderBy { get; set; }
 
@@ -2746,7 +2742,6 @@ namespace Google.Apis.Blogger.v3
             public virtual string PostId { get; private set; }
 
 
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("fetchBody", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBody { get; set; }
 
@@ -2979,7 +2974,6 @@ namespace Google.Apis.Blogger.v3
             public virtual string BlogId { get; private set; }
 
 
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("fetchBody", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBody { get; set; }
 
@@ -3080,7 +3074,6 @@ namespace Google.Apis.Blogger.v3
             public virtual string EndDate { get; set; }
 
 
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("fetchBodies", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBodies { get; set; }
 
@@ -3097,7 +3090,6 @@ namespace Google.Apis.Blogger.v3
             public virtual System.Nullable<long> MaxResults { get; set; }
 
 
-            /// [default: PUBLISHED]
             [Google.Apis.Util.RequestParameterAttribute("orderBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<OrderByEnum> OrderBy { get; set; }
 
@@ -3302,7 +3294,6 @@ namespace Google.Apis.Blogger.v3
             public virtual string PostId { get; private set; }
 
 
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("fetchBody", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBody { get; set; }
 
@@ -3585,12 +3576,10 @@ namespace Google.Apis.Blogger.v3
             public virtual string Q { get; private set; }
 
 
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("fetchBodies", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBodies { get; set; }
 
 
-            /// [default: PUBLISHED]
             [Google.Apis.Util.RequestParameterAttribute("orderBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<OrderByEnum> OrderBy { get; set; }
 
@@ -3692,7 +3681,6 @@ namespace Google.Apis.Blogger.v3
             public virtual string PostId { get; private set; }
 
 
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("fetchBody", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> FetchBody { get; set; }
 

--- a/Src/Generated/Google.Apis.Books.v1/Google.Apis.Books.v1.cs
+++ b/Src/Generated/Google.Apis.Books.v1/Google.Apis.Books.v1.cs
@@ -157,7 +157,6 @@ namespace Google.Apis.Books.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -193,7 +192,6 @@ namespace Google.Apis.Books.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Calendar.v3/Google.Apis.Calendar.v3.cs
+++ b/Src/Generated/Google.Apis.Calendar.v3/Google.Apis.Calendar.v3.cs
@@ -144,7 +144,6 @@ namespace Google.Apis.Calendar.v3
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -170,7 +169,6 @@ namespace Google.Apis.Calendar.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -510,7 +508,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>Maximum number of entries returned on one result page. By default the value is 100 entries. The
             /// page size can never be larger than 250 entries. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -809,7 +806,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>Maximum number of entries returned on one result page. By default the value is 100 entries. The
             /// page size can never be larger than 250 entries. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1104,7 +1100,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>Maximum number of entries returned on one result page. By default the value is 100 entries. The
             /// page size can never be larger than 250 entries. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1404,7 +1399,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>Maximum number of entries returned on one result page. By default the value is 100 entries. The
             /// page size can never be larger than 250 entries. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2165,7 +2159,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
@@ -2271,8 +2264,6 @@ namespace Google.Apis.Calendar.v3
             /// data support and ignores conference data in the event's body. Version 1 enables support for copying of
             /// ConferenceData as well as for creating new conferences using the createRequest field of conferenceData.
             /// The default is 0.</summary>
-            /// [minimum: 0]
-            /// [maximum: 1]
             [Google.Apis.Util.RequestParameterAttribute("conferenceDataVersion", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> ConferenceDataVersion { get; set; }
 
@@ -2364,14 +2355,11 @@ namespace Google.Apis.Calendar.v3
             /// data support and ignores conference data in the event's body. Version 1 enables support for copying of
             /// ConferenceData as well as for creating new conferences using the createRequest field of conferenceData.
             /// The default is 0.</summary>
-            /// [minimum: 0]
-            /// [maximum: 1]
             [Google.Apis.Util.RequestParameterAttribute("conferenceDataVersion", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> ConferenceDataVersion { get; set; }
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
@@ -2527,13 +2515,11 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
             /// <summary>Maximum number of events returned on one result page. By default the value is 250 events. The
             /// page size can never be larger than 2500 events. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2721,7 +2707,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
@@ -2729,8 +2714,6 @@ namespace Google.Apis.Calendar.v3
             /// page may be less than this value, or none at all, even if there are more events matching the query.
             /// Incomplete pages can be detected by a non-empty nextPageToken field in the response. By default the
             /// value is 250 events. The page size can never be larger than 2500 events. Optional.</summary>
-            /// [default: 250]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3181,14 +3164,11 @@ namespace Google.Apis.Calendar.v3
             /// data support and ignores conference data in the event's body. Version 1 enables support for copying of
             /// ConferenceData as well as for creating new conferences using the createRequest field of conferenceData.
             /// The default is 0.</summary>
-            /// [minimum: 0]
-            /// [maximum: 1]
             [Google.Apis.Util.RequestParameterAttribute("conferenceDataVersion", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> ConferenceDataVersion { get; set; }
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
@@ -3479,14 +3459,11 @@ namespace Google.Apis.Calendar.v3
             /// data support and ignores conference data in the event's body. Version 1 enables support for copying of
             /// ConferenceData as well as for creating new conferences using the createRequest field of conferenceData.
             /// The default is 0.</summary>
-            /// [minimum: 0]
-            /// [maximum: 1]
             [Google.Apis.Util.RequestParameterAttribute("conferenceDataVersion", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> ConferenceDataVersion { get; set; }
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
@@ -3659,7 +3636,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>The maximum number of attendees to include in the response. If there are more than the
             /// specified number of attendees, only the participant is returned. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxAttendees", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxAttendees { get; set; }
 
@@ -3667,8 +3643,6 @@ namespace Google.Apis.Calendar.v3
             /// page may be less than this value, or none at all, even if there are more events matching the query.
             /// Incomplete pages can be detected by a non-empty nextPageToken field in the response. By default the
             /// value is 250 events. The page size can never be larger than 2500 events. Optional.</summary>
-            /// [default: 250]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4102,7 +4076,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>Maximum number of entries returned on one result page. By default the value is 100 entries. The
             /// page size can never be larger than 250 entries. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4185,7 +4158,6 @@ namespace Google.Apis.Calendar.v3
 
             /// <summary>Maximum number of entries returned on one result page. By default the value is 100 entries. The
             /// page size can never be larger than 250 entries. Optional.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.ChromeUXReport.v1/Google.Apis.ChromeUXReport.v1.cs
+++ b/Src/Generated/Google.Apis.ChromeUXReport.v1/Google.Apis.ChromeUXReport.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.ChromeUXReport.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.ChromeUXReport.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CivicInfo.v2/Google.Apis.CivicInfo.v2.cs
+++ b/Src/Generated/Google.Apis.CivicInfo.v2/Google.Apis.CivicInfo.v2.cs
@@ -103,7 +103,6 @@ namespace Google.Apis.CivicInfo.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -139,7 +138,6 @@ namespace Google.Apis.CivicInfo.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -411,19 +409,16 @@ namespace Google.Apis.CivicInfo.v2
             /// https://www.googleapis.com/civicinfo/{version}/elections. If no election ID is specified in the query
             /// and there is more than one election with data for the given voter, the additional elections are provided
             /// in the otherElections response field.</summary>
-            /// [default: 0]
             [Google.Apis.Util.RequestParameterAttribute("electionId", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> ElectionId { get; set; }
 
             /// <summary>If set to true, only data from official state sources will be returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("officialOnly", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> OfficialOnly { get; set; }
 
             /// <summary>If set to true, the query will return the success code and include any partial information when
             /// it is unable to determine a matching address or unable to determine the election for electionId=0
             /// queries.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("returnAllAvailableData", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> ReturnAllAvailableData { get; set; }
 
@@ -523,7 +518,6 @@ namespace Google.Apis.CivicInfo.v2
 
             /// <summary>Whether to return information about offices and officials. If false, only the top-level
             /// district information will be returned.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeOffices", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeOffices { get; set; }
 

--- a/Src/Generated/Google.Apis.Classroom.v1/Google.Apis.Classroom.v1.cs
+++ b/Src/Generated/Google.Apis.Classroom.v1/Google.Apis.Classroom.v1.cs
@@ -241,7 +241,6 @@ namespace Google.Apis.Classroom.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -277,7 +276,6 @@ namespace Google.Apis.Classroom.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudAsset.v1/Google.Apis.CloudAsset.v1.cs
+++ b/Src/Generated/Google.Apis.CloudAsset.v1/Google.Apis.CloudAsset.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.CloudAsset.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.CloudAsset.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudAsset.v1beta1/Google.Apis.CloudAsset.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudAsset.v1beta1/Google.Apis.CloudAsset.v1beta1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.CloudAsset.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.CloudAsset.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudAsset.v1p1beta1/Google.Apis.CloudAsset.v1p1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudAsset.v1p1beta1/Google.Apis.CloudAsset.v1p1beta1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.CloudAsset.v1p1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.CloudAsset.v1p1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudAsset.v1p4beta1/Google.Apis.CloudAsset.v1p4beta1.cs
+++ b/Src/Generated/Google.Apis.CloudAsset.v1p4beta1/Google.Apis.CloudAsset.v1p4beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudAsset.v1p4beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudAsset.v1p4beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudAsset.v1p5beta1/Google.Apis.CloudAsset.v1p5beta1.cs
+++ b/Src/Generated/Google.Apis.CloudAsset.v1p5beta1/Google.Apis.CloudAsset.v1p5beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudAsset.v1p5beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudAsset.v1p5beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudBillingBudget.v1beta1/Google.Apis.CloudBillingBudget.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudBillingBudget.v1beta1/Google.Apis.CloudBillingBudget.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudBillingBudget.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudBillingBudget.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudBuild.v1/Google.Apis.CloudBuild.v1.cs
+++ b/Src/Generated/Google.Apis.CloudBuild.v1/Google.Apis.CloudBuild.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.CloudBuild.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.CloudBuild.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudBuild.v1alpha1/Google.Apis.CloudBuild.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.CloudBuild.v1alpha1/Google.Apis.CloudBuild.v1alpha1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudBuild.v1alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudBuild.v1alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudBuild.v1alpha2/Google.Apis.CloudBuild.v1alpha2.cs
+++ b/Src/Generated/Google.Apis.CloudBuild.v1alpha2/Google.Apis.CloudBuild.v1alpha2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudBuild.v1alpha2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudBuild.v1alpha2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudComposer.v1/Google.Apis.CloudComposer.v1.cs
+++ b/Src/Generated/Google.Apis.CloudComposer.v1/Google.Apis.CloudComposer.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudComposer.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudComposer.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudComposer.v1beta1/Google.Apis.CloudComposer.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudComposer.v1beta1/Google.Apis.CloudComposer.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudComposer.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudComposer.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudDebugger.v2/Google.Apis.CloudDebugger.v2.cs
+++ b/Src/Generated/Google.Apis.CloudDebugger.v2/Google.Apis.CloudDebugger.v2.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.CloudDebugger.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.CloudDebugger.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudFilestore.v1/Google.Apis.CloudFilestore.v1.cs
+++ b/Src/Generated/Google.Apis.CloudFilestore.v1/Google.Apis.CloudFilestore.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudFilestore.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudFilestore.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudFilestore.v1beta1/Google.Apis.CloudFilestore.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudFilestore.v1beta1/Google.Apis.CloudFilestore.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudFilestore.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudFilestore.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudFunctions.v1/Google.Apis.CloudFunctions.v1.cs
+++ b/Src/Generated/Google.Apis.CloudFunctions.v1/Google.Apis.CloudFunctions.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.CloudFunctions.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.CloudFunctions.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudHealthcare.v1/Google.Apis.CloudHealthcare.v1.cs
+++ b/Src/Generated/Google.Apis.CloudHealthcare.v1/Google.Apis.CloudHealthcare.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudHealthcare.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudHealthcare.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudHealthcare.v1beta1/Google.Apis.CloudHealthcare.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudHealthcare.v1beta1/Google.Apis.CloudHealthcare.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudHealthcare.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudHealthcare.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudIAP.v1/Google.Apis.CloudIAP.v1.cs
+++ b/Src/Generated/Google.Apis.CloudIAP.v1/Google.Apis.CloudIAP.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.CloudIAP.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.CloudIAP.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudIAP.v1beta1/Google.Apis.CloudIAP.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudIAP.v1beta1/Google.Apis.CloudIAP.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudIAP.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudIAP.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudIdentity.v1/Google.Apis.CloudIdentity.v1.cs
+++ b/Src/Generated/Google.Apis.CloudIdentity.v1/Google.Apis.CloudIdentity.v1.cs
@@ -135,7 +135,6 @@ namespace Google.Apis.CloudIdentity.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -171,7 +170,6 @@ namespace Google.Apis.CloudIdentity.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudIdentity.v1beta1/Google.Apis.CloudIdentity.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudIdentity.v1beta1/Google.Apis.CloudIdentity.v1beta1.cs
@@ -135,7 +135,6 @@ namespace Google.Apis.CloudIdentity.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -171,7 +170,6 @@ namespace Google.Apis.CloudIdentity.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudIot.v1/Google.Apis.CloudIot.v1.cs
+++ b/Src/Generated/Google.Apis.CloudIot.v1/Google.Apis.CloudIot.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudIot.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudIot.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudKMS.v1/Google.Apis.CloudKMS.v1.cs
+++ b/Src/Generated/Google.Apis.CloudKMS.v1/Google.Apis.CloudKMS.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudKMS.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudKMS.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudLifeSciences.v2beta/Google.Apis.CloudLifeSciences.v2beta.cs
+++ b/Src/Generated/Google.Apis.CloudLifeSciences.v2beta/Google.Apis.CloudLifeSciences.v2beta.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudLifeSciences.v2beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudLifeSciences.v2beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudMachineLearningEngine.v1/Google.Apis.CloudMachineLearningEngine.v1.cs
+++ b/Src/Generated/Google.Apis.CloudMachineLearningEngine.v1/Google.Apis.CloudMachineLearningEngine.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudMachineLearningEngine.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudMachineLearningEngine.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudMemorystoreforMemcached.v1beta2/Google.Apis.CloudMemorystoreforMemcached.v1beta2.cs
+++ b/Src/Generated/Google.Apis.CloudMemorystoreforMemcached.v1beta2/Google.Apis.CloudMemorystoreforMemcached.v1beta2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudMemorystoreforMemcached.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudMemorystoreforMemcached.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudNaturalLanguage.v1/Google.Apis.CloudNaturalLanguage.v1.cs
+++ b/Src/Generated/Google.Apis.CloudNaturalLanguage.v1/Google.Apis.CloudNaturalLanguage.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudNaturalLanguage.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudNaturalLanguage.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudNaturalLanguage.v1beta1/Google.Apis.CloudNaturalLanguage.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudNaturalLanguage.v1beta1/Google.Apis.CloudNaturalLanguage.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudNaturalLanguage.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudNaturalLanguage.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudNaturalLanguage.v1beta2/Google.Apis.CloudNaturalLanguage.v1beta2.cs
+++ b/Src/Generated/Google.Apis.CloudNaturalLanguage.v1beta2/Google.Apis.CloudNaturalLanguage.v1beta2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudNaturalLanguage.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudNaturalLanguage.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudOSLogin.v1/Google.Apis.CloudOSLogin.v1.cs
+++ b/Src/Generated/Google.Apis.CloudOSLogin.v1/Google.Apis.CloudOSLogin.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudOSLogin.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudOSLogin.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudOSLogin.v1alpha/Google.Apis.CloudOSLogin.v1alpha.cs
+++ b/Src/Generated/Google.Apis.CloudOSLogin.v1alpha/Google.Apis.CloudOSLogin.v1alpha.cs
@@ -127,7 +127,6 @@ namespace Google.Apis.CloudOSLogin.v1alpha
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -163,7 +162,6 @@ namespace Google.Apis.CloudOSLogin.v1alpha
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudOSLogin.v1beta/Google.Apis.CloudOSLogin.v1beta.cs
+++ b/Src/Generated/Google.Apis.CloudOSLogin.v1beta/Google.Apis.CloudOSLogin.v1beta.cs
@@ -127,7 +127,6 @@ namespace Google.Apis.CloudOSLogin.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -163,7 +162,6 @@ namespace Google.Apis.CloudOSLogin.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudProfiler.v2/Google.Apis.CloudProfiler.v2.cs
+++ b/Src/Generated/Google.Apis.CloudProfiler.v2/Google.Apis.CloudProfiler.v2.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.CloudProfiler.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.CloudProfiler.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRedis.v1/Google.Apis.CloudRedis.v1.cs
+++ b/Src/Generated/Google.Apis.CloudRedis.v1/Google.Apis.CloudRedis.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudRedis.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudRedis.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRedis.v1beta1/Google.Apis.CloudRedis.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudRedis.v1beta1/Google.Apis.CloudRedis.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudRedis.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudRedis.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudResourceManager.v1/Google.Apis.CloudResourceManager.v1.cs
+++ b/Src/Generated/Google.Apis.CloudResourceManager.v1/Google.Apis.CloudResourceManager.v1.cs
@@ -131,7 +131,6 @@ namespace Google.Apis.CloudResourceManager.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -167,7 +166,6 @@ namespace Google.Apis.CloudResourceManager.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudResourceManager.v1beta1/Google.Apis.CloudResourceManager.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudResourceManager.v1beta1/Google.Apis.CloudResourceManager.v1beta1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.CloudResourceManager.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.CloudResourceManager.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudResourceManager.v2/Google.Apis.CloudResourceManager.v2.cs
+++ b/Src/Generated/Google.Apis.CloudResourceManager.v2/Google.Apis.CloudResourceManager.v2.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.CloudResourceManager.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.CloudResourceManager.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudResourceManager.v2beta1/Google.Apis.CloudResourceManager.v2beta1.cs
+++ b/Src/Generated/Google.Apis.CloudResourceManager.v2beta1/Google.Apis.CloudResourceManager.v2beta1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.CloudResourceManager.v2beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.CloudResourceManager.v2beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRun.v1/Google.Apis.CloudRun.v1.cs
+++ b/Src/Generated/Google.Apis.CloudRun.v1/Google.Apis.CloudRun.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.CloudRun.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.CloudRun.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRun.v1alpha1/Google.Apis.CloudRun.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.CloudRun.v1alpha1/Google.Apis.CloudRun.v1alpha1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.CloudRun.v1alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.CloudRun.v1alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRun.v1beta1/Google.Apis.CloudRun.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudRun.v1beta1/Google.Apis.CloudRun.v1beta1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.CloudRun.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.CloudRun.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRuntimeConfig.v1/Google.Apis.CloudRuntimeConfig.v1.cs
+++ b/Src/Generated/Google.Apis.CloudRuntimeConfig.v1/Google.Apis.CloudRuntimeConfig.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudRuntimeConfig.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudRuntimeConfig.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudRuntimeConfig.v1beta1/Google.Apis.CloudRuntimeConfig.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudRuntimeConfig.v1beta1/Google.Apis.CloudRuntimeConfig.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudRuntimeConfig.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudRuntimeConfig.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudScheduler.v1/Google.Apis.CloudScheduler.v1.cs
+++ b/Src/Generated/Google.Apis.CloudScheduler.v1/Google.Apis.CloudScheduler.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudScheduler.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudScheduler.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudScheduler.v1beta1/Google.Apis.CloudScheduler.v1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudScheduler.v1beta1/Google.Apis.CloudScheduler.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudScheduler.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudScheduler.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudSearch.v1/Google.Apis.CloudSearch.v1.cs
+++ b/Src/Generated/Google.Apis.CloudSearch.v1/Google.Apis.CloudSearch.v1.cs
@@ -181,7 +181,6 @@ namespace Google.Apis.CloudSearch.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -217,7 +216,6 @@ namespace Google.Apis.CloudSearch.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2112,7 +2110,6 @@ namespace Google.Apis.CloudSearch.v1
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -2148,7 +2145,6 @@ namespace Google.Apis.CloudSearch.v1
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudShell.v1/Google.Apis.CloudShell.v1.cs
+++ b/Src/Generated/Google.Apis.CloudShell.v1/Google.Apis.CloudShell.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudShell.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudShell.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudShell.v1alpha1/Google.Apis.CloudShell.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.CloudShell.v1alpha1/Google.Apis.CloudShell.v1alpha1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudShell.v1alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudShell.v1alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudSourceRepositories.v1/Google.Apis.CloudSourceRepositories.v1.cs
+++ b/Src/Generated/Google.Apis.CloudSourceRepositories.v1/Google.Apis.CloudSourceRepositories.v1.cs
@@ -127,7 +127,6 @@ namespace Google.Apis.CloudSourceRepositories.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -163,7 +162,6 @@ namespace Google.Apis.CloudSourceRepositories.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTalentSolution.v2/Google.Apis.CloudTalentSolution.v2.cs
+++ b/Src/Generated/Google.Apis.CloudTalentSolution.v2/Google.Apis.CloudTalentSolution.v2.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.CloudTalentSolution.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.CloudTalentSolution.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTalentSolution.v3/Google.Apis.CloudTalentSolution.v3.cs
+++ b/Src/Generated/Google.Apis.CloudTalentSolution.v3/Google.Apis.CloudTalentSolution.v3.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudTalentSolution.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudTalentSolution.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTalentSolution.v3p1beta1/Google.Apis.CloudTalentSolution.v3p1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudTalentSolution.v3p1beta1/Google.Apis.CloudTalentSolution.v3p1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudTalentSolution.v3p1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudTalentSolution.v3p1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTasks.v2/Google.Apis.CloudTasks.v2.cs
+++ b/Src/Generated/Google.Apis.CloudTasks.v2/Google.Apis.CloudTasks.v2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudTasks.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudTasks.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTasks.v2beta2/Google.Apis.CloudTasks.v2beta2.cs
+++ b/Src/Generated/Google.Apis.CloudTasks.v2beta2/Google.Apis.CloudTasks.v2beta2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudTasks.v2beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudTasks.v2beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTasks.v2beta3/Google.Apis.CloudTasks.v2beta3.cs
+++ b/Src/Generated/Google.Apis.CloudTasks.v2beta3/Google.Apis.CloudTasks.v2beta3.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudTasks.v2beta3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudTasks.v2beta3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTrace.v1/Google.Apis.CloudTrace.v1.cs
+++ b/Src/Generated/Google.Apis.CloudTrace.v1/Google.Apis.CloudTrace.v1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.CloudTrace.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.CloudTrace.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTrace.v2/Google.Apis.CloudTrace.v2.cs
+++ b/Src/Generated/Google.Apis.CloudTrace.v2/Google.Apis.CloudTrace.v2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.CloudTrace.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.CloudTrace.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudTrace.v2beta1/Google.Apis.CloudTrace.v2beta1.cs
+++ b/Src/Generated/Google.Apis.CloudTrace.v2beta1/Google.Apis.CloudTrace.v2beta1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.CloudTrace.v2beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.CloudTrace.v2beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudVideoIntelligence.v1/Google.Apis.CloudVideoIntelligence.v1.cs
+++ b/Src/Generated/Google.Apis.CloudVideoIntelligence.v1/Google.Apis.CloudVideoIntelligence.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudVideoIntelligence.v1beta2/Google.Apis.CloudVideoIntelligence.v1beta2.cs
+++ b/Src/Generated/Google.Apis.CloudVideoIntelligence.v1beta2/Google.Apis.CloudVideoIntelligence.v1beta2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudVideoIntelligence.v1p1beta1/Google.Apis.CloudVideoIntelligence.v1p1beta1.cs
+++ b/Src/Generated/Google.Apis.CloudVideoIntelligence.v1p1beta1/Google.Apis.CloudVideoIntelligence.v1p1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1p1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1p1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudVideoIntelligence.v1p2beta1/Google.Apis.CloudVideoIntelligence.v1p2beta1.cs
+++ b/Src/Generated/Google.Apis.CloudVideoIntelligence.v1p2beta1/Google.Apis.CloudVideoIntelligence.v1p2beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1p2beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1p2beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.CloudVideoIntelligence.v1p3beta1/Google.Apis.CloudVideoIntelligence.v1p3beta1.cs
+++ b/Src/Generated/Google.Apis.CloudVideoIntelligence.v1p3beta1/Google.Apis.CloudVideoIntelligence.v1p3beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1p3beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.CloudVideoIntelligence.v1p3beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Cloudbilling.v1/Google.Apis.Cloudbilling.v1.cs
+++ b/Src/Generated/Google.Apis.Cloudbilling.v1/Google.Apis.Cloudbilling.v1.cs
@@ -129,7 +129,6 @@ namespace Google.Apis.Cloudbilling.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -165,7 +164,6 @@ namespace Google.Apis.Cloudbilling.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Clouderrorreporting.v1beta1/Google.Apis.Clouderrorreporting.v1beta1.cs
+++ b/Src/Generated/Google.Apis.Clouderrorreporting.v1beta1/Google.Apis.Clouderrorreporting.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Clouderrorreporting.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Clouderrorreporting.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Container.v1/Google.Apis.Container.v1.cs
+++ b/Src/Generated/Google.Apis.Container.v1/Google.Apis.Container.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Container.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Container.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Container.v1beta1/Google.Apis.Container.v1beta1.cs
+++ b/Src/Generated/Google.Apis.Container.v1beta1/Google.Apis.Container.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Container.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Container.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ContainerAnalysis.v1alpha1/Google.Apis.ContainerAnalysis.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.ContainerAnalysis.v1alpha1/Google.Apis.ContainerAnalysis.v1alpha1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.ContainerAnalysis.v1alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.ContainerAnalysis.v1alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ContainerAnalysis.v1beta1/Google.Apis.ContainerAnalysis.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ContainerAnalysis.v1beta1/Google.Apis.ContainerAnalysis.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ContainerAnalysis.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ContainerAnalysis.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Customsearch.v1/Google.Apis.Customsearch.v1.cs
+++ b/Src/Generated/Google.Apis.Customsearch.v1/Google.Apis.Customsearch.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.Customsearch.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.Customsearch.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DLP.v2/Google.Apis.DLP.v2.cs
+++ b/Src/Generated/Google.Apis.DLP.v2/Google.Apis.DLP.v2.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.DLP.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.DLP.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DataFusion.v1/Google.Apis.DataFusion.v1.cs
+++ b/Src/Generated/Google.Apis.DataFusion.v1/Google.Apis.DataFusion.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.DataFusion.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.DataFusion.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DataFusion.v1beta1/Google.Apis.DataFusion.v1beta1.cs
+++ b/Src/Generated/Google.Apis.DataFusion.v1beta1/Google.Apis.DataFusion.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.DataFusion.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.DataFusion.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Dataflow.v1b3/Google.Apis.Dataflow.v1b3.cs
+++ b/Src/Generated/Google.Apis.Dataflow.v1b3/Google.Apis.Dataflow.v1b3.cs
@@ -127,7 +127,6 @@ namespace Google.Apis.Dataflow.v1b3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -163,7 +162,6 @@ namespace Google.Apis.Dataflow.v1b3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Dataproc.v1/Google.Apis.Dataproc.v1.cs
+++ b/Src/Generated/Google.Apis.Dataproc.v1/Google.Apis.Dataproc.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Dataproc.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Dataproc.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Dataproc.v1beta2/Google.Apis.Dataproc.v1beta2.cs
+++ b/Src/Generated/Google.Apis.Dataproc.v1beta2/Google.Apis.Dataproc.v1beta2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Dataproc.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Dataproc.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Datastore.v1/Google.Apis.Datastore.v1.cs
+++ b/Src/Generated/Google.Apis.Datastore.v1/Google.Apis.Datastore.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Datastore.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Datastore.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Datastore.v1beta1/Google.Apis.Datastore.v1beta1.cs
+++ b/Src/Generated/Google.Apis.Datastore.v1beta1/Google.Apis.Datastore.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Datastore.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Datastore.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Datastore.v1beta3/Google.Apis.Datastore.v1beta3.cs
+++ b/Src/Generated/Google.Apis.Datastore.v1beta3/Google.Apis.Datastore.v1beta3.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Datastore.v1beta3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Datastore.v1beta3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DeploymentManager.v2/Google.Apis.DeploymentManager.v2.cs
+++ b/Src/Generated/Google.Apis.DeploymentManager.v2/Google.Apis.DeploymentManager.v2.cs
@@ -128,7 +128,6 @@ namespace Google.Apis.DeploymentManager.v2
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -154,7 +153,6 @@ namespace Google.Apis.DeploymentManager.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -360,7 +358,6 @@ namespace Google.Apis.DeploymentManager.v2
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -581,7 +578,6 @@ namespace Google.Apis.DeploymentManager.v2
             public virtual string Project { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -701,8 +697,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -820,7 +814,6 @@ namespace Google.Apis.DeploymentManager.v2
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -834,7 +827,6 @@ namespace Google.Apis.DeploymentManager.v2
             }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -854,7 +846,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// you can deploy your resources by making a request with the `update()` or you can `cancelPreview()` to
             /// remove the preview altogether. Note that the deployment will still exist after you cancel the preview
             /// and you must separately delete this deployment if you want to remove it.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preview", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preview { get; set; }
 
@@ -1188,7 +1179,6 @@ namespace Google.Apis.DeploymentManager.v2
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1202,7 +1192,6 @@ namespace Google.Apis.DeploymentManager.v2
             }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1222,7 +1211,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// you can deploy your resources by making a request with the `update()` or you can `cancelPreview()` to
             /// remove the preview altogether. Note that the deployment will still exist after you cancel the preview
             /// and you must separately delete this deployment if you want to remove it.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preview", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preview { get; set; }
 
@@ -1449,8 +1437,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1674,8 +1660,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1913,8 +1897,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2071,8 +2053,6 @@ namespace Google.Apis.DeploymentManager.v2
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.DeploymentManagerAlpha.alpha/Google.Apis.DeploymentManagerAlpha.alpha.cs
+++ b/Src/Generated/Google.Apis.DeploymentManagerAlpha.alpha/Google.Apis.DeploymentManagerAlpha.alpha.cs
@@ -136,7 +136,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -162,7 +161,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -501,8 +499,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -874,7 +870,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1108,7 +1103,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             public virtual string Project { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1230,8 +1224,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1363,7 +1355,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1379,7 +1370,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1399,7 +1389,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// you can deploy your resources by making a request with the `update()` or you can `cancelPreview()` to
             /// remove the preview altogether. Note that the deployment will still exist after you cancel the preview
             /// and you must separately delete this deployment if you want to remove it.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preview", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preview { get; set; }
 
@@ -1733,7 +1722,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1749,7 +1737,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1769,7 +1756,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// you can deploy your resources by making a request with the `update()` or you can `cancelPreview()` to
             /// remove the preview altogether. Note that the deployment will still exist after you cancel the preview
             /// and you must separately delete this deployment if you want to remove it.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preview", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preview { get; set; }
 
@@ -1996,8 +1982,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2235,8 +2219,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2488,8 +2470,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2936,8 +2916,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -3089,8 +3067,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -3478,8 +3454,6 @@ namespace Google.Apis.DeploymentManagerAlpha.alpha
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.DeploymentManagerV2Beta.v2beta/Google.Apis.DeploymentManagerV2Beta.v2beta.cs
+++ b/Src/Generated/Google.Apis.DeploymentManagerV2Beta.v2beta/Google.Apis.DeploymentManagerV2Beta.v2beta.cs
@@ -136,7 +136,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -162,7 +161,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -501,8 +499,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -860,7 +856,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1081,7 +1076,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             public virtual string Project { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1203,8 +1197,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1322,7 +1314,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1338,7 +1329,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1358,7 +1348,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// you can deploy your resources by making a request with the `update()` or you can `cancelPreview()` to
             /// remove the preview altogether. Note that the deployment will still exist after you cancel the preview
             /// and you must separately delete this deployment if you want to remove it.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preview", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preview { get; set; }
 
@@ -1692,7 +1681,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             public virtual string Deployment { get; private set; }
 
             /// <summary>Sets the policy to use for creating new resources.</summary>
-            /// [default: CREATE_OR_ACQUIRE]
             [Google.Apis.Util.RequestParameterAttribute("createPolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<CreatePolicyEnum> CreatePolicy { get; set; }
 
@@ -1708,7 +1696,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             }
 
             /// <summary>Sets the policy to use for deleting resources.</summary>
-            /// [default: DELETE]
             [Google.Apis.Util.RequestParameterAttribute("deletePolicy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<DeletePolicyEnum> DeletePolicy { get; set; }
 
@@ -1728,7 +1715,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// you can deploy your resources by making a request with the `update()` or you can `cancelPreview()` to
             /// remove the preview altogether. Note that the deployment will still exist after you cancel the preview
             /// and you must separately delete this deployment if you want to remove it.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preview", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preview { get; set; }
 
@@ -1955,8 +1941,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2180,8 +2164,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2419,8 +2401,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2853,8 +2833,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -2992,8 +2970,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -3300,8 +3276,6 @@ namespace Google.Apis.DeploymentManagerV2Beta.v2beta
             /// results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get
             /// the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive.
             /// (Default: `500`)</summary>
-            /// [default: 500]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.Dfareporting.v3_3/Google.Apis.Dfareporting.v3_3.cs
+++ b/Src/Generated/Google.Apis.Dfareporting.v3_3/Google.Apis.Dfareporting.v3_3.cs
@@ -357,7 +357,6 @@ namespace Google.Apis.Dfareporting.v3_3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -393,7 +392,6 @@ namespace Google.Apis.Dfareporting.v3_3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1047,9 +1045,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1066,7 +1061,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -1080,7 +1074,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -1458,9 +1451,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1477,7 +1467,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -1491,7 +1480,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -1964,9 +1952,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> LandingPageIds { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1998,7 +1983,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SizeIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -2012,7 +1996,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -2654,9 +2637,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2673,7 +2653,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -2687,7 +2666,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -3097,9 +3075,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3116,7 +3091,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -3130,7 +3104,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -3579,9 +3552,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<bool> IncludeAdvertisersWithoutGroupsOnly { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3602,7 +3572,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -3616,7 +3585,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -4108,9 +4076,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual long CampaignId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4119,7 +4084,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string PageToken { get; set; }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -4388,9 +4352,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4411,7 +4372,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -4425,7 +4385,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -4881,9 +4840,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string MaxChangeTime { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -5612,9 +5568,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -5631,7 +5584,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -5645,7 +5597,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -6286,7 +6237,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -6322,7 +6272,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -6672,9 +6621,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -6688,7 +6634,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -6702,7 +6647,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -7211,9 +7155,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -7231,7 +7172,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -7245,7 +7185,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -7651,8 +7590,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> AdvertiserIds { get; set; }
 
             /// <summary>Select only creative groups that belong to this subgroup.</summary>
-            /// [minimum: 1]
-            /// [maximum: 2]
             [Google.Apis.Util.RequestParameterAttribute("groupNumber", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> GroupNumber { get; set; }
 
@@ -7661,9 +7598,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -7681,7 +7615,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -7695,7 +7628,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -8135,9 +8067,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8162,7 +8091,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SizeIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -8176,7 +8104,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -8598,9 +8525,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 100]
-            /// [minimum: 0]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8855,9 +8779,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8874,7 +8795,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -8888,7 +8808,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -9631,7 +9550,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -9645,7 +9563,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -10070,9 +9987,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 10]
-            /// [minimum: 0]
-            /// [maximum: 10]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -10081,7 +9995,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string PageToken { get; set; }
 
             /// <summary>The scope that defines which results are returned.</summary>
-            /// [default: MINE]
             [Google.Apis.Util.RequestParameterAttribute("scope", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ScopeEnum> Scope { get; set; }
 
@@ -10100,7 +10013,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>The field by which to sort the list.</summary>
-            /// [default: LAST_MODIFIED_TIME]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -10116,7 +10028,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: DESCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -10545,9 +10456,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -10565,7 +10473,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -10579,7 +10486,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -11056,9 +10962,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -11076,7 +10979,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -11090,7 +10992,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -11776,9 +11677,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<bool> InPlan { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -11795,7 +11693,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SiteId { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -11809,7 +11706,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -12216,9 +12112,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -12849,9 +12742,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -12877,7 +12767,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SiteId { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -12891,7 +12780,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -13156,9 +13044,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -13179,7 +13064,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SiteId { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -13193,7 +13077,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -13503,9 +13386,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string MaxEndDate { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 800]
-            /// [minimum: 0]
-            /// [maximum: 800]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -13588,7 +13468,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SiteIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -13602,7 +13481,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -14183,9 +14061,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -14203,7 +14078,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -14217,7 +14091,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -14806,9 +14679,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string MaxEndDate { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -14886,7 +14756,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> SizeIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -14900,7 +14769,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -15656,9 +15524,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -15675,7 +15540,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -15689,7 +15553,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -16274,9 +16137,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<long> FloodlightActivityId { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -16294,7 +16154,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string PageToken { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -16308,7 +16167,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -16837,9 +16695,6 @@ namespace Google.Apis.Dfareporting.v3_3
                 public virtual long ReportId { get; private set; }
 
                 /// <summary>Maximum number of results to return.</summary>
-                /// [default: 10]
-                /// [minimum: 0]
-                /// [maximum: 10]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -16848,7 +16703,6 @@ namespace Google.Apis.Dfareporting.v3_3
                 public virtual string PageToken { get; set; }
 
                 /// <summary>The field by which to sort the list.</summary>
-                /// [default: LAST_MODIFIED_TIME]
                 [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -16862,7 +16716,6 @@ namespace Google.Apis.Dfareporting.v3_3
                 }
 
                 /// <summary>Order of sorted results.</summary>
-                /// [default: DESCENDING]
                 [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -17166,9 +17019,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 10]
-            /// [minimum: 0]
-            /// [maximum: 10]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -17177,7 +17027,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string PageToken { get; set; }
 
             /// <summary>The scope that defines which results are returned.</summary>
-            /// [default: MINE]
             [Google.Apis.Util.RequestParameterAttribute("scope", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ScopeEnum> Scope { get; set; }
 
@@ -17193,7 +17042,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>The field by which to sort the list.</summary>
-            /// [default: LAST_MODIFIED_TIME]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -17212,7 +17060,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: DESCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -17406,7 +17253,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual long ReportId { get; private set; }
 
             /// <summary>If set and true, tries to run the report synchronously.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("synchronous", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Synchronous { get; set; }
 
@@ -17732,9 +17578,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -17751,7 +17594,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -17765,7 +17607,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -18251,8 +18092,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Select only sizes with this height.</summary>
-            /// [minimum: 0]
-            /// [maximum: 32767]
             [Google.Apis.Util.RequestParameterAttribute("height", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> Height { get; set; }
 
@@ -18265,8 +18104,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Select only sizes with this width.</summary>
-            /// [minimum: 0]
-            /// [maximum: 32767]
             [Google.Apis.Util.RequestParameterAttribute("width", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> Width { get; set; }
 
@@ -18505,9 +18342,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -18524,7 +18358,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -18538,7 +18371,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -18885,9 +18717,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<bool> Active { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -18905,7 +18734,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string PageToken { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -18919,7 +18747,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -19200,9 +19027,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -19219,7 +19043,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -19233,7 +19056,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -20097,9 +19919,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -20116,7 +19935,6 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -20130,7 +19948,6 @@ namespace Google.Apis.Dfareporting.v3_3
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 

--- a/Src/Generated/Google.Apis.Dfareporting.v3_4/Google.Apis.Dfareporting.v3_4.cs
+++ b/Src/Generated/Google.Apis.Dfareporting.v3_4/Google.Apis.Dfareporting.v3_4.cs
@@ -361,7 +361,6 @@ namespace Google.Apis.Dfareporting.v3_4
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -397,7 +396,6 @@ namespace Google.Apis.Dfareporting.v3_4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1051,9 +1049,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1070,7 +1065,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -1084,7 +1078,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -1462,9 +1455,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1481,7 +1471,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -1495,7 +1484,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -1968,9 +1956,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> LandingPageIds { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2002,7 +1987,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SizeIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -2016,7 +2000,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -2658,9 +2641,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2677,7 +2657,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -2691,7 +2670,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -3101,9 +3079,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3120,7 +3095,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -3134,7 +3108,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -3583,9 +3556,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<bool> IncludeAdvertisersWithoutGroupsOnly { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3606,7 +3576,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -3620,7 +3589,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -4112,9 +4080,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual long CampaignId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4123,7 +4088,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string PageToken { get; set; }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -4392,9 +4356,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -4415,7 +4376,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -4429,7 +4389,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -4885,9 +4844,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string MaxChangeTime { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -5616,9 +5572,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -5635,7 +5588,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -5649,7 +5601,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -6290,7 +6241,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -6326,7 +6276,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -6676,9 +6625,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -6692,7 +6638,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -6706,7 +6651,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -7215,9 +7159,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -7235,7 +7176,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -7249,7 +7189,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -7655,8 +7594,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> AdvertiserIds { get; set; }
 
             /// <summary>Select only creative groups that belong to this subgroup.</summary>
-            /// [minimum: 1]
-            /// [maximum: 2]
             [Google.Apis.Util.RequestParameterAttribute("groupNumber", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> GroupNumber { get; set; }
 
@@ -7665,9 +7602,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -7685,7 +7619,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -7699,7 +7632,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -8139,9 +8071,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8166,7 +8095,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SizeIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -8180,7 +8108,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -8678,9 +8605,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 100]
-            /// [minimum: 0]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8935,9 +8859,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8954,7 +8875,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -8968,7 +8888,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -9711,7 +9630,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -9725,7 +9643,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -10150,9 +10067,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 10]
-            /// [minimum: 0]
-            /// [maximum: 10]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -10161,7 +10075,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string PageToken { get; set; }
 
             /// <summary>The scope that defines which results are returned.</summary>
-            /// [default: MINE]
             [Google.Apis.Util.RequestParameterAttribute("scope", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ScopeEnum> Scope { get; set; }
 
@@ -10180,7 +10093,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>The field by which to sort the list.</summary>
-            /// [default: LAST_MODIFIED_TIME]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -10196,7 +10108,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: DESCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -10625,9 +10536,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -10645,7 +10553,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -10659,7 +10566,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -11136,9 +11042,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -11156,7 +11059,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -11170,7 +11072,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -11856,9 +11757,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<bool> InPlan { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -11875,7 +11773,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SiteId { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -11889,7 +11786,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -12296,9 +12192,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -12929,9 +12822,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -12957,7 +12847,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SiteId { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -12971,7 +12860,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -13236,9 +13124,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -13259,7 +13144,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SiteId { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -13273,7 +13157,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -13583,9 +13466,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string MaxEndDate { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 800]
-            /// [minimum: 0]
-            /// [maximum: 800]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -13668,7 +13548,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SiteIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -13682,7 +13561,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -14263,9 +14141,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -14283,7 +14158,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -14297,7 +14171,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -14886,9 +14759,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string MaxEndDate { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -14966,7 +14836,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> SizeIds { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -14980,7 +14849,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -15736,9 +15604,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -15755,7 +15620,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -15769,7 +15633,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -16354,9 +16217,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<long> FloodlightActivityId { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -16374,7 +16234,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string PageToken { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -16388,7 +16247,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -16917,9 +16775,6 @@ namespace Google.Apis.Dfareporting.v3_4
                 public virtual long ReportId { get; private set; }
 
                 /// <summary>Maximum number of results to return.</summary>
-                /// [default: 10]
-                /// [minimum: 0]
-                /// [maximum: 10]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -16928,7 +16783,6 @@ namespace Google.Apis.Dfareporting.v3_4
                 public virtual string PageToken { get; set; }
 
                 /// <summary>The field by which to sort the list.</summary>
-                /// [default: LAST_MODIFIED_TIME]
                 [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -16942,7 +16796,6 @@ namespace Google.Apis.Dfareporting.v3_4
                 }
 
                 /// <summary>Order of sorted results.</summary>
-                /// [default: DESCENDING]
                 [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -17246,9 +17099,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 10]
-            /// [minimum: 0]
-            /// [maximum: 10]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -17257,7 +17107,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string PageToken { get; set; }
 
             /// <summary>The scope that defines which results are returned.</summary>
-            /// [default: MINE]
             [Google.Apis.Util.RequestParameterAttribute("scope", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ScopeEnum> Scope { get; set; }
 
@@ -17273,7 +17122,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>The field by which to sort the list.</summary>
-            /// [default: LAST_MODIFIED_TIME]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -17292,7 +17140,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: DESCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -17486,7 +17333,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual long ReportId { get; private set; }
 
             /// <summary>If set and true, tries to run the report synchronously.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("synchronous", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Synchronous { get; set; }
 
@@ -17812,9 +17658,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -17831,7 +17674,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -17845,7 +17687,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -18331,8 +18172,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual long ProfileId { get; private set; }
 
             /// <summary>Select only sizes with this height.</summary>
-            /// [minimum: 0]
-            /// [maximum: 32767]
             [Google.Apis.Util.RequestParameterAttribute("height", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> Height { get; set; }
 
@@ -18345,8 +18184,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Select only sizes with this width.</summary>
-            /// [minimum: 0]
-            /// [maximum: 32767]
             [Google.Apis.Util.RequestParameterAttribute("width", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> Width { get; set; }
 
@@ -18585,9 +18422,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -18604,7 +18438,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -18618,7 +18451,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -18965,9 +18797,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<bool> Active { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -18985,7 +18814,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string PageToken { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -18999,7 +18827,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -19280,9 +19107,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -19299,7 +19123,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -19313,7 +19136,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -20177,9 +19999,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual Google.Apis.Util.Repeatable<string> Ids { get; set; }
 
             /// <summary>Maximum number of results to return.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -20196,7 +20015,6 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual string SearchString { get; set; }
 
             /// <summary>Field by which to sort the list.</summary>
-            /// [default: ID]
             [Google.Apis.Util.RequestParameterAttribute("sortField", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortFieldEnum> SortField { get; set; }
 
@@ -20210,7 +20028,6 @@ namespace Google.Apis.Dfareporting.v3_4
             }
 
             /// <summary>Order of sorted results.</summary>
-            /// [default: ASCENDING]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 

--- a/Src/Generated/Google.Apis.Dialogflow.v2/Google.Apis.Dialogflow.v2.cs
+++ b/Src/Generated/Google.Apis.Dialogflow.v2/Google.Apis.Dialogflow.v2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Dialogflow.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Dialogflow.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Dialogflow.v3beta1/Google.Apis.Dialogflow.v3beta1.cs
+++ b/Src/Generated/Google.Apis.Dialogflow.v3beta1/Google.Apis.Dialogflow.v3beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Dialogflow.v3beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Dialogflow.v3beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Digitalassetlinks.v1/Google.Apis.Digitalassetlinks.v1.cs
+++ b/Src/Generated/Google.Apis.Digitalassetlinks.v1/Google.Apis.Digitalassetlinks.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.Digitalassetlinks.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.Digitalassetlinks.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Discovery.v1/Google.Apis.Discovery.v1.cs
+++ b/Src/Generated/Google.Apis.Discovery.v1/Google.Apis.Discovery.v1.cs
@@ -76,7 +76,6 @@ namespace Google.Apis.Discovery.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -102,7 +101,6 @@ namespace Google.Apis.Discovery.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -290,7 +288,6 @@ namespace Google.Apis.Discovery.v1
             public virtual string Name { get; set; }
 
             /// <summary>Return only the preferred version of an API.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("preferred", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Preferred { get; set; }
 

--- a/Src/Generated/Google.Apis.DisplayVideo.v1/Google.Apis.DisplayVideo.v1.cs
+++ b/Src/Generated/Google.Apis.DisplayVideo.v1/Google.Apis.DisplayVideo.v1.cs
@@ -181,7 +181,6 @@ namespace Google.Apis.DisplayVideo.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -217,7 +216,6 @@ namespace Google.Apis.DisplayVideo.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -497,7 +495,6 @@ namespace Google.Apis.DisplayVideo.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -533,7 +530,6 @@ namespace Google.Apis.DisplayVideo.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DisplayVideo.v1beta/Google.Apis.DisplayVideo.v1beta.cs
+++ b/Src/Generated/Google.Apis.DisplayVideo.v1beta/Google.Apis.DisplayVideo.v1beta.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.DisplayVideo.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.DisplayVideo.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DisplayVideo.v1beta2/Google.Apis.DisplayVideo.v1beta2.cs
+++ b/Src/Generated/Google.Apis.DisplayVideo.v1beta2/Google.Apis.DisplayVideo.v1beta2.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.DisplayVideo.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.DisplayVideo.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DisplayVideo.v1dev/Google.Apis.DisplayVideo.v1dev.cs
+++ b/Src/Generated/Google.Apis.DisplayVideo.v1dev/Google.Apis.DisplayVideo.v1dev.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.DisplayVideo.v1dev
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.DisplayVideo.v1dev
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Dns.v1/Google.Apis.Dns.v1.cs
+++ b/Src/Generated/Google.Apis.Dns.v1/Google.Apis.Dns.v1.cs
@@ -151,7 +151,6 @@ namespace Google.Apis.Dns.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -187,7 +186,6 @@ namespace Google.Apis.Dns.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -561,7 +559,6 @@ namespace Google.Apis.Dns.v1
             public virtual string PageToken { get; set; }
 
             /// <summary>Sorting criterion. The only supported value is change sequence.</summary>
-            /// [default: changeSequence]
             [Google.Apis.Util.RequestParameterAttribute("sortBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortByEnum> SortBy { get; set; }
 
@@ -1044,7 +1041,6 @@ namespace Google.Apis.Dns.v1
             public virtual string PageToken { get; set; }
 
             /// <summary>Sorting criterion. The only supported values are START_TIME and ID.</summary>
-            /// [default: startTime]
             [Google.Apis.Util.RequestParameterAttribute("sortBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortByEnum> SortBy { get; set; }
 

--- a/Src/Generated/Google.Apis.Dns.v1beta2/Google.Apis.Dns.v1beta2.cs
+++ b/Src/Generated/Google.Apis.Dns.v1beta2/Google.Apis.Dns.v1beta2.cs
@@ -151,7 +151,6 @@ namespace Google.Apis.Dns.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -187,7 +186,6 @@ namespace Google.Apis.Dns.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -561,7 +559,6 @@ namespace Google.Apis.Dns.v1beta2
             public virtual string PageToken { get; set; }
 
             /// <summary>Sorting criterion. The only supported value is change sequence.</summary>
-            /// [default: changeSequence]
             [Google.Apis.Util.RequestParameterAttribute("sortBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortByEnum> SortBy { get; set; }
 
@@ -1044,7 +1041,6 @@ namespace Google.Apis.Dns.v1beta2
             public virtual string PageToken { get; set; }
 
             /// <summary>Sorting criterion. The only supported values are START_TIME and ID.</summary>
-            /// [default: startTime]
             [Google.Apis.Util.RequestParameterAttribute("sortBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortByEnum> SortBy { get; set; }
 

--- a/Src/Generated/Google.Apis.Docs.v1/Google.Apis.Docs.v1.cs
+++ b/Src/Generated/Google.Apis.Docs.v1/Google.Apis.Docs.v1.cs
@@ -135,7 +135,6 @@ namespace Google.Apis.Docs.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -171,7 +170,6 @@ namespace Google.Apis.Docs.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Document.v1beta2/Google.Apis.Document.v1beta2.cs
+++ b/Src/Generated/Google.Apis.Document.v1beta2/Google.Apis.Document.v1beta2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Document.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Document.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DomainsRDAP.v1/Google.Apis.DomainsRDAP.v1.cs
+++ b/Src/Generated/Google.Apis.DomainsRDAP.v1/Google.Apis.DomainsRDAP.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.DomainsRDAP.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.DomainsRDAP.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DoubleClickBidManager.v1/Google.Apis.DoubleClickBidManager.v1.cs
+++ b/Src/Generated/Google.Apis.DoubleClickBidManager.v1/Google.Apis.DoubleClickBidManager.v1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.DoubleClickBidManager.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.DoubleClickBidManager.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.DoubleClickBidManager.v1_1/Google.Apis.DoubleClickBidManager.v1_1.cs
+++ b/Src/Generated/Google.Apis.DoubleClickBidManager.v1_1/Google.Apis.DoubleClickBidManager.v1_1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.DoubleClickBidManager.v1_1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.DoubleClickBidManager.v1_1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -423,7 +421,6 @@ namespace Google.Apis.DoubleClickBidManager.v1_1
 
             /// <summary>If true, tries to run the query asynchronously. Only applicable when the frequency is
             /// ONE_TIME.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("asynchronous", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Asynchronous { get; set; }
 
@@ -652,7 +649,6 @@ namespace Google.Apis.DoubleClickBidManager.v1_1
             public virtual long QueryId { get; private set; }
 
             /// <summary>If true, tries to run the query asynchronously.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("asynchronous", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Asynchronous { get; set; }
 

--- a/Src/Generated/Google.Apis.Doubleclicksearch.v2/Google.Apis.Doubleclicksearch.v2.cs
+++ b/Src/Generated/Google.Apis.Doubleclicksearch.v2/Google.Apis.Doubleclicksearch.v2.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.Doubleclicksearch.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.Doubleclicksearch.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -342,20 +340,14 @@ namespace Google.Apis.Doubleclicksearch.v2
             public virtual long EngineAccountId { get; private set; }
 
             /// <summary>Last date (inclusive) on which to retrieve conversions. Format is yyyymmdd.</summary>
-            /// [minimum: 20091101]
-            /// [maximum: 99991231]
             [Google.Apis.Util.RequestParameterAttribute("endDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual int EndDate { get; private set; }
 
             /// <summary>The number of conversions to return per call.</summary>
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("rowCount", Google.Apis.Util.RequestParameterType.Query)]
             public virtual int RowCount { get; private set; }
 
             /// <summary>First date (inclusive) on which to retrieve conversions. Format is yyyymmdd.</summary>
-            /// [minimum: 20091101]
-            /// [maximum: 99991231]
             [Google.Apis.Util.RequestParameterAttribute("startDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual int StartDate { get; private set; }
 
@@ -769,7 +761,6 @@ namespace Google.Apis.Doubleclicksearch.v2
             public virtual string ReportId { get; private set; }
 
             /// <summary>The index of the report fragment to download.</summary>
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("reportFragment", Google.Apis.Util.RequestParameterType.Path)]
             public virtual int ReportFragment { get; private set; }
 

--- a/Src/Generated/Google.Apis.Drive.v2/Google.Apis.Drive.v2.cs
+++ b/Src/Generated/Google.Apis.Drive.v2/Google.Apis.Drive.v2.cs
@@ -192,7 +192,6 @@ namespace Google.Apis.Drive.v2
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -218,7 +217,6 @@ namespace Google.Apis.Drive.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -338,12 +336,10 @@ namespace Google.Apis.Drive.v2
             /// <summary>Whether to count changes outside the My Drive hierarchy. When set to false, changes to files
             /// such as those in the Application Data folder or shared files which have not been added to My Drive will
             /// be omitted from the maxChangeIdCount.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeSubscribed", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeSubscribed { get; set; }
 
             /// <summary>Maximum number of remaining change IDs to count</summary>
-            /// [default: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxChangeIdCount", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxChangeIdCount { get; set; }
 
@@ -591,12 +587,10 @@ namespace Google.Apis.Drive.v2
             public virtual string DriveId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -691,12 +685,10 @@ namespace Google.Apis.Drive.v2
             public virtual string DriveId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -784,18 +776,15 @@ namespace Google.Apis.Drive.v2
             /// <summary>Whether changes should include the file resource if the file is still accessible by the user at
             /// the time of the request, even when a file was removed from the list of changes and there will be no
             /// further change entries for this file.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeCorpusRemovals", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeCorpusRemovals { get; set; }
 
             /// <summary>Whether to include changes indicating that items have been removed from the list of changes,
             /// for example by deletion or loss of access.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
             /// <summary>Whether both My Drive and shared drive items should be included in results.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeItemsFromAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeItemsFromAllDrives { get; set; }
 
@@ -807,18 +796,14 @@ namespace Google.Apis.Drive.v2
             /// <summary>Whether to include changes outside the My Drive hierarchy in the result. When set to false,
             /// changes to files such as those in the Application Data folder or shared files which have not been added
             /// to My Drive are omitted from the result.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeSubscribed", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeSubscribed { get; set; }
 
             /// <summary>Deprecated use includeItemsFromAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeTeamDriveItems", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeTeamDriveItems { get; set; }
 
             /// <summary>Maximum number of changes to return.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -838,12 +823,10 @@ namespace Google.Apis.Drive.v2
             public virtual System.Nullable<long> StartChangeId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -1023,18 +1006,15 @@ namespace Google.Apis.Drive.v2
             /// <summary>Whether changes should include the file resource if the file is still accessible by the user at
             /// the time of the request, even when a file was removed from the list of changes and there will be no
             /// further change entries for this file.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeCorpusRemovals", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeCorpusRemovals { get; set; }
 
             /// <summary>Whether to include changes indicating that items have been removed from the list of changes,
             /// for example by deletion or loss of access.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
             /// <summary>Whether both My Drive and shared drive items should be included in results.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeItemsFromAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeItemsFromAllDrives { get; set; }
 
@@ -1046,18 +1026,14 @@ namespace Google.Apis.Drive.v2
             /// <summary>Whether to include changes outside the My Drive hierarchy in the result. When set to false,
             /// changes to files such as those in the Application Data folder or shared files which have not been added
             /// to My Drive are omitted from the result.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeSubscribed", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeSubscribed { get; set; }
 
             /// <summary>Deprecated use includeItemsFromAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeTeamDriveItems", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeTeamDriveItems { get; set; }
 
             /// <summary>Maximum number of changes to return.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1077,12 +1053,10 @@ namespace Google.Apis.Drive.v2
             public virtual System.Nullable<long> StartChangeId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -1351,7 +1325,6 @@ namespace Google.Apis.Drive.v2
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. If the item's last parent is removed,
             /// the item is placed under its owner's root.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -1497,17 +1470,14 @@ namespace Google.Apis.Drive.v2
             /// request, the child is removed from all current folders and placed in the requested folder. Any other
             /// requests that increase the number of the child's parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -1596,8 +1566,6 @@ namespace Google.Apis.Drive.v2
             public virtual string FolderId { get; private set; }
 
             /// <summary>Maximum number of children to return.</summary>
-            /// [default: 100]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -1796,7 +1764,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>If set, this will succeed when retrieving a deleted comment, and will include any deleted
             /// replies.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
@@ -1930,14 +1897,10 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>If set, all comments and replies, including deleted comments and replies (with content
             /// stripped) will be returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
             /// <summary>The maximum number of discussions to include in the response, used for paging.</summary>
-            /// [default: 20]
-            /// [minimum: 0]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2258,7 +2221,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -2433,9 +2395,6 @@ namespace Google.Apis.Drive.v2
 
 
             /// <summary>Maximum number of shared drives to return.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -2449,7 +2408,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Issue the request as a domain administrator; if set to true, then all shared drives of the
             /// domain in which the requester is an administrator are returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -2586,7 +2544,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -2676,14 +2633,12 @@ namespace Google.Apis.Drive.v2
             public virtual string FileId { get; private set; }
 
             /// <summary>Whether to convert this file to the corresponding Google Docs format.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("convert", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Convert { get; set; }
 
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. Requests that specify more than one
             /// parent fail.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -2693,7 +2648,6 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ocr", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Ocr { get; set; }
 
@@ -2703,17 +2657,14 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether to pin the head revision of the new copy. A file can have a maximum of 200 pinned
             /// revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("pinned", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Pinned { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -2727,7 +2678,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>The visibility of the new file. This parameter is only relevant when the source is not a native
             /// Google Doc and convert=false.</summary>
-            /// [default: DEFAULT]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<VisibilityEnum> Visibility { get; set; }
 
@@ -2905,17 +2855,14 @@ namespace Google.Apis.Drive.v2
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter will only take effect if the item is not in a shared drive. If an item's last parent is
             /// deleted but the item itself is not, the item will be placed under its owner's root.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -2994,7 +2941,6 @@ namespace Google.Apis.Drive.v2
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter will only take effect if the item is not in a shared drive. If an item's last parent is
             /// deleted but the item itself is not, the item will be placed under its owner's root.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -3166,15 +3112,11 @@ namespace Google.Apis.Drive.v2
 
 
             /// <summary>Maximum number of IDs to return.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
             /// <summary>The space in which the IDs can be used to create new files. Supported values are 'drive' and
             /// 'appDataFolder'.</summary>
-            /// [default: drive]
             [Google.Apis.Util.RequestParameterAttribute("space", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Space { get; set; }
 
@@ -3241,7 +3183,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether the user is acknowledging the risk of downloading known malware or other abusive
             /// files.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("acknowledgeAbuse", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> AcknowledgeAbuse { get; set; }
 
@@ -3271,18 +3212,15 @@ namespace Google.Apis.Drive.v2
             public virtual string RevisionId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Deprecated: Use files.update with modifiedDateBehavior=noChange, updateViewedDate=true and an
             /// empty request body.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("updateViewedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UpdateViewedDate { get; set; }
 
@@ -3449,14 +3387,12 @@ namespace Google.Apis.Drive.v2
 
 
             /// <summary>Whether to convert this file to the corresponding Google Docs format.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("convert", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Convert { get; set; }
 
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. Requests that specify more than one
             /// parent fail.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -3466,7 +3402,6 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ocr", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Ocr { get; set; }
 
@@ -3476,17 +3411,14 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether to pin the head revision of the uploaded file. A file can have a maximum of 200 pinned
             /// revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("pinned", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Pinned { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -3499,12 +3431,10 @@ namespace Google.Apis.Drive.v2
             public virtual string TimedTextTrackName { get; set; }
 
             /// <summary>Whether to use the content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
             /// <summary>The visibility of the new file. This parameter is only relevant when convert=false.</summary>
-            /// [default: DEFAULT]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<VisibilityEnum> Visibility { get; set; }
 
@@ -3684,7 +3614,6 @@ namespace Google.Apis.Drive.v2
         {
 
             /// <summary>Data format for the response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -3710,7 +3639,6 @@ namespace Google.Apis.Drive.v2
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -3725,14 +3653,12 @@ namespace Google.Apis.Drive.v2
 
 
             /// <summary>Whether to convert this file to the corresponding Google Docs format.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("convert", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Convert { get; set; }
 
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. Requests that specify more than one
             /// parent fail.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -3742,7 +3668,6 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ocr", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Ocr { get; set; }
 
@@ -3752,17 +3677,14 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether to pin the head revision of the uploaded file. A file can have a maximum of 200 pinned
             /// revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("pinned", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Pinned { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -3775,12 +3697,10 @@ namespace Google.Apis.Drive.v2
             public virtual string TimedTextTrackName { get; set; }
 
             /// <summary>Whether to use the content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
             /// <summary>The visibility of the new file. This parameter is only relevant when convert=false.</summary>
-            /// [default: DEFAULT]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<VisibilityEnum> Visibility { get; set; }
 
@@ -3868,7 +3788,6 @@ namespace Google.Apis.Drive.v2
             public virtual string DriveId { get; set; }
 
             /// <summary>Whether both My Drive and shared drive items should be included in results.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeItemsFromAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeItemsFromAllDrives { get; set; }
 
@@ -3878,14 +3797,11 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Deprecated use includeItemsFromAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeTeamDriveItems", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeTeamDriveItems { get; set; }
 
             /// <summary>The maximum number of files to return per page. Partial or empty result pages are possible even
             /// before the end of the files list has been reached.</summary>
-            /// [default: 100]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -3927,12 +3843,10 @@ namespace Google.Apis.Drive.v2
             public virtual string Spaces { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -4124,7 +4038,6 @@ namespace Google.Apis.Drive.v2
             public virtual string AddParents { get; set; }
 
             /// <summary>This parameter is deprecated and has no function.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("convert", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Convert { get; set; }
 
@@ -4133,7 +4046,6 @@ namespace Google.Apis.Drive.v2
             /// add a single parent, the item is removed from all current folders and placed in the requested folder.
             /// Other requests that increase the number of parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -4180,12 +4092,10 @@ namespace Google.Apis.Drive.v2
             /// additional storage quota, up to a maximum of 200 revisions. For details on how revisions are retained,
             /// see the Drive Help Center. Note that this field is ignored if there is no payload in the
             /// request.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("newRevision", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> NewRevision { get; set; }
 
             /// <summary>Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ocr", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Ocr { get; set; }
 
@@ -4195,7 +4105,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether to pin the new revision. A file can have a maximum of 200 pinned revisions. Note that
             /// this field is ignored if there is no payload in the request.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("pinned", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Pinned { get; set; }
 
@@ -4207,17 +4116,14 @@ namespace Google.Apis.Drive.v2
             /// field to true is equivalent to modifiedDateBehavior=fromBodyOrNow, and false is equivalent to
             /// modifiedDateBehavior=now. To prevent any changes to the modified date set
             /// modifiedDateBehavior=noChange.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("setModifiedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SetModifiedDate { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -4230,12 +4136,10 @@ namespace Google.Apis.Drive.v2
             public virtual string TimedTextTrackName { get; set; }
 
             /// <summary>Whether to update the view date after successfully updating the file.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("updateViewedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UpdateViewedDate { get; set; }
 
             /// <summary>Whether to use the content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -4455,12 +4359,10 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -4556,12 +4458,10 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -4651,12 +4551,10 @@ namespace Google.Apis.Drive.v2
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -4745,7 +4643,6 @@ namespace Google.Apis.Drive.v2
             public virtual string AddParents { get; set; }
 
             /// <summary>This parameter is deprecated and has no function.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("convert", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Convert { get; set; }
 
@@ -4754,7 +4651,6 @@ namespace Google.Apis.Drive.v2
             /// add a single parent, the item is removed from all current folders and placed in the requested folder.
             /// Other requests that increase the number of parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -4801,12 +4697,10 @@ namespace Google.Apis.Drive.v2
             /// additional storage quota, up to a maximum of 200 revisions. For details on how revisions are retained,
             /// see the Drive Help Center. Note that this field is ignored if there is no payload in the
             /// request.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("newRevision", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> NewRevision { get; set; }
 
             /// <summary>Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ocr", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Ocr { get; set; }
 
@@ -4816,7 +4710,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether to pin the new revision. A file can have a maximum of 200 pinned revisions. Note that
             /// this field is ignored if there is no payload in the request.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("pinned", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Pinned { get; set; }
 
@@ -4828,17 +4721,14 @@ namespace Google.Apis.Drive.v2
             /// field to true is equivalent to modifiedDateBehavior=fromBodyOrNow, and false is equivalent to
             /// modifiedDateBehavior=now. To prevent any changes to the modified date set
             /// modifiedDateBehavior=noChange.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("setModifiedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SetModifiedDate { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -4851,12 +4741,10 @@ namespace Google.Apis.Drive.v2
             public virtual string TimedTextTrackName { get; set; }
 
             /// <summary>Whether to update the view date after successfully updating the file.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("updateViewedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UpdateViewedDate { get; set; }
 
             /// <summary>Whether to use the content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -5079,7 +4967,6 @@ namespace Google.Apis.Drive.v2
         {
 
             /// <summary>Data format for the response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -5105,7 +4992,6 @@ namespace Google.Apis.Drive.v2
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -5128,7 +5014,6 @@ namespace Google.Apis.Drive.v2
             public virtual string AddParents { get; set; }
 
             /// <summary>This parameter is deprecated and has no function.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("convert", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Convert { get; set; }
 
@@ -5137,7 +5022,6 @@ namespace Google.Apis.Drive.v2
             /// add a single parent, the item is removed from all current folders and placed in the requested folder.
             /// Other requests that increase the number of parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -5184,12 +5068,10 @@ namespace Google.Apis.Drive.v2
             /// additional storage quota, up to a maximum of 200 revisions. For details on how revisions are retained,
             /// see the Drive Help Center. Note that this field is ignored if there is no payload in the
             /// request.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("newRevision", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> NewRevision { get; set; }
 
             /// <summary>Whether to attempt OCR on .jpg, .png, .gif, or .pdf uploads.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ocr", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Ocr { get; set; }
 
@@ -5199,7 +5081,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether to pin the new revision. A file can have a maximum of 200 pinned revisions. Note that
             /// this field is ignored if there is no payload in the request.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("pinned", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Pinned { get; set; }
 
@@ -5211,17 +5092,14 @@ namespace Google.Apis.Drive.v2
             /// field to true is equivalent to modifiedDateBehavior=fromBodyOrNow, and false is equivalent to
             /// modifiedDateBehavior=now. To prevent any changes to the modified date set
             /// modifiedDateBehavior=noChange.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("setModifiedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SetModifiedDate { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -5234,12 +5112,10 @@ namespace Google.Apis.Drive.v2
             public virtual string TimedTextTrackName { get; set; }
 
             /// <summary>Whether to update the view date after successfully updating the file.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("updateViewedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UpdateViewedDate { get; set; }
 
             /// <summary>Whether to use the content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -5298,7 +5174,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Whether the user is acknowledging the risk of downloading known malware or other abusive
             /// files.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("acknowledgeAbuse", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> AcknowledgeAbuse { get; set; }
 
@@ -5328,18 +5203,15 @@ namespace Google.Apis.Drive.v2
             public virtual string RevisionId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Deprecated: Use files.update with modifiedDateBehavior=noChange, updateViewedDate=true and an
             /// empty request body.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("updateViewedDate", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UpdateViewedDate { get; set; }
 
@@ -5541,7 +5413,6 @@ namespace Google.Apis.Drive.v2
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. If the item's last parent is removed,
             /// the item is placed under its owner's root.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -5687,17 +5558,14 @@ namespace Google.Apis.Drive.v2
             /// request, the child is removed from all current folders and placed in the requested folder. Any other
             /// requests that increase the number of the child's parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -5861,19 +5729,16 @@ namespace Google.Apis.Drive.v2
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -5972,19 +5837,16 @@ namespace Google.Apis.Drive.v2
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -6135,7 +5997,6 @@ namespace Google.Apis.Drive.v2
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. See moveToNewOwnersRoot for
             /// details.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -6145,30 +6006,25 @@ namespace Google.Apis.Drive.v2
             /// enforceSingleParent=true, parents are not changed. If set to false, when enforceSingleParent=false,
             /// existing parents are not changed; however, the file will be added to the new owner's My Drive root
             /// folder, unless it is already in the new owner's My Drive.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("moveToNewOwnersRoot", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> MoveToNewOwnersRoot { get; set; }
 
             /// <summary>Whether to send notification emails when sharing to users or groups. This parameter is ignored
             /// and an email is sent if the role is owner.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("sendNotificationEmails", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SendNotificationEmails { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -6300,8 +6156,6 @@ namespace Google.Apis.Drive.v2
             /// <summary>The maximum number of permissions to return per page. When not set for files in a shared drive,
             /// at most 100 results will be returned. When not set for files that are not in a shared drive, the entire
             /// list will be returned.</summary>
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -6311,19 +6165,16 @@ namespace Google.Apis.Drive.v2
             public virtual string PageToken { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -6442,30 +6293,25 @@ namespace Google.Apis.Drive.v2
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether to remove the expiration date.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("removeExpiration", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> RemoveExpiration { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether changing a role to 'owner' downgrades the current owners to writers. Does nothing if
             /// the specified role is not 'owner'.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("transferOwnership", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> TransferOwnership { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -6590,30 +6436,25 @@ namespace Google.Apis.Drive.v2
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether to remove the expiration date.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("removeExpiration", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> RemoveExpiration { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether changing a role to 'owner' downgrades the current owners to writers. Does nothing if
             /// the specified role is not 'owner'.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("transferOwnership", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> TransferOwnership { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -6753,7 +6594,6 @@ namespace Google.Apis.Drive.v2
             public virtual string PropertyKey { get; private set; }
 
             /// <summary>The visibility of the property.</summary>
-            /// [default: private]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Visibility { get; set; }
 
@@ -6834,7 +6674,6 @@ namespace Google.Apis.Drive.v2
             public virtual string PropertyKey { get; private set; }
 
             /// <summary>The visibility of the property.</summary>
-            /// [default: private]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Visibility { get; set; }
 
@@ -7028,7 +6867,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>The visibility of the property. Allowed values are PRIVATE and PUBLIC. (Default:
             /// PRIVATE)</summary>
-            /// [default: private]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Visibility { get; set; }
 
@@ -7118,7 +6956,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>The visibility of the property. Allowed values are PRIVATE and PUBLIC. (Default:
             /// PRIVATE)</summary>
-            /// [default: private]
             [Google.Apis.Util.RequestParameterAttribute("visibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Visibility { get; set; }
 
@@ -7310,7 +7147,6 @@ namespace Google.Apis.Drive.v2
             public virtual string ReplyId { get; private set; }
 
             /// <summary>If set, this will succeed when retrieving a deleted reply.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
@@ -7474,14 +7310,10 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>If set, all replies, including deleted replies (with content stripped) will be
             /// returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
             /// <summary>The maximum number of replies to include in the response, used for paging.</summary>
-            /// [default: 20]
-            /// [minimum: 0]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -7913,9 +7745,6 @@ namespace Google.Apis.Drive.v2
             public virtual string FileId { get; private set; }
 
             /// <summary>Maximum number of revisions to return.</summary>
-            /// [default: 200]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8213,7 +8042,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the Team Drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -8337,9 +8165,6 @@ namespace Google.Apis.Drive.v2
 
 
             /// <summary>Maximum number of Team Drives to return.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> MaxResults { get; set; }
 
@@ -8353,7 +8178,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Issue the request as a domain administrator; if set to true, then all Team Drives of the domain
             /// in which the requester is an administrator are returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -8439,7 +8263,6 @@ namespace Google.Apis.Drive.v2
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the Team Drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 

--- a/Src/Generated/Google.Apis.Drive.v3/Google.Apis.Drive.v3.cs
+++ b/Src/Generated/Google.Apis.Drive.v3/Google.Apis.Drive.v3.cs
@@ -170,7 +170,6 @@ namespace Google.Apis.Drive.v3
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -196,7 +195,6 @@ namespace Google.Apis.Drive.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -372,12 +370,10 @@ namespace Google.Apis.Drive.v3
             public virtual string DriveId { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -475,12 +471,10 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether changes should include the file resource if the file is still accessible by the user at
             /// the time of the request, even when a file was removed from the list of changes and there will be no
             /// further change entries for this file.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeCorpusRemovals", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeCorpusRemovals { get; set; }
 
             /// <summary>Whether both My Drive and shared drive items should be included in results.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeItemsFromAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeItemsFromAllDrives { get; set; }
 
@@ -491,42 +485,33 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether to include changes indicating that items have been removed from the list of changes,
             /// for example by deletion or loss of access.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeRemoved", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeRemoved { get; set; }
 
             /// <summary>Deprecated use includeItemsFromAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeTeamDriveItems", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeTeamDriveItems { get; set; }
 
             /// <summary>The maximum number of changes to return per page.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
             /// <summary>Whether to restrict the results to changes inside the My Drive hierarchy. This omits changes to
             /// files such as those in the Application Data folder or shared files which have not been added to My
             /// Drive.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("restrictToMyDrive", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> RestrictToMyDrive { get; set; }
 
             /// <summary>A comma-separated list of spaces to query within the user corpus. Supported values are 'drive',
             /// 'appDataFolder' and 'photos'.</summary>
-            /// [default: drive]
             [Google.Apis.Util.RequestParameterAttribute("spaces", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Spaces { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -707,12 +692,10 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether changes should include the file resource if the file is still accessible by the user at
             /// the time of the request, even when a file was removed from the list of changes and there will be no
             /// further change entries for this file.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeCorpusRemovals", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeCorpusRemovals { get; set; }
 
             /// <summary>Whether both My Drive and shared drive items should be included in results.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeItemsFromAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeItemsFromAllDrives { get; set; }
 
@@ -723,42 +706,33 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether to include changes indicating that items have been removed from the list of changes,
             /// for example by deletion or loss of access.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("includeRemoved", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeRemoved { get; set; }
 
             /// <summary>Deprecated use includeItemsFromAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeTeamDriveItems", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeTeamDriveItems { get; set; }
 
             /// <summary>The maximum number of changes to return per page.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
             /// <summary>Whether to restrict the results to changes inside the My Drive hierarchy. This omits changes to
             /// files such as those in the Application Data folder or shared files which have not been added to My
             /// Drive.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("restrictToMyDrive", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> RestrictToMyDrive { get; set; }
 
             /// <summary>A comma-separated list of spaces to query within the user corpus. Supported values are 'drive',
             /// 'appDataFolder' and 'photos'.</summary>
-            /// [default: drive]
             [Google.Apis.Util.RequestParameterAttribute("spaces", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Spaces { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -1142,7 +1116,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether to return deleted comments. Deleted comments will not include their original
             /// content.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
@@ -1217,14 +1190,10 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether to include deleted comments. Deleted comments will not include their original
             /// content.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
             /// <summary>The maximum number of comments to return per page.</summary>
-            /// [default: 20]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -1535,7 +1504,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -1645,9 +1613,6 @@ namespace Google.Apis.Drive.v3
 
 
             /// <summary>Maximum number of shared drives to return.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -1661,7 +1626,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Issue the request as a domain administrator; if set to true, then all shared drives of the
             /// domain in which the requester is an administrator are returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -1798,7 +1762,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -1892,14 +1855,12 @@ namespace Google.Apis.Drive.v3
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. Requests that specify more than one
             /// parent fail.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether to ignore the domain's default visibility settings for the created file. Domain
             /// administrators can choose to make all uploaded files visible to the domain by default; this parameter
             /// bypasses that behavior for the request. Permissions are still inherited from parent folders.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ignoreDefaultVisibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IgnoreDefaultVisibility { get; set; }
 
@@ -1911,7 +1872,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether to set the 'keepForever' field in the new head revision. This is only applicable to
             /// files with binary content in Google Drive. Only 200 revisions for the file can be kept forever. If the
             /// limit is reached, try deleting pinned revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("keepRevisionForever", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> KeepRevisionForever { get; set; }
 
@@ -1920,12 +1880,10 @@ namespace Google.Apis.Drive.v3
             public virtual string OcrLanguage { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -2048,14 +2006,12 @@ namespace Google.Apis.Drive.v3
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. Requests that specify more than one
             /// parent fail.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether to ignore the domain's default visibility settings for the created file. Domain
             /// administrators can choose to make all uploaded files visible to the domain by default; this parameter
             /// bypasses that behavior for the request. Permissions are still inherited from parent folders.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ignoreDefaultVisibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IgnoreDefaultVisibility { get; set; }
 
@@ -2067,7 +2023,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether to set the 'keepForever' field in the new head revision. This is only applicable to
             /// files with binary content in Google Drive. Only 200 revisions for the file can be kept forever. If the
             /// limit is reached, try deleting pinned revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("keepRevisionForever", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> KeepRevisionForever { get; set; }
 
@@ -2076,17 +2031,14 @@ namespace Google.Apis.Drive.v3
             public virtual string OcrLanguage { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether to use the uploaded content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -2218,7 +2170,6 @@ namespace Google.Apis.Drive.v3
         {
 
             /// <summary>Data format for the response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -2244,7 +2195,6 @@ namespace Google.Apis.Drive.v3
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2261,14 +2211,12 @@ namespace Google.Apis.Drive.v3
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. Requests that specify more than one
             /// parent fail.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether to ignore the domain's default visibility settings for the created file. Domain
             /// administrators can choose to make all uploaded files visible to the domain by default; this parameter
             /// bypasses that behavior for the request. Permissions are still inherited from parent folders.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("ignoreDefaultVisibility", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IgnoreDefaultVisibility { get; set; }
 
@@ -2280,7 +2228,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether to set the 'keepForever' field in the new head revision. This is only applicable to
             /// files with binary content in Google Drive. Only 200 revisions for the file can be kept forever. If the
             /// limit is reached, try deleting pinned revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("keepRevisionForever", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> KeepRevisionForever { get; set; }
 
@@ -2289,17 +2236,14 @@ namespace Google.Apis.Drive.v3
             public virtual string OcrLanguage { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether to use the uploaded content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -2358,17 +2302,14 @@ namespace Google.Apis.Drive.v3
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter will only take effect if the item is not in a shared drive. If an item's last parent is
             /// deleted but the item itself is not, the item will be placed under its owner's root.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -2447,7 +2388,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter will only take effect if the item is not in a shared drive. If an item's last parent is
             /// deleted but the item itself is not, the item will be placed under its owner's root.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -2619,15 +2559,11 @@ namespace Google.Apis.Drive.v3
 
 
             /// <summary>The number of IDs to return.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("count", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> Count { get; set; }
 
             /// <summary>The space in which the IDs can be used to create new files. Supported values are 'drive' and
             /// 'appDataFolder'.</summary>
-            /// [default: drive]
             [Google.Apis.Util.RequestParameterAttribute("space", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Space { get; set; }
 
@@ -2694,7 +2630,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether the user is acknowledging the risk of downloading known malware or other abusive files.
             /// This is only applicable when alt=media.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("acknowledgeAbuse", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> AcknowledgeAbuse { get; set; }
 
@@ -2704,12 +2639,10 @@ namespace Google.Apis.Drive.v3
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -2876,7 +2809,6 @@ namespace Google.Apis.Drive.v3
             public virtual string DriveId { get; set; }
 
             /// <summary>Whether both My Drive and shared drive items should be included in results.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeItemsFromAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeItemsFromAllDrives { get; set; }
 
@@ -2886,7 +2818,6 @@ namespace Google.Apis.Drive.v3
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Deprecated use includeItemsFromAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeTeamDriveItems", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeTeamDriveItems { get; set; }
 
@@ -2901,9 +2832,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>The maximum number of files to return per page. Partial or empty result pages are possible even
             /// before the end of the files list has been reached.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -2919,17 +2847,14 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>A comma-separated list of spaces to query within the corpus. Supported values are 'drive',
             /// 'appDataFolder' and 'photos'.</summary>
-            /// [default: drive]
             [Google.Apis.Util.RequestParameterAttribute("spaces", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Spaces { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -3116,7 +3041,6 @@ namespace Google.Apis.Drive.v3
             /// add a single parent, the item is removed from all current folders and placed in the requested folder.
             /// Other requests that increase the number of parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -3128,7 +3052,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether to set the 'keepForever' field in the new head revision. This is only applicable to
             /// files with binary content in Google Drive. Only 200 revisions for the file can be kept forever. If the
             /// limit is reached, try deleting pinned revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("keepRevisionForever", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> KeepRevisionForever { get; set; }
 
@@ -3141,17 +3064,14 @@ namespace Google.Apis.Drive.v3
             public virtual string RemoveParents { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether to use the uploaded content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -3302,7 +3222,6 @@ namespace Google.Apis.Drive.v3
         {
 
             /// <summary>Data format for the response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -3328,7 +3247,6 @@ namespace Google.Apis.Drive.v3
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -3355,7 +3273,6 @@ namespace Google.Apis.Drive.v3
             /// add a single parent, the item is removed from all current folders and placed in the requested folder.
             /// Other requests that increase the number of parents fail, except when the canAddMyDriveParent file
             /// capability is true and a single parent is being added.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -3367,7 +3284,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Whether to set the 'keepForever' field in the new head revision. This is only applicable to
             /// files with binary content in Google Drive. Only 200 revisions for the file can be kept forever. If the
             /// limit is reached, try deleting pinned revisions.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("keepRevisionForever", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> KeepRevisionForever { get; set; }
 
@@ -3380,17 +3296,14 @@ namespace Google.Apis.Drive.v3
             public virtual string RemoveParents { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether to use the uploaded content as indexable text.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useContentAsIndexableText", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseContentAsIndexableText { get; set; }
 
@@ -3449,7 +3362,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether the user is acknowledging the risk of downloading known malware or other abusive files.
             /// This is only applicable when alt=media.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("acknowledgeAbuse", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> AcknowledgeAbuse { get; set; }
 
@@ -3459,12 +3371,10 @@ namespace Google.Apis.Drive.v3
             public virtual string IncludePermissionsForView { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
@@ -3639,7 +3549,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>Set to true to opt in to API behavior that aims for all items to have exactly one parent. This
             /// parameter only takes effect if the item is not in a shared drive. See moveToNewOwnersRoot for
             /// details.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("enforceSingleParent", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> EnforceSingleParent { get; set; }
 
@@ -3649,7 +3558,6 @@ namespace Google.Apis.Drive.v3
             /// parents are not changed. If set to false, when enforceSingleParent=false, existing parents are not
             /// changed; however, the file will be added to the new owner's My Drive root folder, unless it is already
             /// in the new owner's My Drive.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("moveToNewOwnersRoot", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> MoveToNewOwnersRoot { get; set; }
 
@@ -3660,25 +3568,21 @@ namespace Google.Apis.Drive.v3
             public virtual System.Nullable<bool> SendNotificationEmail { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether to transfer ownership to the specified user and downgrade the current owner to a
             /// writer. This parameter is required as an acknowledgement of the side effect.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("transferOwnership", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> TransferOwnership { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -3819,19 +3723,16 @@ namespace Google.Apis.Drive.v3
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -3930,19 +3831,16 @@ namespace Google.Apis.Drive.v3
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -4041,8 +3939,6 @@ namespace Google.Apis.Drive.v3
             /// <summary>The maximum number of permissions to return per page. When not set for files in a shared drive,
             /// at most 100 results will be returned. When not set for files that are not in a shared drive, the entire
             /// list will be returned.</summary>
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -4052,19 +3948,16 @@ namespace Google.Apis.Drive.v3
             public virtual string PageToken { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -4183,30 +4076,25 @@ namespace Google.Apis.Drive.v3
             public virtual string PermissionId { get; private set; }
 
             /// <summary>Whether to remove the expiration date.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("removeExpiration", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> RemoveExpiration { get; set; }
 
             /// <summary>Whether the requesting application supports both My Drives and shared drives.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsAllDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsAllDrives { get; set; }
 
             /// <summary>Deprecated use supportsAllDrives instead.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("supportsTeamDrives", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> SupportsTeamDrives { get; set; }
 
             /// <summary>Whether to transfer ownership to the specified user and downgrade the current owner to a
             /// writer. This parameter is required as an acknowledgement of the side effect.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("transferOwnership", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> TransferOwnership { get; set; }
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if the file ID parameter refers to a shared drive and the requester is an administrator of the
             /// domain to which the shared drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -4509,7 +4397,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether to return deleted replies. Deleted replies will not include their original
             /// content.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
@@ -4599,14 +4486,10 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether to include deleted replies. Deleted replies will not include their original
             /// content.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 
             /// <summary>The maximum number of replies to return per page.</summary>
-            /// [default: 20]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -4890,7 +4773,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Whether the user is acknowledging the risk of downloading known malware or other abusive files.
             /// This is only applicable when alt=media.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("acknowledgeAbuse", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> AcknowledgeAbuse { get; set; }
 
@@ -5016,9 +4898,6 @@ namespace Google.Apis.Drive.v3
             public virtual string FileId { get; private set; }
 
             /// <summary>The maximum number of revisions to return per page.</summary>
-            /// [default: 200]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -5306,7 +5185,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the Team Drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -5365,9 +5243,6 @@ namespace Google.Apis.Drive.v3
 
 
             /// <summary>Maximum number of Team Drives to return.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("pageSize", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> PageSize { get; set; }
 
@@ -5381,7 +5256,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Issue the request as a domain administrator; if set to true, then all Team Drives of the domain
             /// in which the requester is an administrator are returned.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 
@@ -5467,7 +5341,6 @@ namespace Google.Apis.Drive.v3
 
             /// <summary>Issue the request as a domain administrator; if set to true, then the requester will be granted
             /// access if they are an administrator of the domain to which the Team Drive belongs.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("useDomainAdminAccess", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> UseDomainAdminAccess { get; set; }
 

--- a/Src/Generated/Google.Apis.DriveActivity.v2/Google.Apis.DriveActivity.v2.cs
+++ b/Src/Generated/Google.Apis.DriveActivity.v2/Google.Apis.DriveActivity.v2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.DriveActivity.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.DriveActivity.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FactCheckTools.v1alpha1/Google.Apis.FactCheckTools.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.FactCheckTools.v1alpha1/Google.Apis.FactCheckTools.v1alpha1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.FactCheckTools.v1alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.FactCheckTools.v1alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseCloudMessaging.v1/Google.Apis.FirebaseCloudMessaging.v1.cs
+++ b/Src/Generated/Google.Apis.FirebaseCloudMessaging.v1/Google.Apis.FirebaseCloudMessaging.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.FirebaseCloudMessaging.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.FirebaseCloudMessaging.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseDynamicLinks.v1/Google.Apis.FirebaseDynamicLinks.v1.cs
+++ b/Src/Generated/Google.Apis.FirebaseDynamicLinks.v1/Google.Apis.FirebaseDynamicLinks.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.FirebaseDynamicLinks.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.FirebaseDynamicLinks.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseHosting.v1/Google.Apis.FirebaseHosting.v1.cs
+++ b/Src/Generated/Google.Apis.FirebaseHosting.v1/Google.Apis.FirebaseHosting.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.FirebaseHosting.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.FirebaseHosting.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseHosting.v1beta1/Google.Apis.FirebaseHosting.v1beta1.cs
+++ b/Src/Generated/Google.Apis.FirebaseHosting.v1beta1/Google.Apis.FirebaseHosting.v1beta1.cs
@@ -131,7 +131,6 @@ namespace Google.Apis.FirebaseHosting.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -167,7 +166,6 @@ namespace Google.Apis.FirebaseHosting.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseML.v1/Google.Apis.FirebaseML.v1.cs
+++ b/Src/Generated/Google.Apis.FirebaseML.v1/Google.Apis.FirebaseML.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.FirebaseML.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.FirebaseML.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseML.v1beta2/Google.Apis.FirebaseML.v1beta2.cs
+++ b/Src/Generated/Google.Apis.FirebaseML.v1beta2/Google.Apis.FirebaseML.v1beta2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.FirebaseML.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.FirebaseML.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseManagement.v1beta1/Google.Apis.FirebaseManagement.v1beta1.cs
+++ b/Src/Generated/Google.Apis.FirebaseManagement.v1beta1/Google.Apis.FirebaseManagement.v1beta1.cs
@@ -135,7 +135,6 @@ namespace Google.Apis.FirebaseManagement.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -171,7 +170,6 @@ namespace Google.Apis.FirebaseManagement.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.FirebaseRules.v1/Google.Apis.FirebaseRules.v1.cs
+++ b/Src/Generated/Google.Apis.FirebaseRules.v1/Google.Apis.FirebaseRules.v1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.FirebaseRules.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.FirebaseRules.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Firestore.v1/Google.Apis.Firestore.v1.cs
+++ b/Src/Generated/Google.Apis.Firestore.v1/Google.Apis.Firestore.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Firestore.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Firestore.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Firestore.v1beta1/Google.Apis.Firestore.v1beta1.cs
+++ b/Src/Generated/Google.Apis.Firestore.v1beta1/Google.Apis.Firestore.v1beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Firestore.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Firestore.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Firestore.v1beta2/Google.Apis.Firestore.v1beta2.cs
+++ b/Src/Generated/Google.Apis.Firestore.v1beta2/Google.Apis.Firestore.v1beta2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Firestore.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Firestore.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Fitness.v1/Google.Apis.Fitness.v1.cs
+++ b/Src/Generated/Google.Apis.Fitness.v1/Google.Apis.Fitness.v1.cs
@@ -231,7 +231,6 @@ namespace Google.Apis.Fitness.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -267,7 +266,6 @@ namespace Google.Apis.Fitness.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.GameServices.v1/Google.Apis.GameServices.v1.cs
+++ b/Src/Generated/Google.Apis.GameServices.v1/Google.Apis.GameServices.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.GameServices.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.GameServices.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.GameServices.v1beta/Google.Apis.GameServices.v1beta.cs
+++ b/Src/Generated/Google.Apis.GameServices.v1beta/Google.Apis.GameServices.v1beta.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.GameServices.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.GameServices.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Games.v1/Google.Apis.Games.v1.cs
+++ b/Src/Generated/Google.Apis.Games.v1/Google.Apis.Games.v1.cs
@@ -155,7 +155,6 @@ namespace Google.Apis.Games.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -191,7 +190,6 @@ namespace Google.Apis.Games.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.GamesConfiguration.v1configuration/Google.Apis.GamesConfiguration.v1configuration.cs
+++ b/Src/Generated/Google.Apis.GamesConfiguration.v1configuration/Google.Apis.GamesConfiguration.v1configuration.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.GamesConfiguration.v1configuration
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.GamesConfiguration.v1configuration
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -743,7 +741,6 @@ namespace Google.Apis.GamesConfiguration.v1configuration
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -779,7 +776,6 @@ namespace Google.Apis.GamesConfiguration.v1configuration
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.GamesManagement.v1management/Google.Apis.GamesManagement.v1management.cs
+++ b/Src/Generated/Google.Apis.GamesManagement.v1management/Google.Apis.GamesManagement.v1management.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.GamesManagement.v1management
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.GamesManagement.v1management
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Genomics.v1/Google.Apis.Genomics.v1.cs
+++ b/Src/Generated/Google.Apis.Genomics.v1/Google.Apis.Genomics.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Genomics.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Genomics.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Genomics.v1alpha2/Google.Apis.Genomics.v1alpha2.cs
+++ b/Src/Generated/Google.Apis.Genomics.v1alpha2/Google.Apis.Genomics.v1alpha2.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.Genomics.v1alpha2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.Genomics.v1alpha2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Genomics.v2alpha1/Google.Apis.Genomics.v2alpha1.cs
+++ b/Src/Generated/Google.Apis.Genomics.v2alpha1/Google.Apis.Genomics.v2alpha1.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.Genomics.v2alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.Genomics.v2alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Gmail.v1/Google.Apis.Gmail.v1.cs
+++ b/Src/Generated/Google.Apis.Gmail.v1/Google.Apis.Gmail.v1.cs
@@ -187,7 +187,6 @@ namespace Google.Apis.Gmail.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -223,7 +222,6 @@ namespace Google.Apis.Gmail.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -411,7 +409,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -501,7 +498,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -537,7 +533,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -557,7 +552,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -612,7 +606,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -681,7 +674,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -690,7 +682,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string Id { get; private set; }
 
                 /// <summary>The format to return the draft in.</summary>
-                /// [default: full]
                 [Google.Apis.Util.RequestParameterAttribute("format", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<FormatEnum> Format { get; set; }
 
@@ -784,17 +775,14 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Include drafts from `SPAM` and `TRASH` in the results.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("includeSpamTrash", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IncludeSpamTrash { get; set; }
 
                 /// <summary>Maximum number of drafts to return.</summary>
-                /// [default: 100]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -897,7 +885,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -988,7 +975,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -1024,7 +1010,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1044,7 +1029,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1101,7 +1085,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1205,7 +1188,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -1241,7 +1223,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1261,7 +1242,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1341,7 +1321,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1367,7 +1346,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string LabelId { get; set; }
 
                 /// <summary>The maximum number of history records to return.</summary>
-                /// [default: 100]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1502,7 +1480,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1566,7 +1543,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1635,7 +1611,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1702,7 +1677,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1760,7 +1734,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1837,7 +1810,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -1953,7 +1925,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>The user's email address. The special value `me` can be used to indicate the
                     /// authenticated user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -2038,7 +2009,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -2100,7 +2070,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -2164,7 +2133,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -2233,7 +2201,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -2242,7 +2209,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string Id { get; private set; }
 
                 /// <summary>The format to return the message in.</summary>
-                /// [default: full]
                 [Google.Apis.Util.RequestParameterAttribute("format", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<FormatEnum> Format { get; set; }
 
@@ -2355,18 +2321,15 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Mark the email as permanently deleted (not TRASH) and only visible in Google Vault to a
                 /// Vault administrator. Only used for G Suite accounts.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("deleted", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> Deleted { get; set; }
 
                 /// <summary>Source for Gmail's internal date of the message.</summary>
-                /// [default: dateHeader]
                 [Google.Apis.Util.RequestParameterAttribute("internalDateSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<InternalDateSourceEnum> InternalDateSource { get; set; }
 
@@ -2383,13 +2346,11 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>Ignore the Gmail spam classifier decision and never mark this email as SPAM in the
                 /// mailbox.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("neverMarkSpam", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> NeverMarkSpam { get; set; }
 
                 /// <summary>Process calendar invites in the email and add any extracted meetings to the Google Calendar
                 /// for this user.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("processForCalendar", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> ProcessForCalendar { get; set; }
 
@@ -2517,7 +2478,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -2553,7 +2513,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2573,18 +2532,15 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Mark the email as permanently deleted (not TRASH) and only visible in Google Vault to a
                 /// Vault administrator. Only used for G Suite accounts.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("deleted", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> Deleted { get; set; }
 
                 /// <summary>Source for Gmail's internal date of the message.</summary>
-                /// [default: dateHeader]
                 [Google.Apis.Util.RequestParameterAttribute("internalDateSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<InternalDateSourceEnum> InternalDateSource { get; set; }
 
@@ -2601,13 +2557,11 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>Ignore the Gmail spam classifier decision and never mark this email as SPAM in the
                 /// mailbox.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("neverMarkSpam", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> NeverMarkSpam { get; set; }
 
                 /// <summary>Process calendar invites in the email and add any extracted meetings to the Google Calendar
                 /// for this user.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("processForCalendar", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> ProcessForCalendar { get; set; }
 
@@ -2664,18 +2618,15 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Mark the email as permanently deleted (not TRASH) and only visible in Google Vault to a
                 /// Vault administrator. Only used for G Suite accounts.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("deleted", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> Deleted { get; set; }
 
                 /// <summary>Source for Gmail's internal date of the message.</summary>
-                /// [default: receivedTime]
                 [Google.Apis.Util.RequestParameterAttribute("internalDateSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<InternalDateSourceEnum> InternalDateSource { get; set; }
 
@@ -2795,7 +2746,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -2831,7 +2781,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -2851,18 +2800,15 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Mark the email as permanently deleted (not TRASH) and only visible in Google Vault to a
                 /// Vault administrator. Only used for G Suite accounts.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("deleted", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> Deleted { get; set; }
 
                 /// <summary>Source for Gmail's internal date of the message.</summary>
-                /// [default: receivedTime]
                 [Google.Apis.Util.RequestParameterAttribute("internalDateSource", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<InternalDateSourceEnum> InternalDateSource { get; set; }
 
@@ -2926,12 +2872,10 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Include messages from `SPAM` and `TRASH` in the results.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("includeSpamTrash", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IncludeSpamTrash { get; set; }
 
@@ -2940,7 +2884,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual Google.Apis.Util.Repeatable<string> LabelIds { get; set; }
 
                 /// <summary>Maximum number of messages to return.</summary>
-                /// [default: 100]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -3053,7 +2996,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -3128,7 +3070,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -3218,7 +3159,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -3254,7 +3194,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -3274,7 +3213,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -3329,7 +3267,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -3398,7 +3335,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -3522,7 +3458,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -3591,7 +3526,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -3665,7 +3599,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -3734,7 +3667,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -3809,7 +3741,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -3871,7 +3802,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -3940,7 +3870,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4007,7 +3936,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4088,7 +4016,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4154,7 +4081,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4223,7 +4149,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4290,7 +4215,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4387,7 +4311,6 @@ namespace Google.Apis.Gmail.v1
 
                         /// <summary>The user's email address. The special value `me` can be used to indicate the
                         /// authenticated user.</summary>
-                        /// [default: me]
                         [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                         public virtual string UserId { get; private set; }
 
@@ -4473,7 +4396,6 @@ namespace Google.Apis.Gmail.v1
 
                         /// <summary>The user's email address. The special value `me` can be used to indicate the
                         /// authenticated user.</summary>
-                        /// [default: me]
                         [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                         public virtual string UserId { get; private set; }
 
@@ -4561,7 +4483,6 @@ namespace Google.Apis.Gmail.v1
 
                         /// <summary>The user's email address. The special value `me` can be used to indicate the
                         /// authenticated user.</summary>
-                        /// [default: me]
                         [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                         public virtual string UserId { get; private set; }
 
@@ -4638,7 +4559,6 @@ namespace Google.Apis.Gmail.v1
 
                         /// <summary>The user's email address. The special value `me` can be used to indicate the
                         /// authenticated user.</summary>
-                        /// [default: me]
                         [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                         public virtual string UserId { get; private set; }
 
@@ -4711,7 +4631,6 @@ namespace Google.Apis.Gmail.v1
 
                         /// <summary>The user's email address. The special value `me` can be used to indicate the
                         /// authenticated user.</summary>
-                        /// [default: me]
                         [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                         public virtual string UserId { get; private set; }
 
@@ -4807,7 +4726,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4873,7 +4791,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -4944,7 +4861,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -5013,7 +4929,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -5071,7 +4986,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -5152,7 +5066,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -5231,7 +5144,6 @@ namespace Google.Apis.Gmail.v1
 
                     /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                     /// user.</summary>
-                    /// [default: me]
                     [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                     public virtual string UserId { get; private set; }
 
@@ -5299,7 +5211,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5353,7 +5264,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5407,7 +5317,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5461,7 +5370,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5515,7 +5423,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5575,7 +5482,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5637,7 +5543,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5705,7 +5610,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5767,7 +5671,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5829,7 +5732,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>User's email address. The special value "me" can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5912,7 +5814,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5981,7 +5882,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -5990,7 +5890,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual string Id { get; private set; }
 
                 /// <summary>The format to return the messages in.</summary>
-                /// [default: full]
                 [Google.Apis.Util.RequestParameterAttribute("format", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<FormatEnum> Format { get; set; }
 
@@ -6092,12 +5991,10 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
                 /// <summary>Include threads from `SPAM` and `TRASH` in the results.</summary>
-                /// [default: false]
                 [Google.Apis.Util.RequestParameterAttribute("includeSpamTrash", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> IncludeSpamTrash { get; set; }
 
@@ -6106,7 +6003,6 @@ namespace Google.Apis.Gmail.v1
                 public virtual Google.Apis.Util.Repeatable<string> LabelIds { get; set; }
 
                 /// <summary>Maximum number of threads to return.</summary>
-                /// [default: 100]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -6221,7 +6117,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -6296,7 +6191,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -6365,7 +6259,6 @@ namespace Google.Apis.Gmail.v1
 
                 /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
                 /// user.</summary>
-                /// [default: me]
                 [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
                 public virtual string UserId { get; private set; }
 
@@ -6433,7 +6326,6 @@ namespace Google.Apis.Gmail.v1
 
             /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
             /// user.</summary>
-            /// [default: me]
             [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
             public virtual string UserId { get; private set; }
 
@@ -6487,7 +6379,6 @@ namespace Google.Apis.Gmail.v1
 
             /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
             /// user.</summary>
-            /// [default: me]
             [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
             public virtual string UserId { get; private set; }
 
@@ -6543,7 +6434,6 @@ namespace Google.Apis.Gmail.v1
 
             /// <summary>The user's email address. The special value `me` can be used to indicate the authenticated
             /// user.</summary>
-            /// [default: me]
             [Google.Apis.Util.RequestParameterAttribute("userId", Google.Apis.Util.RequestParameterType.Path)]
             public virtual string UserId { get; private set; }
 

--- a/Src/Generated/Google.Apis.GroupsMigration.v1/Google.Apis.GroupsMigration.v1.cs
+++ b/Src/Generated/Google.Apis.GroupsMigration.v1/Google.Apis.GroupsMigration.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.GroupsMigration.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.GroupsMigration.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -387,7 +385,6 @@ namespace Google.Apis.GroupsMigration.v1
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -423,7 +420,6 @@ namespace Google.Apis.GroupsMigration.v1
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Groupssettings.v1/Google.Apis.Groupssettings.v1.cs
+++ b/Src/Generated/Google.Apis.Groupssettings.v1/Google.Apis.Groupssettings.v1.cs
@@ -90,7 +90,6 @@ namespace Google.Apis.Groupssettings.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: atom]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -119,7 +118,6 @@ namespace Google.Apis.Groupssettings.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.HangoutsChat.v1/Google.Apis.HangoutsChat.v1.cs
+++ b/Src/Generated/Google.Apis.HangoutsChat.v1/Google.Apis.HangoutsChat.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.HangoutsChat.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.HangoutsChat.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.HomeGraphService.v1/Google.Apis.HomeGraphService.v1.cs
+++ b/Src/Generated/Google.Apis.HomeGraphService.v1/Google.Apis.HomeGraphService.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.HomeGraphService.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.HomeGraphService.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.IAMCredentials.v1/Google.Apis.IAMCredentials.v1.cs
+++ b/Src/Generated/Google.Apis.IAMCredentials.v1/Google.Apis.IAMCredentials.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.IAMCredentials.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.IAMCredentials.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Iam.v1/Google.Apis.Iam.v1.cs
+++ b/Src/Generated/Google.Apis.Iam.v1/Google.Apis.Iam.v1.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.Iam.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.Iam.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Indexing.v3/Google.Apis.Indexing.v3.cs
+++ b/Src/Generated/Google.Apis.Indexing.v3/Google.Apis.Indexing.v3.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Indexing.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Indexing.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Kgsearch.v1/Google.Apis.Kgsearch.v1.cs
+++ b/Src/Generated/Google.Apis.Kgsearch.v1/Google.Apis.Kgsearch.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.Kgsearch.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.Kgsearch.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Libraryagent.v1/Google.Apis.Libraryagent.v1.cs
+++ b/Src/Generated/Google.Apis.Libraryagent.v1/Google.Apis.Libraryagent.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Libraryagent.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Libraryagent.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Licensing.v1/Google.Apis.Licensing.v1.cs
+++ b/Src/Generated/Google.Apis.Licensing.v1/Google.Apis.Licensing.v1.cs
@@ -90,7 +90,6 @@ namespace Google.Apis.Licensing.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -116,7 +115,6 @@ namespace Google.Apis.Licensing.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -514,9 +512,6 @@ namespace Google.Apis.Licensing.v1
 
             /// <summary>The maxResults query string determines how many entries are returned on each page of a large
             /// response. This is an optional parameter. The value must be a positive number.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -625,9 +620,6 @@ namespace Google.Apis.Licensing.v1
 
             /// <summary>The maxResults query string determines how many entries are returned on each page of a large
             /// response. This is an optional parameter. The value must be a positive number.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 1000]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.Localservices.v1/Google.Apis.Localservices.v1.cs
+++ b/Src/Generated/Google.Apis.Localservices.v1/Google.Apis.Localservices.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.Localservices.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.Localservices.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Logging.v2/Google.Apis.Logging.v2.cs
+++ b/Src/Generated/Google.Apis.Logging.v2/Google.Apis.Logging.v2.cs
@@ -173,7 +173,6 @@ namespace Google.Apis.Logging.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -209,7 +208,6 @@ namespace Google.Apis.Logging.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1.cs
+++ b/Src/Generated/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1alpha1/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1alpha1/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1alpha1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1alp
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1alp
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1beta1/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1beta1/Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1bet
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ManagedServiceforMicrosoftActiveDirectoryConsumerAPI.v1bet
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
+++ b/Src/Generated/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ManufacturerCenter.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ManufacturerCenter.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Monitoring.v1/Google.Apis.Monitoring.v1.cs
+++ b/Src/Generated/Google.Apis.Monitoring.v1/Google.Apis.Monitoring.v1.cs
@@ -129,7 +129,6 @@ namespace Google.Apis.Monitoring.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -165,7 +164,6 @@ namespace Google.Apis.Monitoring.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Monitoring.v3/Google.Apis.Monitoring.v3.cs
+++ b/Src/Generated/Google.Apis.Monitoring.v3/Google.Apis.Monitoring.v3.cs
@@ -137,7 +137,6 @@ namespace Google.Apis.Monitoring.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -173,7 +172,6 @@ namespace Google.Apis.Monitoring.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.NetworkManagement.v1/Google.Apis.NetworkManagement.v1.cs
+++ b/Src/Generated/Google.Apis.NetworkManagement.v1/Google.Apis.NetworkManagement.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.NetworkManagement.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.NetworkManagement.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.NetworkManagement.v1beta1/Google.Apis.NetworkManagement.v1beta1.cs
+++ b/Src/Generated/Google.Apis.NetworkManagement.v1beta1/Google.Apis.NetworkManagement.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.NetworkManagement.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.NetworkManagement.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PagespeedInsights.v5/Google.Apis.PagespeedInsights.v5.cs
+++ b/Src/Generated/Google.Apis.PagespeedInsights.v5/Google.Apis.PagespeedInsights.v5.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.PagespeedInsights.v5
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.PagespeedInsights.v5
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PeopleService.v1/Google.Apis.PeopleService.v1.cs
+++ b/Src/Generated/Google.Apis.PeopleService.v1/Google.Apis.PeopleService.v1.cs
@@ -183,7 +183,6 @@ namespace Google.Apis.PeopleService.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -219,7 +218,6 @@ namespace Google.Apis.PeopleService.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PlayableLocations.v3/Google.Apis.PlayableLocations.v3.cs
+++ b/Src/Generated/Google.Apis.PlayableLocations.v3/Google.Apis.PlayableLocations.v3.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.PlayableLocations.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.PlayableLocations.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Playcustomapp.v1/Google.Apis.Playcustomapp.v1.cs
+++ b/Src/Generated/Google.Apis.Playcustomapp.v1/Google.Apis.Playcustomapp.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Playcustomapp.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Playcustomapp.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -414,7 +412,6 @@ namespace Google.Apis.Playcustomapp.v1
                 public virtual string AccessToken { get; set; }
 
                 /// <summary>Data format for response.</summary>
-                /// [default: json]
                 [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -450,7 +447,6 @@ namespace Google.Apis.Playcustomapp.v1
                 public virtual string OauthToken { get; set; }
 
                 /// <summary>Returns response with indentations and line breaks.</summary>
-                /// [default: true]
                 [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Plus.v1/Google.Apis.Plus.v1.cs
+++ b/Src/Generated/Google.Apis.Plus.v1/Google.Apis.Plus.v1.cs
@@ -116,7 +116,6 @@ namespace Google.Apis.Plus.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -142,7 +141,6 @@ namespace Google.Apis.Plus.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -334,9 +332,6 @@ namespace Google.Apis.Plus.v1
 
             /// <summary>The maximum number of activities to include in the response, which is used for paging. For any
             /// response, the actual number returned might be less than the specified maxResults.</summary>
-            /// [default: 20]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -425,20 +420,15 @@ namespace Google.Apis.Plus.v1
 
             /// <summary>Specify the preferred language to search with. See search language codes for available
             /// values.</summary>
-            /// [default: en-US]
             [Google.Apis.Util.RequestParameterAttribute("language", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Language { get; set; }
 
             /// <summary>The maximum number of activities to include in the response, which is used for paging. For any
             /// response, the actual number returned might be less than the specified maxResults.</summary>
-            /// [default: 10]
-            /// [minimum: 1]
-            /// [maximum: 20]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
             /// <summary>Specifies how to order search results.</summary>
-            /// [default: recent]
             [Google.Apis.Util.RequestParameterAttribute("orderBy", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<OrderByEnum> OrderBy { get; set; }
 
@@ -616,9 +606,6 @@ namespace Google.Apis.Plus.v1
 
             /// <summary>The maximum number of comments to include in the response, which is used for paging. For any
             /// response, the actual number returned might be less than the specified maxResults.</summary>
-            /// [default: 20]
-            /// [minimum: 0]
-            /// [maximum: 500]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -628,7 +615,6 @@ namespace Google.Apis.Plus.v1
             public virtual string PageToken { get; set; }
 
             /// <summary>The order in which to sort the list of comments.</summary>
-            /// [default: ascending]
             [Google.Apis.Util.RequestParameterAttribute("sortOrder", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SortOrderEnum> SortOrder { get; set; }
 
@@ -817,9 +803,6 @@ namespace Google.Apis.Plus.v1
 
             /// <summary>The maximum number of people to include in the response, which is used for paging. For any
             /// response, the actual number returned might be less than the specified maxResults.</summary>
-            /// [default: 100]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -950,9 +933,6 @@ namespace Google.Apis.Plus.v1
 
             /// <summary>The maximum number of people to include in the response, which is used for paging. For any
             /// response, the actual number returned might be less than the specified maxResults.</summary>
-            /// [default: 20]
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -1041,15 +1021,11 @@ namespace Google.Apis.Plus.v1
 
             /// <summary>Specify the preferred language to search with. See search language codes for available
             /// values.</summary>
-            /// [default: en-US]
             [Google.Apis.Util.RequestParameterAttribute("language", Google.Apis.Util.RequestParameterType.Query)]
             public virtual string Language { get; set; }
 
             /// <summary>The maximum number of people to include in the response, which is used for paging. For any
             /// response, the actual number returned might be less than the specified maxResults.</summary>
-            /// [default: 25]
-            /// [minimum: 1]
-            /// [maximum: 50]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.PolicyTroubleshooter.v1/Google.Apis.PolicyTroubleshooter.v1.cs
+++ b/Src/Generated/Google.Apis.PolicyTroubleshooter.v1/Google.Apis.PolicyTroubleshooter.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.PolicyTroubleshooter.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.PolicyTroubleshooter.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PolicyTroubleshooter.v1beta/Google.Apis.PolicyTroubleshooter.v1beta.cs
+++ b/Src/Generated/Google.Apis.PolicyTroubleshooter.v1beta/Google.Apis.PolicyTroubleshooter.v1beta.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.PolicyTroubleshooter.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.PolicyTroubleshooter.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PolyService.v1/Google.Apis.PolyService.v1.cs
+++ b/Src/Generated/Google.Apis.PolyService.v1/Google.Apis.PolyService.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.PolyService.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.PolyService.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PostmasterTools.v1beta1/Google.Apis.PostmasterTools.v1beta1.cs
+++ b/Src/Generated/Google.Apis.PostmasterTools.v1beta1/Google.Apis.PostmasterTools.v1beta1.cs
@@ -111,7 +111,6 @@ namespace Google.Apis.PostmasterTools.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -147,7 +146,6 @@ namespace Google.Apis.PostmasterTools.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Pubsub.v1/Google.Apis.Pubsub.v1.cs
+++ b/Src/Generated/Google.Apis.Pubsub.v1/Google.Apis.Pubsub.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Pubsub.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Pubsub.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Pubsub.v1beta1a/Google.Apis.Pubsub.v1beta1a.cs
+++ b/Src/Generated/Google.Apis.Pubsub.v1beta1a/Google.Apis.Pubsub.v1beta1a.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.Pubsub.v1beta1a
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.Pubsub.v1beta1a
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Pubsub.v1beta2/Google.Apis.Pubsub.v1beta2.cs
+++ b/Src/Generated/Google.Apis.Pubsub.v1beta2/Google.Apis.Pubsub.v1beta2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Pubsub.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Pubsub.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.PubsubLite.v1/Google.Apis.PubsubLite.v1.cs
+++ b/Src/Generated/Google.Apis.PubsubLite.v1/Google.Apis.PubsubLite.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.PubsubLite.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.PubsubLite.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.RealTimeBidding.v1/Google.Apis.RealTimeBidding.v1.cs
+++ b/Src/Generated/Google.Apis.RealTimeBidding.v1/Google.Apis.RealTimeBidding.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.RealTimeBidding.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.RealTimeBidding.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.RecommendationsAI.v1beta1/Google.Apis.RecommendationsAI.v1beta1.cs
+++ b/Src/Generated/Google.Apis.RecommendationsAI.v1beta1/Google.Apis.RecommendationsAI.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.RecommendationsAI.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.RecommendationsAI.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Recommender.v1/Google.Apis.Recommender.v1.cs
+++ b/Src/Generated/Google.Apis.Recommender.v1/Google.Apis.Recommender.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Recommender.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Recommender.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Recommender.v1beta1/Google.Apis.Recommender.v1beta1.cs
+++ b/Src/Generated/Google.Apis.Recommender.v1beta1/Google.Apis.Recommender.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Recommender.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Recommender.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.RemoteBuildExecution.v1/Google.Apis.RemoteBuildExecution.v1.cs
+++ b/Src/Generated/Google.Apis.RemoteBuildExecution.v1/Google.Apis.RemoteBuildExecution.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.RemoteBuildExecution.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.RemoteBuildExecution.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -507,7 +505,6 @@ namespace Google.Apis.RemoteBuildExecution.v1
             public virtual string AccessToken { get; set; }
 
             /// <summary>Data format for response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -543,7 +540,6 @@ namespace Google.Apis.RemoteBuildExecution.v1
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.RemoteBuildExecution.v1alpha/Google.Apis.RemoteBuildExecution.v1alpha.cs
+++ b/Src/Generated/Google.Apis.RemoteBuildExecution.v1alpha/Google.Apis.RemoteBuildExecution.v1alpha.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.RemoteBuildExecution.v1alpha
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.RemoteBuildExecution.v1alpha
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.RemoteBuildExecution.v2/Google.Apis.RemoteBuildExecution.v2.cs
+++ b/Src/Generated/Google.Apis.RemoteBuildExecution.v2/Google.Apis.RemoteBuildExecution.v2.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.RemoteBuildExecution.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.RemoteBuildExecution.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Reseller.v1/Google.Apis.Reseller.v1.cs
+++ b/Src/Generated/Google.Apis.Reseller.v1/Google.Apis.Reseller.v1.cs
@@ -104,7 +104,6 @@ namespace Google.Apis.Reseller.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -130,7 +129,6 @@ namespace Google.Apis.Reseller.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1278,8 +1276,6 @@ namespace Google.Apis.Reseller.v1
 
             /// <summary>When retrieving a large list, the maxResults is the maximum number of results per page. The
             /// nextPageToken value takes you to the next page. The default is 20.</summary>
-            /// [minimum: 1]
-            /// [maximum: 100]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.SQLAdmin.v1beta4/Google.Apis.SQLAdmin.v1beta4.cs
+++ b/Src/Generated/Google.Apis.SQLAdmin.v1beta4/Google.Apis.SQLAdmin.v1beta4.cs
@@ -147,7 +147,6 @@ namespace Google.Apis.SQLAdmin.v1beta4
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -183,7 +182,6 @@ namespace Google.Apis.SQLAdmin.v1beta4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Safebrowsing.v4/Google.Apis.Safebrowsing.v4.cs
+++ b/Src/Generated/Google.Apis.Safebrowsing.v4/Google.Apis.Safebrowsing.v4.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.Safebrowsing.v4
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.Safebrowsing.v4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Script.v1/Google.Apis.Script.v1.cs
+++ b/Src/Generated/Google.Apis.Script.v1/Google.Apis.Script.v1.cs
@@ -221,7 +221,6 @@ namespace Google.Apis.Script.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -257,7 +256,6 @@ namespace Google.Apis.Script.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SearchConsole.v1/Google.Apis.SearchConsole.v1.cs
+++ b/Src/Generated/Google.Apis.SearchConsole.v1/Google.Apis.SearchConsole.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.SearchConsole.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.SearchConsole.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SecretManager.v1/Google.Apis.SecretManager.v1.cs
+++ b/Src/Generated/Google.Apis.SecretManager.v1/Google.Apis.SecretManager.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.SecretManager.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.SecretManager.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SecretManager.v1beta1/Google.Apis.SecretManager.v1beta1.cs
+++ b/Src/Generated/Google.Apis.SecretManager.v1beta1/Google.Apis.SecretManager.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.SecretManager.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.SecretManager.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SecurityCommandCenter.v1/Google.Apis.SecurityCommandCenter.v1.cs
+++ b/Src/Generated/Google.Apis.SecurityCommandCenter.v1/Google.Apis.SecurityCommandCenter.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.SecurityCommandCenter.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.SecurityCommandCenter.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SecurityCommandCenter.v1beta1/Google.Apis.SecurityCommandCenter.v1beta1.cs
+++ b/Src/Generated/Google.Apis.SecurityCommandCenter.v1beta1/Google.Apis.SecurityCommandCenter.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.SecurityCommandCenter.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.SecurityCommandCenter.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SecurityCommandCenter.v1beta2/Google.Apis.SecurityCommandCenter.v1beta2.cs
+++ b/Src/Generated/Google.Apis.SecurityCommandCenter.v1beta2/Google.Apis.SecurityCommandCenter.v1beta2.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.SecurityCommandCenter.v1beta2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.SecurityCommandCenter.v1beta2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SemanticTile.v1/Google.Apis.SemanticTile.v1.cs
+++ b/Src/Generated/Google.Apis.SemanticTile.v1/Google.Apis.SemanticTile.v1.cs
@@ -99,7 +99,6 @@ namespace Google.Apis.SemanticTile.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -135,7 +134,6 @@ namespace Google.Apis.SemanticTile.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceConsumerManagement.v1/Google.Apis.ServiceConsumerManagement.v1.cs
+++ b/Src/Generated/Google.Apis.ServiceConsumerManagement.v1/Google.Apis.ServiceConsumerManagement.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.ServiceConsumerManagement.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.ServiceConsumerManagement.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceConsumerManagement.v1beta1/Google.Apis.ServiceConsumerManagement.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ServiceConsumerManagement.v1beta1/Google.Apis.ServiceConsumerManagement.v1beta1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.ServiceConsumerManagement.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.ServiceConsumerManagement.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceControl.v1/Google.Apis.ServiceControl.v1.cs
+++ b/Src/Generated/Google.Apis.ServiceControl.v1/Google.Apis.ServiceControl.v1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.ServiceControl.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.ServiceControl.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceControl.v2/Google.Apis.ServiceControl.v2.cs
+++ b/Src/Generated/Google.Apis.ServiceControl.v2/Google.Apis.ServiceControl.v2.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.ServiceControl.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.ServiceControl.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceDirectory.v1beta1/Google.Apis.ServiceDirectory.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ServiceDirectory.v1beta1/Google.Apis.ServiceDirectory.v1beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ServiceDirectory.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ServiceDirectory.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceManagement.v1/Google.Apis.ServiceManagement.v1.cs
+++ b/Src/Generated/Google.Apis.ServiceManagement.v1/Google.Apis.ServiceManagement.v1.cs
@@ -131,7 +131,6 @@ namespace Google.Apis.ServiceManagement.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -167,7 +166,6 @@ namespace Google.Apis.ServiceManagement.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceNetworking.v1/Google.Apis.ServiceNetworking.v1.cs
+++ b/Src/Generated/Google.Apis.ServiceNetworking.v1/Google.Apis.ServiceNetworking.v1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.ServiceNetworking.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.ServiceNetworking.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceNetworking.v1beta/Google.Apis.ServiceNetworking.v1beta.cs
+++ b/Src/Generated/Google.Apis.ServiceNetworking.v1beta/Google.Apis.ServiceNetworking.v1beta.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.ServiceNetworking.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.ServiceNetworking.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceUsage.v1/Google.Apis.ServiceUsage.v1.cs
+++ b/Src/Generated/Google.Apis.ServiceUsage.v1/Google.Apis.ServiceUsage.v1.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.ServiceUsage.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.ServiceUsage.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ServiceUsage.v1beta1/Google.Apis.ServiceUsage.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ServiceUsage.v1beta1/Google.Apis.ServiceUsage.v1beta1.cs
@@ -125,7 +125,6 @@ namespace Google.Apis.ServiceUsage.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -161,7 +160,6 @@ namespace Google.Apis.ServiceUsage.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Sheets.v4/Google.Apis.Sheets.v4.cs
+++ b/Src/Generated/Google.Apis.Sheets.v4/Google.Apis.Sheets.v4.cs
@@ -135,7 +135,6 @@ namespace Google.Apis.Sheets.v4
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -171,7 +170,6 @@ namespace Google.Apis.Sheets.v4
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ShoppingContent.v2/Google.Apis.ShoppingContent.v2.cs
+++ b/Src/Generated/Google.Apis.ShoppingContent.v2/Google.Apis.ShoppingContent.v2.cs
@@ -146,7 +146,6 @@ namespace Google.Apis.ShoppingContent.v2
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -172,7 +171,6 @@ namespace Google.Apis.ShoppingContent.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -489,7 +487,6 @@ namespace Google.Apis.ShoppingContent.v2
             public virtual System.Nullable<bool> DryRun { get; set; }
 
             /// <summary>Flag to delete sub-accounts with products. The default value is false.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("force", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Force { get; set; }
 

--- a/Src/Generated/Google.Apis.ShoppingContent.v2_1/Google.Apis.ShoppingContent.v2_1.cs
+++ b/Src/Generated/Google.Apis.ShoppingContent.v2_1/Google.Apis.ShoppingContent.v2_1.cs
@@ -170,7 +170,6 @@ namespace Google.Apis.ShoppingContent.v2_1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -196,7 +195,6 @@ namespace Google.Apis.ShoppingContent.v2_1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -494,7 +492,6 @@ namespace Google.Apis.ShoppingContent.v2_1
             public virtual ulong AccountId { get; private set; }
 
             /// <summary>Flag to delete sub-accounts with products. The default value is false.</summary>
-            /// [default: false]
             [Google.Apis.Util.RequestParameterAttribute("force", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> Force { get; set; }
 

--- a/Src/Generated/Google.Apis.SiteVerification.v1/Google.Apis.SiteVerification.v1.cs
+++ b/Src/Generated/Google.Apis.SiteVerification.v1/Google.Apis.SiteVerification.v1.cs
@@ -96,7 +96,6 @@ namespace Google.Apis.SiteVerification.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -122,7 +121,6 @@ namespace Google.Apis.SiteVerification.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: false]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Slides.v1/Google.Apis.Slides.v1.cs
+++ b/Src/Generated/Google.Apis.Slides.v1/Google.Apis.Slides.v1.cs
@@ -147,7 +147,6 @@ namespace Google.Apis.Slides.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -183,7 +182,6 @@ namespace Google.Apis.Slides.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Spanner.v1/Google.Apis.Spanner.v1.cs
+++ b/Src/Generated/Google.Apis.Spanner.v1/Google.Apis.Spanner.v1.cs
@@ -121,7 +121,6 @@ namespace Google.Apis.Spanner.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -157,7 +156,6 @@ namespace Google.Apis.Spanner.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Speech.v1/Google.Apis.Speech.v1.cs
+++ b/Src/Generated/Google.Apis.Speech.v1/Google.Apis.Speech.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.Speech.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.Speech.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Speech.v1p1beta1/Google.Apis.Speech.v1p1beta1.cs
+++ b/Src/Generated/Google.Apis.Speech.v1p1beta1/Google.Apis.Speech.v1p1beta1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.Speech.v1p1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.Speech.v1p1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Speech.v2beta1/Google.Apis.Speech.v2beta1.cs
+++ b/Src/Generated/Google.Apis.Speech.v2beta1/Google.Apis.Speech.v2beta1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Speech.v2beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Speech.v2beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
+++ b/Src/Generated/Google.Apis.Storage.v1/Google.Apis.Storage.v1.cs
@@ -142,7 +142,6 @@ namespace Google.Apis.Storage.v1
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -168,7 +167,6 @@ namespace Google.Apis.Storage.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -1108,7 +1106,6 @@ namespace Google.Apis.Storage.v1
 
             /// <summary>The IAM policy format version to be returned. If the optionsRequestedPolicyVersion is for an
             /// older version that doesn't support part of the requested IAM policy, the request fails.</summary>
-            /// [minimum: 1]
             [Google.Apis.Util.RequestParameterAttribute("optionsRequestedPolicyVersion", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<int> OptionsRequestedPolicyVersion { get; set; }
 
@@ -1384,8 +1381,6 @@ namespace Google.Apis.Storage.v1
 
             /// <summary>Maximum number of buckets to return in a single response. The service will use this parameter
             /// or 1,000 items, whichever is smaller.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -5373,7 +5368,6 @@ namespace Google.Apis.Storage.v1
         {
 
             /// <summary>Data format for the response.</summary>
-            /// [default: json]
             [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -5399,7 +5393,6 @@ namespace Google.Apis.Storage.v1
             public virtual string OauthToken { get; set; }
 
             /// <summary>Returns response with indentations and line breaks.</summary>
-            /// [default: true]
             [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -5584,8 +5577,6 @@ namespace Google.Apis.Storage.v1
             /// <summary>Maximum number of items plus prefixes to return in a single page of responses. As duplicate
             /// prefixes are omitted, fewer total results may be returned than requested. The service will use this
             /// parameter or 1,000 items, whichever is smaller.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -6905,8 +6896,6 @@ namespace Google.Apis.Storage.v1
             /// <summary>Maximum number of items plus prefixes to return in a single page of responses. As duplicate
             /// prefixes are omitted, fewer total results may be returned than requested. The service will use this
             /// parameter or 1,000 items, whichever is smaller.</summary>
-            /// [default: 1000]
-            /// [minimum: 0]
             [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<long> MaxResults { get; set; }
 
@@ -7392,8 +7381,6 @@ namespace Google.Apis.Storage.v1
                 /// by the number of distinct service accounts in the response. If the number of service accounts in a
                 /// single response is too high, the page will truncated and a next page token will be
                 /// returned.</summary>
-                /// [default: 250]
-                /// [minimum: 0]
                 [Google.Apis.Util.RequestParameterAttribute("maxResults", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<long> MaxResults { get; set; }
 

--- a/Src/Generated/Google.Apis.Storagetransfer.v1/Google.Apis.Storagetransfer.v1.cs
+++ b/Src/Generated/Google.Apis.Storagetransfer.v1/Google.Apis.Storagetransfer.v1.cs
@@ -117,7 +117,6 @@ namespace Google.Apis.Storagetransfer.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -153,7 +152,6 @@ namespace Google.Apis.Storagetransfer.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.StreetViewPublish.v1/Google.Apis.StreetViewPublish.v1.cs
+++ b/Src/Generated/Google.Apis.StreetViewPublish.v1/Google.Apis.StreetViewPublish.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.StreetViewPublish.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.StreetViewPublish.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SystemsManagement.v1/Google.Apis.SystemsManagement.v1.cs
+++ b/Src/Generated/Google.Apis.SystemsManagement.v1/Google.Apis.SystemsManagement.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.SystemsManagement.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.SystemsManagement.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.SystemsManagement.v1beta/Google.Apis.SystemsManagement.v1beta.cs
+++ b/Src/Generated/Google.Apis.SystemsManagement.v1beta/Google.Apis.SystemsManagement.v1beta.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.SystemsManagement.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.SystemsManagement.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.TPU.v1/Google.Apis.TPU.v1.cs
+++ b/Src/Generated/Google.Apis.TPU.v1/Google.Apis.TPU.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.TPU.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.TPU.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.TPU.v1alpha1/Google.Apis.TPU.v1alpha1.cs
+++ b/Src/Generated/Google.Apis.TPU.v1alpha1/Google.Apis.TPU.v1alpha1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.TPU.v1alpha1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.TPU.v1alpha1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.TagManager.v1/Google.Apis.TagManager.v1.cs
+++ b/Src/Generated/Google.Apis.TagManager.v1/Google.Apis.TagManager.v1.cs
@@ -147,7 +147,6 @@ namespace Google.Apis.TagManager.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -183,7 +182,6 @@ namespace Google.Apis.TagManager.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 
@@ -3145,12 +3143,10 @@ namespace Google.Apis.TagManager.v1
                     public virtual string ContainerId { get; private set; }
 
                     /// <summary>Retrieve headers only when true.</summary>
-                    /// [default: false]
                     [Google.Apis.Util.RequestParameterAttribute("headers", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<bool> Headers { get; set; }
 
                     /// <summary>Also retrieve deleted (archived) versions when true.</summary>
-                    /// [default: false]
                     [Google.Apis.Util.RequestParameterAttribute("includeDeleted", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<bool> IncludeDeleted { get; set; }
 

--- a/Src/Generated/Google.Apis.TagManager.v2/Google.Apis.TagManager.v2.cs
+++ b/Src/Generated/Google.Apis.TagManager.v2/Google.Apis.TagManager.v2.cs
@@ -147,7 +147,6 @@ namespace Google.Apis.TagManager.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -183,7 +182,6 @@ namespace Google.Apis.TagManager.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Tasks.v1/Google.Apis.Tasks.v1.cs
+++ b/Src/Generated/Google.Apis.Tasks.v1/Google.Apis.Tasks.v1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.Tasks.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.Tasks.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Testing.v1/Google.Apis.Testing.v1.cs
+++ b/Src/Generated/Google.Apis.Testing.v1/Google.Apis.Testing.v1.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.Testing.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.Testing.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Texttospeech.v1/Google.Apis.Texttospeech.v1.cs
+++ b/Src/Generated/Google.Apis.Texttospeech.v1/Google.Apis.Texttospeech.v1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.Texttospeech.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.Texttospeech.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Texttospeech.v1beta1/Google.Apis.Texttospeech.v1beta1.cs
+++ b/Src/Generated/Google.Apis.Texttospeech.v1beta1/Google.Apis.Texttospeech.v1beta1.cs
@@ -113,7 +113,6 @@ namespace Google.Apis.Texttospeech.v1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -149,7 +148,6 @@ namespace Google.Apis.Texttospeech.v1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.ToolResults.v1beta3/Google.Apis.ToolResults.v1beta3.cs
+++ b/Src/Generated/Google.Apis.ToolResults.v1beta3/Google.Apis.ToolResults.v1beta3.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.ToolResults.v1beta3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.ToolResults.v1beta3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.TrafficDirectorService.v2/Google.Apis.TrafficDirectorService.v2.cs
+++ b/Src/Generated/Google.Apis.TrafficDirectorService.v2/Google.Apis.TrafficDirectorService.v2.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.TrafficDirectorService.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.TrafficDirectorService.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Translate.v2/Google.Apis.Translate.v2.cs
+++ b/Src/Generated/Google.Apis.Translate.v2/Google.Apis.Translate.v2.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.Translate.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -163,12 +162,10 @@ namespace Google.Apis.Translate.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Pretty-print response.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("pp", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> Pp { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Translate.v3/Google.Apis.Translate.v3.cs
+++ b/Src/Generated/Google.Apis.Translate.v3/Google.Apis.Translate.v3.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Translate.v3
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Translate.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Translate.v3beta1/Google.Apis.Translate.v3beta1.cs
+++ b/Src/Generated/Google.Apis.Translate.v3beta1/Google.Apis.Translate.v3beta1.cs
@@ -115,7 +115,6 @@ namespace Google.Apis.Translate.v3beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -151,7 +150,6 @@ namespace Google.Apis.Translate.v3beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Vault.v1/Google.Apis.Vault.v1.cs
+++ b/Src/Generated/Google.Apis.Vault.v1/Google.Apis.Vault.v1.cs
@@ -119,7 +119,6 @@ namespace Google.Apis.Vault.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -155,7 +154,6 @@ namespace Google.Apis.Vault.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Verifiedaccess.v1/Google.Apis.Verifiedaccess.v1.cs
+++ b/Src/Generated/Google.Apis.Verifiedaccess.v1/Google.Apis.Verifiedaccess.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Verifiedaccess.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Verifiedaccess.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Vision.v1/Google.Apis.Vision.v1.cs
+++ b/Src/Generated/Google.Apis.Vision.v1/Google.Apis.Vision.v1.cs
@@ -131,7 +131,6 @@ namespace Google.Apis.Vision.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -167,7 +166,6 @@ namespace Google.Apis.Vision.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Vision.v1p1beta1/Google.Apis.Vision.v1p1beta1.cs
+++ b/Src/Generated/Google.Apis.Vision.v1p1beta1/Google.Apis.Vision.v1p1beta1.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.Vision.v1p1beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.Vision.v1p1beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Vision.v1p2beta1/Google.Apis.Vision.v1p2beta1.cs
+++ b/Src/Generated/Google.Apis.Vision.v1p2beta1/Google.Apis.Vision.v1p2beta1.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.Vision.v1p2beta1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.Vision.v1p2beta1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.WebSecurityScanner.v1/Google.Apis.WebSecurityScanner.v1.cs
+++ b/Src/Generated/Google.Apis.WebSecurityScanner.v1/Google.Apis.WebSecurityScanner.v1.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.WebSecurityScanner.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.WebSecurityScanner.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.WebSecurityScanner.v1alpha/Google.Apis.WebSecurityScanner.v1alpha.cs
+++ b/Src/Generated/Google.Apis.WebSecurityScanner.v1alpha/Google.Apis.WebSecurityScanner.v1alpha.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.WebSecurityScanner.v1alpha
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.WebSecurityScanner.v1alpha
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.WebSecurityScanner.v1beta/Google.Apis.WebSecurityScanner.v1beta.cs
+++ b/Src/Generated/Google.Apis.WebSecurityScanner.v1beta/Google.Apis.WebSecurityScanner.v1beta.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.WebSecurityScanner.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.WebSecurityScanner.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.cs
+++ b/Src/Generated/Google.Apis.Webfonts.v1/Google.Apis.Webfonts.v1.cs
@@ -95,7 +95,6 @@ namespace Google.Apis.Webfonts.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -131,7 +130,6 @@ namespace Google.Apis.Webfonts.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Webmasters.v3/Google.Apis.Webmasters.v3.cs
+++ b/Src/Generated/Google.Apis.Webmasters.v3/Google.Apis.Webmasters.v3.cs
@@ -104,7 +104,6 @@ namespace Google.Apis.Webmasters.v3
         }
 
         /// <summary>Data format for the response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -130,7 +129,6 @@ namespace Google.Apis.Webmasters.v3
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.Workflows.v1beta/Google.Apis.Workflows.v1beta.cs
+++ b/Src/Generated/Google.Apis.Workflows.v1beta/Google.Apis.Workflows.v1beta.cs
@@ -109,7 +109,6 @@ namespace Google.Apis.Workflows.v1beta
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -145,7 +144,6 @@ namespace Google.Apis.Workflows.v1beta
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.YouTubeAnalytics.v1/Google.Apis.YouTubeAnalytics.v1.cs
+++ b/Src/Generated/Google.Apis.YouTubeAnalytics.v1/Google.Apis.YouTubeAnalytics.v1.cs
@@ -92,7 +92,6 @@ namespace Google.Apis.YouTubeAnalytics.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -128,7 +127,6 @@ namespace Google.Apis.YouTubeAnalytics.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.YouTubeAnalytics.v2/Google.Apis.YouTubeAnalytics.v2.cs
+++ b/Src/Generated/Google.Apis.YouTubeAnalytics.v2/Google.Apis.YouTubeAnalytics.v2.cs
@@ -141,7 +141,6 @@ namespace Google.Apis.YouTubeAnalytics.v2
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -177,7 +176,6 @@ namespace Google.Apis.YouTubeAnalytics.v2
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 

--- a/Src/Generated/Google.Apis.YouTubeReporting.v1/Google.Apis.YouTubeReporting.v1.cs
+++ b/Src/Generated/Google.Apis.YouTubeReporting.v1/Google.Apis.YouTubeReporting.v1.cs
@@ -123,7 +123,6 @@ namespace Google.Apis.YouTubeReporting.v1
         public virtual string AccessToken { get; set; }
 
         /// <summary>Data format for response.</summary>
-        /// [default: json]
         [Google.Apis.Util.RequestParameterAttribute("alt", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<AltEnum> Alt { get; set; }
 
@@ -159,7 +158,6 @@ namespace Google.Apis.YouTubeReporting.v1
         public virtual string OauthToken { get; set; }
 
         /// <summary>Returns response with indentations and line breaks.</summary>
-        /// [default: true]
         [Google.Apis.Util.RequestParameterAttribute("prettyPrint", Google.Apis.Util.RequestParameterType.Query)]
         public virtual System.Nullable<bool> PrettyPrint { get; set; }
 


### PR DESCRIPTION
First commit is the generator change; second commit is the impact.

Basically I don't want to have to reproduce these comments in the C# generator.