### PR TITLE
Allow parameter validation to be bypassed

### DIFF
--- a/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
+++ b/Src/Support/Google.Apis/Requests/ClientServiceRequest.cs
@@ -117,6 +117,14 @@ namespace Google.Apis.Requests
         /// </summary>
         public Action<HttpRequestMessage> ModifyRequest { get; set; }
 
+        /// <summary>
+        /// Override for service-wide validation configuration in <see cref="BaseClientService.Initializer.ValidateParameters"/>.
+        /// If this is null (the default) then the value from the service initializer is used to determine
+        /// whether or not parameters should be validated client-side. If this is non-null, it overrides
+        /// whatever value is specified in the service.
+        /// </summary>
+        public bool? ValidateParameters { get; set; }
+
         #region IClientServiceRequest Properties
 
         /// <inheritdoc/>
@@ -377,6 +385,8 @@ namespace Google.Apis.Requests
         /// <summary>Adds path and query parameters to the given <c>requestBuilder</c>.</summary>
         private void AddParameters(RequestBuilder requestBuilder, ParameterCollection inputParameters)
         {
+            bool validateParameters = ValidateParameters ?? (Service as BaseClientService)?.ValidateParameters ?? true;
+
             foreach (var parameter in inputParameters)
             {
                 if (!RequestParameters.TryGetValue(parameter.Key, out IParameter parameterDefinition))
@@ -386,7 +396,8 @@ namespace Google.Apis.Requests
                 }
 
                 string value = parameter.Value;
-                if (!ParameterValidator.ValidateParameter(parameterDefinition, value, out string error))
+                if (validateParameters &&
+                    !ParameterValidator.ValidateParameter(parameterDefinition, value, out string error))
                 {
                     throw new GoogleApiException(Service.Name,
                         $"Parameter validation failed for \"{parameterDefinition.Name}\" : {error}");

--- a/Src/Support/Google.Apis/Services/BaseClientService.cs
+++ b/Src/Support/Google.Apis/Services/BaseClientService.cs
@@ -120,7 +120,13 @@ namespace Google.Apis.Services
             /// may add their own version here.
             /// </summary>
             public VersionHeaderBuilder VersionHeaderBuilder { get; }
-            
+
+            /// <summary>
+            /// Determines whether request parameters are validated (client-side) by default.
+            /// Defaults to true. This can be overridden on a per-request basis using <see cref="ClientServiceRequest{TResponse}.ValidateParameters"/>.
+            /// </summary>
+            public bool ValidateParameters { get; set; } = true;
+
             /// <summary>Constructs a new initializer with default values.</summary>
             public Initializer()
             {
@@ -163,6 +169,7 @@ namespace Google.Apis.Services
             ApiKey = initializer.ApiKey;
             ApplicationName = initializer.ApplicationName;
             BaseUriOverride = initializer.BaseUri;
+            ValidateParameters = initializer.ValidateParameters;
             if (ApplicationName == null)
             {
                 Logger.Warning("Application name is not set. Please set Initializer.ApplicationName property");
@@ -172,6 +179,12 @@ namespace Google.Apis.Services
             // Create a HTTP client for this service.
             HttpClient = CreateHttpClient(initializer, versionHeader);
         }
+
+        /// <summary>
+        /// Determines whether or not request parameters should be validated client-side.
+        /// This may be overridden on a per-request basis.
+        /// </summary>
+        internal bool ValidateParameters { get; }
 
         /// <summary>
         /// The BaseUri provided in the initializer, which may be null.


### PR DESCRIPTION
This only allows the validation of patterns to be bypassed - required parameters still have to be provided.

Workaround for #1729.