### PR TITLE
feat: Adds configuration for JWTs emission as access tokens.

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -33,7 +33,7 @@ namespace Google.Apis.Auth.OAuth2
     /// See <see cref="GetApplicationDefaultAsync(CancellationToken)"/> for the credential retrieval logic.
     /// </para>
     /// </summary>
-    public class GoogleCredential : ICredential, ITokenAccessWithHeaders, IOidcTokenProvider
+    public class GoogleCredential : ICredential, ITokenAccessWithHeaders, IOidcTokenProvider, IJwtTokenAccess
     {
         /// <summary>Provider implements the logic for creating the application default credential.</summary>
         private static readonly DefaultCredentialProvider defaultCredentialProvider = new DefaultCredentialProvider();
@@ -300,6 +300,15 @@ namespace Google.Apis.Auth.OAuth2
         /// <returns>A copy of this credential with <see cref="QuotaProject"/> set to <paramref name="quotaProject"/>.</returns>
         public virtual GoogleCredential CreateWithQuotaProject(string quotaProject) =>
             new GoogleCredential(credential.WithQuotaProject(quotaProject));
+
+        /// <inheritdoc/>
+        public void RegisterForJwtEmission(JwtAsAccessTokenOptions options, bool overrideExisting)
+        {
+            if (credential is IJwtTokenAccess jwtEmitter) 
+            {
+                jwtEmitter.RegisterForJwtEmission(options, overrideExisting);
+            }
+        }
 
         void IConfigurableHttpClientInitializer.Initialize(ConfigurableHttpClient httpClient)
         {

--- a/Src/Support/Google.Apis.Auth/OAuth2/IJwtTokenAccess.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/IJwtTokenAccess.cs
@@ -1,0 +1,39 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Implementors can emit self signed JWTs as access tokens
+    /// for registered andpoints.
+    /// </summary>
+    public interface IJwtTokenAccess : ITokenAccess
+    {
+        /// <summary>
+        /// Registers a set of conditions under which a JWT can be emitted
+        /// as an access token.
+        /// </summary>
+        /// <param name="options">The options to register.</param>
+        /// <param name="overrideExisting">true to override any existing registration for
+        /// the <see cref="JwtAsAccessTokenOptions.Endpoint"/> of <paramref name="options"/>.
+        /// Else <see cref="ArgumentException"/> will be thrown of the <see cref="JwtAsAccessTokenOptions.Endpoint"/>
+        /// of <paramref name="options"/> has already been registered.</param>
+        void RegisterForJwtEmission(JwtAsAccessTokenOptions options, bool overrideExisting);
+        // TODO: We probably want this inmutable.
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/JwtAsAccessTokenOptions.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/JwtAsAccessTokenOptions.cs
@@ -1,0 +1,75 @@
+﻿/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Describes the conditions under which a self signed
+    /// JWT can be emitted as an access token.
+    /// </summary>
+    public sealed class JwtAsAccessTokenOptions
+    {
+        /// <summary>
+        /// The endpoint for which a JWT can be emitted as an access token.
+        /// Must not be null.
+        /// </summary>
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// The audience to use when emitting the JWT.
+        /// May be null, in which case, the <see cref="Endpoint"/> will be used
+        /// as audience.
+        /// </summary>
+        public string Audience { get; set; }
+
+        /// <summary>
+        /// Effective audience that will be used for emitting the JWT.
+        /// <see cref="Audience"/> will be used if it's not null,
+        /// else <see cref="Endpoint"/> will be used.
+        /// </summary>
+        internal string EffectiveAudience => Audience ?? Endpoint;
+
+        /// <summary>
+        /// The scopes for which a JWT token access can be emitted as an access token.
+        /// May be null or empty, in which case JWT emission will only occurred for an
+        /// unscoped credential.
+        /// </summary>
+        public IEnumerable<string> AllowedScopes { get; set; }
+
+        /// <summary>
+        /// Checks if the given scopes are contained by <see cref="AllowedScopes"/>.
+        /// </summary>
+        internal bool ScopesAllowed(IEnumerable<string> scopes) => 
+            !scopes?.Except(AllowedScopes ?? Enumerable.Empty<string>()).Any() ?? true;
+
+        internal JwtAsAccessTokenOptions Copy() =>
+            new JwtAsAccessTokenOptions
+            {
+                Endpoint = Endpoint,
+                Audience = Audience,
+                AllowedScopes = new List<string>(AllowedScopes)
+            };
+
+        internal JwtAsAccessTokenOptions ValidateForRegistrationAndCopy() => ThrowIfInvalid().Copy();
+
+        private JwtAsAccessTokenOptions ThrowIfInvalid() =>
+            Endpoint is null ? throw new InvalidOperationException($"{nameof(Endpoint)} cannot be null.") : this;
+    }
+}


### PR DESCRIPTION
This will be accompanied by a GAX PR showing how to use the configuration.

My two cents again on pros and cons (mostly compared to Gax only solution in googleapis/gax-dotnet#427):

* Pros:
  * This is more extensible and flexible which should allow for unknown requirements down the line.
  * Can be easily used independent og Google APIs.
  * The credentials can be reused across endpoints.
  * Fairly good separation of concerns. Changing the "default scopes" terminology with "allowed scopes" goes a long way but also being able to hide the behaviour behind GoogleCredential.

* Cons:
  * It's way more complicated than the Gax only solution. Harder to maintain and test. And still there's no ironclad guarantee that this is flexible enough for unknown requirements.

