### PR TITLE
Add more information to parameter validation failures.

### DIFF
--- a/Src/Support/Google.Apis.Core/Requests/Parameters/ParameterValidator.cs
+++ b/Src/Support/Google.Apis.Core/Requests/Parameters/ParameterValidator.cs
@@ -29,7 +29,12 @@ namespace Google.Apis.Requests.Parameters
     {
         /// <summary>Validates a parameter value against the methods regex.</summary>
         [VisibleForTestOnly]
-        public static bool ValidateRegex(IParameter param, string paramValue, out string error)
+        [Obsolete("Use ValidateParameter instead")]
+        public static bool ValidateRegex(IParameter param, string paramValue) => ValidateRegex(param, paramValue, out _);
+
+        /// <summary>Validates a parameter value against the methods regex.</summary>
+        [VisibleForTestOnly]
+        internal static bool ValidateRegex(IParameter param, string paramValue, out string error)
         {
             if (string.IsNullOrEmpty(param.Pattern) || new Regex(param.Pattern).IsMatch(paramValue))
             {
@@ -42,6 +47,10 @@ namespace Google.Apis.Requests.Parameters
                 return false;
             }
         }
+
+        /// <summary>Validates if a parameter is valid.</summary>
+        [Obsolete("Use the overload with error output instead")]
+        public static bool ValidateParameter(IParameter parameter, string value) => ValidateParameter(parameter, value, out _);
 
         /// <summary>Validates if a parameter is valid.</summary>
         public static bool ValidateParameter(IParameter parameter, string value, out string error)

--- a/Src/Support/Google.Apis.Core/Requests/Parameters/ParameterValidator.cs
+++ b/Src/Support/Google.Apis.Core/Requests/Parameters/ParameterValidator.cs
@@ -29,22 +29,42 @@ namespace Google.Apis.Requests.Parameters
     {
         /// <summary>Validates a parameter value against the methods regex.</summary>
         [VisibleForTestOnly]
-        public static bool ValidateRegex(IParameter param, string paramValue)
+        public static bool ValidateRegex(IParameter param, string paramValue, out string error)
         {
-            return string.IsNullOrEmpty(param.Pattern) || new Regex(param.Pattern).IsMatch(paramValue);
+            if (string.IsNullOrEmpty(param.Pattern) || new Regex(param.Pattern).IsMatch(paramValue))
+            {
+                error = null;
+                return true;
+            }
+            else
+            {
+                error = string.Format("The value did not match the regex {0}", param.Pattern);
+                return false;
+            }
         }
 
         /// <summary>Validates if a parameter is valid.</summary>
-        public static bool ValidateParameter(IParameter parameter, string value)
+        public static bool ValidateParameter(IParameter parameter, string value, out string error)
         {
-            // Fail if a required parameter is not present.
-            if (String.IsNullOrEmpty(value))
+            if (string.IsNullOrEmpty(value))
             {
-                return !parameter.IsRequired;
+                // Fail if a required parameter is not present.
+                if (parameter.IsRequired)
+                {
+                    error = "The parameter value must be a non-empty string";
+                    return false;
+                }
+                else
+                {
+                    error = null;
+                    return true;
+                }
             }
-
-            // The parameter has value so validate the regex.
-            return ValidateRegex(parameter, value);
+            else
+            {
+                // The parameter has value so validate the regex.
+                return ValidateRegex(parameter, value, out error);
+            }
         }
     }
 }

--- a/Src/Support/Google.Apis.Core/Requests/Parameters/ParameterValidator.cs
+++ b/Src/Support/Google.Apis.Core/Requests/Parameters/ParameterValidator.cs
@@ -43,7 +43,7 @@ namespace Google.Apis.Requests.Parameters
             }
             else
             {
-                error = string.Format("The value did not match the regex {0}", param.Pattern);
+                error = $"The value did not match the regular expression {param.Pattern}";
                 return false;
             }
         }

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/Parameters/ParameterValidatorTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/Parameters/ParameterValidatorTest.cs
@@ -28,7 +28,8 @@ namespace Google.Apis.Tests.Apis.Requests.Parameters
         public void ValidateRegexEmptyNeedsDataTest()
         {
             var parameter = new Parameter { Pattern = ".+", Name = "test" };
-            Assert.False(ParameterValidator.ValidateRegex(parameter, ""));
+            Assert.False(ParameterValidator.ValidateRegex(parameter, "", out string error));
+            Assert.Contains(parameter.Pattern, error);
         }
 
         /// <summary>Tests validate regex.</summary>
@@ -36,7 +37,8 @@ namespace Google.Apis.Tests.Apis.Requests.Parameters
         public void ValidateRegexTest()
         {
             var parameter = new Parameter { Pattern = ".+", Name = "test" };
-            Assert.True(ParameterValidator.ValidateRegex(parameter, "Test"));
+            Assert.True(ParameterValidator.ValidateRegex(parameter, "Test", out string error));
+            Assert.Null(error);
         }
     }
 }

--- a/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
+++ b/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
@@ -382,14 +382,14 @@ namespace Google.Apis.Requests
                 if (!RequestParameters.TryGetValue(parameter.Key, out IParameter parameterDefinition))
                 {
                     throw new GoogleApiException(Service.Name,
-                        String.Format("Invalid parameter \"{0}\" was specified", parameter.Key));
+                        $"Invalid parameter \"{parameter.Key}\" was specified");
                 }
 
                 string value = parameter.Value;
                 if (!ParameterValidator.ValidateParameter(parameterDefinition, value, out string error))
                 {
                     throw new GoogleApiException(Service.Name,
-                        string.Format("Parameter validation failed for \"{0}\" : {1}", parameterDefinition.Name, error));
+                        $"Parameter validation failed for \"{parameterDefinition.Name}\" : {error}");
                 }
 
                 if (value == null) // If the parameter is null, use the default value.
@@ -411,8 +411,7 @@ namespace Google.Apis.Requests
                         break;
                     default:
                         throw new GoogleApiException(service.Name,
-                            string.Format("Unsupported parameter type \"{0}\" for \"{1}\"",
-                            parameterDefinition.ParameterType, parameterDefinition.Name));
+                            $"Unsupported parameter type \"{parameterDefinition.ParameterType}\" for \"{parameterDefinition.Name}\"");
                 }
             }
 
@@ -422,7 +421,7 @@ namespace Google.Apis.Requests
                 if (parameter.IsRequired && !inputParameters.ContainsKey(parameter.Name))
                 {
                     throw new GoogleApiException(service.Name,
-                        string.Format("Parameter \"{0}\" is missing", parameter.Name));
+                        $"Parameter \"{parameter.Name}\" is missing");
                 }
             }
         }

--- a/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
+++ b/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
@@ -379,19 +379,17 @@ namespace Google.Apis.Requests
         {
             foreach (var parameter in inputParameters)
             {
-                IParameter parameterDefinition;
-
-                if (!RequestParameters.TryGetValue(parameter.Key, out parameterDefinition))
+                if (!RequestParameters.TryGetValue(parameter.Key, out IParameter parameterDefinition))
                 {
                     throw new GoogleApiException(Service.Name,
                         String.Format("Invalid parameter \"{0}\" was specified", parameter.Key));
                 }
 
                 string value = parameter.Value;
-                if (!ParameterValidator.ValidateParameter(parameterDefinition, value))
+                if (!ParameterValidator.ValidateParameter(parameterDefinition, value, out string error))
                 {
                     throw new GoogleApiException(Service.Name,
-                        string.Format("Parameter validation failed for \"{0}\"", parameterDefinition.Name));
+                        string.Format("Parameter validation failed for \"{0}\" : {1}", parameterDefinition.Name, error));
                 }
 
                 if (value == null) // If the parameter is null, use the default value.


### PR DESCRIPTION
I have added more information to validation failure exceptions generated by ClientServiceRequest.AddParameters()
This is an attempt at the following issue #1704 