### PR TITLE
feat: make timeout configurable for GCE

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
@@ -35,6 +35,23 @@ namespace Google.Apis.Auth.Tests.OAuth2
         }*/
 
         [Fact]
+        public void GetMetadaSeverPingTimeoutInMilliseconds_UseDefault()
+        {
+            MockEnvironmentVariableProvider provider = new MockEnvironmentVariableProvider();
+            int timeout = ComputeCredential.GetMetadaSeverPingTimeoutInMilliseconds(provider);
+            Assert.Equal(500, timeout);
+        }
+
+        [Fact]
+        public void GetMetadaSeverPingTimeoutInMilliseconds_FromEnvironmentVariable()
+        {
+            MockEnvironmentVariableProvider provider = new MockEnvironmentVariableProvider();
+            provider.SetEnvironmentVariable("GCE_METADATA_TIMEOUT", "10");
+            int timeout = ComputeCredential.GetMetadaSeverPingTimeoutInMilliseconds(provider);
+            Assert.Equal(10000, timeout);
+        }
+
+        [Fact]
         public void IsRunningOnComputeEngine_ResultIsCached()
         {
             // Two subsequent invocations should return the same task.

--- a/Src/Support/Google.Apis.Core/Util/EnvironmentVariableProvider.cs
+++ b/Src/Support/Google.Apis.Core/Util/EnvironmentVariableProvider.cs
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
+
+namespace Google.Apis.Util
+{
+    /// <summary>A wrapper class for environment variable.</summary>
+    public class EnvironmentVariableProvider
+    {
+        /// <summary>Return the environment variable value.</summary>
+        public virtual string GetEnvironmentVariable(string variableName) {
+            return Environment.GetEnvironmentVariable(variableName);
+        }
+
+        /// <summary>Set the environment variable value.</summary>
+        public virtual void SetEnvironmentVariable(string variableName, string value) {
+            Environment.SetEnvironmentVariable(variableName, value);
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Tests/Mocks/MockEnvironmentVariableProvider.cs
+++ b/Src/Support/Google.Apis.Tests/Mocks/MockEnvironmentVariableProvider.cs
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Google Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections.Generic;
+using Google.Apis.Util;
+
+namespace Google.Apis.Tests.Mocks
+{
+    /// <summary>Mock environment variable provider for testing.</summary>
+    public class MockEnvironmentVariableProvider : EnvironmentVariableProvider {
+        Dictionary<string, string> envVars = new Dictionary<string, string>();
+
+        public override string GetEnvironmentVariable(string variableName)
+        {
+            if (!envVars.ContainsKey(variableName))
+                return null;
+
+            return envVars[variableName];
+        }
+
+        public override void SetEnvironmentVariable(string variableName, string value)
+        {
+            envVars[variableName] = value;
+        }
+    }
+}


### PR DESCRIPTION
Same issue as https://github.com/googleapis/google-auth-library-java/issues/517

The fix allows the users to set a custom timeout using the `GCE_METADATA_TIMEOUT` environment variable. 