### PR TITLE
Change formatting of the feature list array

### DIFF
--- a/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.cs.tmpl
+++ b/ClientGenerator/src/googleapis/codegen/languages/csharp/default/templates/___package_name___/___package_name___.cs.tmpl
@@ -32,10 +32,10 @@ public {{ api.className }}Service(Google.Apis.Services.BaseClientService.Initial
 /// <summary>Gets the service supported features.</summary>
 public override System.Collections.Generic.IList<string> Features => {% noeol %}
 {% if api.features %}
-new string[] {{% parameter_list %}
+new string[] { {% parameter_list %}
 {% for feature in api.features %}
 {% parameter %}"{{ feature }}"{% end_parameter %}
-{% endfor %}{% end_parameter_list %}};
+{% endfor %}, {% end_parameter_list %} };
 {% else %}
 new string[0];
 {% endif %}

--- a/Src/Generated/Google.Apis.Translate.v2/Google.Apis.Translate.v2.cs
+++ b/Src/Generated/Google.Apis.Translate.v2/Google.Apis.Translate.v2.cs
@@ -35,7 +35,7 @@ namespace Google.Apis.Translate.v2
         }
 
         /// <summary>Gets the service supported features.</summary>
-        public override System.Collections.Generic.IList<string> Features => new string[] {"dataWrapper"};
+        public override System.Collections.Generic.IList<string> Features => new string[] { "dataWrapper", };
 
         /// <summary>Gets the service name.</summary>
         public override string Name => "translate";


### PR DESCRIPTION
- Spaces at the start and end
- Comma at the end

This makes it easier to reproduce in the C# generator.

This commit also regenerates all APIs - which only changes Translate v2 as that's the only API to include any features (in the Discovery doc sense).