### PR TITLE
feat: Include the response content on the exception thrown by a batch request.

### DIFF
--- a/Src/Support/Google.Apis/Services/BaseClientService.cs
+++ b/Src/Support/Google.Apis/Services/BaseClientService.cs
@@ -340,7 +340,9 @@ namespace Google.Apis.Services
         {
             if (response?.Content == null)
             {
-                throw new GoogleApiException(Name, "response or response content unexpectedly null.");
+                var ex = new GoogleApiException(Name, "response or response content unexpectedly null.");
+                ex.HttpStatusCode = response?.StatusCode ?? ex.HttpStatusCode;
+                throw ex;
             }
             // If we can't even read the response, let that exception bubble up.
             var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
This is for consideration. The hoops I'm jumping throuhg is so as not to break anyone that relied on the HttpRequestException and its message format which unfortunately is the only way they could had been obtaining the HttpStatusCode.

I considered calling EnsureSuccessStatusCode() before anything, but that will dispose of the content if there's an error, so we cannot later parse the RequestError.

I know this is ugly, but something like this would be very useful for diagnosing batch issues, where the issues are not with the individual requests contained in the batch bot with the batch request itself. See https://github.com/googleapis/google-api-dotnet-client/issues/1619#issuecomment-680051653 for instance.

If you are fine with this, I'll add tests, etc.