### PR TITLE
Use the GCE_METADATA_HOST environment variable for all metadata access

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenFakes.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/OidcTokenFakes.cs
@@ -126,7 +126,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
             }
             // The way we have for identifying that a response came from the compute metadata server identity endpoint
             // is through the request URI, and that's how we know to not build a TokenResponse, so we need to set that here.
-            request.RequestUri = new Uri(GoogleAuthConsts.ComputeOidcTokenUrl + request.RequestUri.Query);
+            request.RequestUri = new Uri(GoogleAuthConsts.EffectiveComputeOidcTokenUrl + request.RequestUri.Query);
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 // The Compute metadata server identity endpoint only sends the raw id_token in the response.

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Responses/TokenResponseTests.cs
@@ -169,7 +169,7 @@ namespace Google.Apis.Auth.Tests.OAuth2.Responses
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(OidcComputeSuccessMessageHandler.FirstCallToken),
-                RequestMessage = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.ComputeOidcTokenUrl)
+                RequestMessage = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.EffectiveComputeOidcTokenUrl)
             };
 
             MockClock clock = new MockClock(new DateTime(2020, 02, 02, 2, 20, 20, DateTimeKind.Utc));

--- a/Src/Support/Google.Apis.Auth/OAuth2/Responses/TokenResponse.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Responses/TokenResponse.cs
@@ -144,7 +144,7 @@ namespace Google.Apis.Auth.OAuth2.Responses
                 TokenResponse newToken;
                 // GCE's metadata server identity endpoint doesn't return a TokenResponse but the raw
                 // id_token, so we build a TokenResponse from that.
-                if (response.RequestMessage?.RequestUri?.AbsoluteUri.StartsWith(GoogleAuthConsts.ComputeOidcTokenUrl) == true)
+                if (response.RequestMessage?.RequestUri?.AbsoluteUri.StartsWith(GoogleAuthConsts.EffectiveComputeOidcTokenUrl) == true)
                 {
                     newToken = new TokenResponse
                     {


### PR DESCRIPTION
Unfortunately ComputeTokenUrl is public, so we can't guarantee at
compile-time that we're not using that anywhere else, but I've
checked it via search in Visual Studio.

I haven't added any tests, but I'm happy to do so if you'd like. Suggestions for *what* you'd like to see tests for would be welcome...