### PR TITLE
ci: Stops patching admin_directory_v1.json which we are not generating anyway.

### DIFF
--- a/Src/Tools/DiscoveryDocPatcher/Program.cs
+++ b/Src/Tools/DiscoveryDocPatcher/Program.cs
@@ -27,9 +27,15 @@ namespace DiscoveryDocPatcher
             try
             {
                 string discoveryDocPath = args[0];
+
                 // No longer required as on 2020-07-09. The offending resource is no longer present at all.
                 // PatchGames(discoveryDocPath);
-                PatchDirectory(discoveryDocPath);
+
+                // No need to generate (or patch) while an internal issue is being fixed.
+                // We'll need to review patching once we have the new discovery doc produced by that fix.
+                // I've let a comment on the script as well.
+                // PatchDirectory(discoveryDocPath);
+
                 PatchDataLabeling(discoveryDocPath);
                 return 0;
             }


### PR DESCRIPTION
Release is failing because the bits that we were patching have changed. But I won't fix the patcher until we are back generating this API (there's an internal issue), the discovery doc might continue to change until then.