### PR TITLE
Cleans up and makes Google.Apis.Auth.AspNetCore3.IntegrationTests clearer.

### DIFF
--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/ClientInfo.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/ClientInfo.cs
@@ -21,24 +21,34 @@ using System.IO;
 namespace Google.Apis.Auth.AspNetCore3.IntegrationTests
 {
     /// <summary>
-    /// Client auth information, loaded from a Google user credential json file.
-    /// Set the TEST_CLIENT_SECRET_FILENAME environment variable to point to the credential file.
+    /// OAuth 2.0 client ID used by this application loaded from a client ID json file.
+    /// Set the TEST_WEB_CLIENT_SECRET_FILENAME environment variable to point to the client ID json file.
     /// </summary>
     public class ClientInfo
     {
+        private const string ClientSecretFilenameVariable = "TEST_WEB_CLIENT_SECRET_FILENAME";
+
         public static ClientInfo Load()
         {
-            const string ClientSecretFilenameVariable = "TEST_WEB_CLIENT_SECRET_FILENAME";
             string clientSecretFilename = Environment.GetEnvironmentVariable(ClientSecretFilenameVariable);
             if (string.IsNullOrEmpty(clientSecretFilename))
             {
                 throw new InvalidOperationException($"Please set the {ClientSecretFilenameVariable} environment variable before running tests.");
             }
-            // This MUST be a "web" credential, not an "installed app" credential.
+
             var secrets = JObject.Parse(File.ReadAllText(clientSecretFilename))["web"];
+
+            // Check that this is a "web" client ID, not any other type of client ID like "installed app".
+            // The "web" element should have been present in the json so secrets value shouldn't be null.
+            if (secrets is null)
+            {
+                throw new InvalidOperationException(
+                    $"The type of the OAuth2 client ID specified in {ClientSecretFilenameVariable} should be Web Application. You can read more about setting up OAuth2 client IDs here: https://support.google.com/cloud/answer/6158849?hl=en");
+            }
             var projectId = secrets["project_id"].Value<string>();
             var clientId = secrets["client_id"].Value<string>();
             var clientSecret = secrets["client_secret"].Value<string>();
+
             return new ClientInfo(projectId, clientId, clientSecret);
         }
 

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Google.Apis.Auth.AspNetCore3.IntegrationTests.csproj
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Google.Apis.Auth.AspNetCore3.IntegrationTests.csproj
@@ -10,11 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Services\" />
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Google.Apis.Auth.AspNetCore3\Google.Apis.Auth.AspNetCore3.csproj" />
   </ItemGroup>
 

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Program.cs
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Program.cs
@@ -32,7 +32,6 @@ namespace Google.Apis.Auth.AspNetCore3.IntegrationTests
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                    webBuilder.ConfigureServices(services => services.AddSingleton(ClientInfo.Load()));
                 });
     }
 }

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ForceTokenRefresh.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ForceTokenRefresh.cshtml
@@ -1,4 +1,6 @@
 ﻿@using Google.Apis.Auth.AspNetCore3.IntegrationTests.Controllers
+@using System.Security.Claims;
+
 @model HomeController.ForceTokenRefreshModel
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
@@ -10,10 +12,12 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - Force Token Refresh</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Force token refresh</title>
 </head>
 <body>
-    <h1>Integration tests - Force Token Refresh</h1>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Force token refresh</h2>
+    <p>You are logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
+    <p>Here's token information from before and after the refresh.</p>
     <ul>
         @foreach (var result in @Model.Results)
         {
@@ -21,9 +25,9 @@
         }
     </ul>
     <form asp-controller="home" asp-action="ForceTokenRefreshCheckPersisted" method="post">
-        @* Passing access token for test only - don't do this in production code! *@
+        @* Passing access token for demonstration purposes only - don't ever do this in production code! *@
         <input name="expectedAccessToken" type="hidden" value="@Model.AccessToken" />
-        <button type="submit">Continue test...</button>
+        <button type="submit">Confirm refreshed token persisted...</button>
     </form>
     <p><a asp-controller="home" asp-action="index">Index</a></p>
 </body>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ForceTokenRefreshCheckPersisted.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ForceTokenRefreshCheckPersisted.cshtml
@@ -1,4 +1,6 @@
-﻿@model IReadOnlyList<string>
+﻿@using System.Security.Claims;
+
+@model IReadOnlyList<string>
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;
@@ -9,14 +11,15 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - Force Token Refresh Check Persisted</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Refreshed token persisted</title>
 </head>
 <body>
-    <h1>Integration tests - Force Token Refresh Check Persisted</h1>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Refreshed token persisted</h2>
+    <p>You are logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
     <ul>
         @foreach (var result in @Model)
         {
-        <li>@result</li>
+            <li>@result</li>
         }
     </ul>
     <p><a asp-controller="home" asp-action="index">Index</a></p>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Index.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Index.cshtml
@@ -1,4 +1,6 @@
-﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+﻿@using System.Security.Claims;
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;
 }
@@ -8,15 +10,61 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - index</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Index</title>
 </head>
 <body>
-    <h1>Integration tests - index</h1>
-    <p><a asp-controller="home" asp-action="logout">Logout</a></p>
-    <p><a asp-controller="home" asp-action="showtokens">Show auth tokens</a></p>
-    <p><a asp-controller="home" asp-action="scopelisting">Test scope listing</a></p>
-    <p><a asp-controller="home" asp-action="storagebucketlisting">Test Storage bucket listing</a> (attribute-based incremental auth)</p>
-    <p><a asp-controller="home" asp-action="translate">Translate</a> (code-based incremental auth)</p>
-    <p><a asp-controller="home" asp-action="forcetokenrefresh">Force token refresh</a></p>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Index</h2>
+    <p>The following links showcase some of the features provided by Google.Apis.Auth.AspNetCore3</p>
+    <br />
+    @if (User.Identity.IsAuthenticated)
+    {
+        <p><a asp-controller="home" asp-action="logout">Logout</a> - You are currently logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
+    }
+    else
+    {
+        <p><a asp-controller="home" asp-action="login">Login</a> - You are not currently logged in.</p>
+    }
+    <p>
+        <a asp-controller="home" asp-action="scopelisting">List current scopes</a> - List all scopes
+        this application is currently authorized for.
+        <ul>
+            <li>Authentication will trigger if there's no authenticated user.</li>
+            <li>This shows how to require authentication without any specific scopes.</li>
+        </ul>
+    </p>
+    <p>
+        <a asp-controller="home" asp-action="storagebucketlisting">List Storage buckets</a> - Use the Storage API to list all Storage buckets
+        that the logged account has access to on this app's GCP project.
+        <ul>
+            <li>Authentication will trigger if there's no authenticated user.</li>
+            <li>If a user is already authenticated but hasn't granted the required scopes, incremental authorization will trigger.</li>
+            <li>This shows how to do incremental authorization via attributes, and how to use the user's credential to access a Google API.</li>
+        </ul>
+    </p>
+    <p>
+        <a asp-controller="home" asp-action="translate">Translate some text</a> - Use the Translate API to translate
+        "The cold weather will soon be over" to French.
+        <ul>
+            <li>Authentication will trigger if there's no authenticated user.</li>
+            <li>If a user is already authenticated but hasn't granted the required scopes, incremental authorization will trigger.</li>
+            <li>This shows how to do incremental authorization via code, and how to use the user's credential to access a Google API.</li>
+        </ul>
+    </p>
+    <p>
+        <a asp-controller="home" asp-action="showtokens">Show OAuth tokens related information</a>
+        <ul>
+            <li>Authentication will trigger if there's no authenticated user.</li>
+            <li>This shows how to inspect OAuth token related information.</li>
+        </ul>
+    </p>
+    <p>
+        <a asp-controller="home" asp-action="forcetokenrefresh">Force access token refresh</a>
+        <ul>
+            <li>Authentication will trigger if there's no authenticated user.</li>
+            <li>This shows how to force OAuth access token refresh.
+            You usually don't need to do this since Google.Apis.Auth.AspNetCore3 will
+            automatically refresh the access token when it's close to expiry.</li>
+        </ul>
+    </p>
 </body>
 </html>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Login.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Login.cshtml
@@ -1,0 +1,20 @@
+﻿@using System.Security.Claims;
+
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Google.Apis.Auth.AspNetCore3 sample - Login</title>
+</head>
+<body>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Login</h2>
+    <p>Hello @User.FindFirst(ClaimTypes.GivenName)?.Value! You have successfully logged in.</p>
+    <p><a asp-controller="home" asp-action="index">Index</a></p>
+</body>
+</html>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Logout.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Logout.cshtml
@@ -8,10 +8,11 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - logout</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Logout</title>
 </head>
 <body>
-    <h1>Integration tests - logout</h1>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Logout</h2>
+    <p>You successfully logged out.</p>
     <p><a asp-controller="home" asp-action="index">Index</a></p>
 </body>
 </html>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ScopeListing.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ScopeListing.cshtml
@@ -1,4 +1,6 @@
-﻿@model IReadOnlyList<string>
+﻿@using System.Security.Claims;
+
+@model IReadOnlyList<string>
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;
@@ -9,23 +11,24 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - Scope Listing</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Scope Listing</title>
 </head>
 <body>
-    <h1>Integration tests - Scope Listing</h1>
-    <ul>
-        @foreach (var scope in @Model)
-        {
-        <li>@scope</li>
-        }
-    </ul>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Scope Listing</h2>
+    <p>You are logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
     @if (@Model.Count > 0)
     {
-    <p>Test passed</p>
+        <p>These are the scopes this application is currently authorized for:</p>
+        <ul>
+            @foreach (var scope in @Model)
+            {
+                <li>@scope</li>
+            }
+        </ul>
     }
     else
     {
-    <p>Test failed</p>
+        <p>There are no scopes this application is currently authorized for. This probably means that something went wrong when attempting to fetch scopes.</p>
     }
     <p><a asp-controller="home" asp-action="index">Index</a></p>
 </body>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ShowTokens.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/ShowTokens.cshtml
@@ -1,4 +1,6 @@
-﻿@model IReadOnlyList<string>
+﻿@using System.Security.Claims;
+
+@model IReadOnlyList<string>
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;
@@ -9,23 +11,24 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - Show Tokens</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - OAuth Tokens</title>
 </head>
 <body>
-    <h1>Integration tests - Show Tokens</h1>
-    <ul>
-        @foreach (var token in @Model)
-        {
-            <li>@token</li>
-        }
-    </ul>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - OAuth Tokens</h2>
+    <p>You are logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
     @if (@Model.Count > 0)
     {
-        <p>Test passed</p>
+        <p>Here is information about the OAuth tokens being used for authentication and authorization purposes. </p>
+        <ul>
+            @foreach (var token in @Model)
+            {
+                <li>@token</li>
+            }
+        </ul>
     }
     else
     {
-        <p>Test failed</p>
+        <p>There's no OAuth token related information that we could find. This probably means that an error has occurred during authentication.</p>
     }
     <p><a asp-controller="home" asp-action="index">Index</a></p>
 </body>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/StorageBucketListing.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/StorageBucketListing.cshtml
@@ -1,4 +1,6 @@
-﻿@model IReadOnlyList<string>
+﻿@using System.Security.Claims;
+
+@model IReadOnlyList<string>
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;
@@ -9,23 +11,24 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - Storage Bucket Listing</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Storage bucket list</title>
 </head>
 <body>
-    <h1>Integration tests - Storage Bucket Listing</h1>
-    <ul>
-        @foreach (var bucketName in @Model)
-        {
-            <li>@bucketName</li>
-        }
-    </ul>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Storage bucket list</h2>
+    <p>You are logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
     @if (@Model.Count > 0)
     {
-        <p>Test passed</p>
+        <p>These are the Storage buckets you have access to on this app's GCP project.</p>
+        <ul>
+            @foreach (var bucketName in @Model)
+            {
+                <li>@bucketName</li>
+            }
+        </ul>
     }
     else
     {
-        <p>Test failed</p>
+        <p>It seems you don't have access to any Storage bucket on this app's GCP project.</p>
     }
     <p><a asp-controller="home" asp-action="index">Index</a></p>
 </body>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Translate.cshtml
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Views/Home/Translate.cshtml
@@ -1,4 +1,6 @@
-﻿@model string
+﻿@using System.Security.Claims;
+
+@model string
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;
@@ -9,14 +11,17 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Integreation tests - Translate</title>
+    <title>Google.Apis.Auth.AspNetCore3 sample - Translate</title>
 </head>
 <body>
-    <h1>Integration tests - Translate</h1>
-    <ul>
-        @Model
-    </ul>
-    <p>Test passed</p>
+    <h2>Google.Apis.Auth.AspNetCore3 sample - Translate</h2>
+    <p>You are logged in as @User.FindFirst(ClaimTypes.GivenName)?.Value.</p>
+    <p>
+        Here's your translation.
+        <ul>
+            @Model
+        </ul>
+    </p>
     <p><a asp-controller="home" asp-action="index">Index</a></p>
 </body>
 </html>


### PR DESCRIPTION
So it can be better used as sample code showing Google.Apis.Auth.AspNetCore3 usage.

Once this is in I'll add a README and update the docs.

Towards #1584 .