### PR TITLE
Relax return type of the HttpClientFactory.CreateClientHandler to HttpMessageHandler

### DIFF
--- a/Src/Support/Google.Apis.Core/Http/UnableToResolveHttpClientHandlerException.cs
+++ b/Src/Support/Google.Apis.Core/Http/UnableToResolveHttpClientHandlerException.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net.Http;
+
+namespace Google.Apis.Http
+{
+    /// <summary>Throws when <see cref="HttpClientFactory.GetHttpClientHandler"/> cannot resolve <see cref="HttpClientHandler"/></summary>
+    public class UnableToResolveHttpClientHandlerException : Exception
+    {
+        /// <summary>A handler on which was <see cref="HttpClientHandler"/> not found</summary>
+        public HttpMessageHandler HttpMessageHandler { get; }
+
+        /// <summary>Creates an exception.</summary>
+        public UnableToResolveHttpClientHandlerException(HttpMessageHandler httpMessageHandler)
+        {
+            HttpMessageHandler = httpMessageHandler;
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
@@ -935,7 +935,7 @@ namespace Google.Apis.Tests.Apis.Http
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.Contains("Parameter name: NumTries", ex.Message);
+                Assert.Contains("Parameter 'NumTries'", ex.Message);
             }
             try
             {
@@ -944,7 +944,7 @@ namespace Google.Apis.Tests.Apis.Http
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.Contains("Parameter name: NumTries", ex.Message);
+                Assert.Contains("Parameter 'NumTries'", ex.Message);
             }
             try
             {
@@ -953,7 +953,7 @@ namespace Google.Apis.Tests.Apis.Http
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.Contains("Parameter name: NumTries", ex.Message);
+                Assert.Contains("Parameter 'NumTries'", ex.Message);
             }
         }
 

--- a/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
@@ -928,32 +928,22 @@ namespace Google.Apis.Tests.Apis.Http
             configurableHanlder.NumTries = 1;
 
             // test invalid values
-            try
+            var numTries = new[]
             {
-                configurableHanlder.NumTries = ConfigurableMessageHandler.MaxAllowedNumTries + 1;
-                Assert.True(false, "Exception expected");
-            }
-            catch (ArgumentOutOfRangeException ex)
+                ConfigurableMessageHandler.MaxAllowedNumTries + 1,
+                0,
+                -2,
+            };
+
+            foreach (var numTry in numTries)
             {
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(() => configurableHanlder.NumTries = numTry);
+
+#if NETCOREAPP3_1
                 Assert.Contains("Parameter 'NumTries'", ex.Message);
-            }
-            try
-            {
-                configurableHanlder.NumTries = 0;
-                Assert.True(false, "Exception expected");
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                Assert.Contains("Parameter 'NumTries'", ex.Message);
-            }
-            try
-            {
-                configurableHanlder.NumTries = -2;
-                Assert.True(false, "Exception expected");
-            }
-            catch (ArgumentOutOfRangeException ex)
-            {
-                Assert.Contains("Parameter 'NumTries'", ex.Message);
+#else
+                Assert.Contains("Parameter name: NumTries", ex.Message);
+#endif
             }
         }
 

--- a/Src/Support/Google.Apis.Tests/Apis/Http/HttpClientFactoryTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/HttpClientFactoryTest.cs
@@ -1,0 +1,141 @@
+using Google.Apis.Http;
+using System.Net.Http;
+using Xunit;
+
+namespace Google.Apis.Tests.Apis.Http
+{
+    public class HttpClientFactoryTest
+    {
+        [Fact]
+        public void TestCreateStreamInterceptionHandler()
+        {
+            var httpClientHandler = new TestHttpClientHandler(true);
+            var httpClientFactory = new TestHttpClientFactory(httpClientHandler);
+
+            var httpMessageHandler = httpClientFactory.AccessibleCreateHandler(new CreateHttpClientArgs());
+
+            var streamInterceptionHandler = Assert.IsType<StreamInterceptionHandler>(httpMessageHandler);
+            Assert.Equal(httpClientHandler, streamInterceptionHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void TestCreateGzipDeflateHandler()
+        {
+            var httpClientHandler = new TestHttpClientHandler(false);
+            var httpClientFactory = new TestHttpClientFactory(httpClientHandler);
+
+            var httpMessageHandler = httpClientFactory.AccessibleCreateHandler(new CreateHttpClientArgs
+            {
+                GZipEnabled = true,
+            });
+
+            var gzipDeflateHandler = Assert.IsType<GzipDeflateHandler>(httpMessageHandler);
+            var streamInterceptionHandler = Assert.IsType<StreamInterceptionHandler>(gzipDeflateHandler.InnerHandler);
+            Assert.Equal(httpClientHandler, streamInterceptionHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void TestCreateTwoWayDelegatingHandler()
+        {
+            var httpClientHandler = new TestHttpClientHandler(true);
+            var httpClientFactory = new TestHttpClientFactory(httpClientHandler);
+
+            var httpMessageHandler = httpClientFactory.AccessibleCreateHandler(new CreateHttpClientArgs
+            {
+                GZipEnabled = true,
+            });
+
+            var twoWayDelegatingHandler = Assert.IsType<TwoWayDelegatingHandler>(httpMessageHandler);
+            Assert.Equal(httpClientHandler, twoWayDelegatingHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void TestCreateStreamInterceptionHandler_WithDelegatedHttpClientHandler()
+        {
+            var httpClientHandler = new TestDelegatingHandler(
+                new TestDelegatingHandler(
+                    new TestHttpClientHandler(true)
+                )
+            );
+            var httpClientFactory = new TestHttpClientFactory(httpClientHandler);
+
+            var httpMessageHandler = httpClientFactory.AccessibleCreateHandler(new CreateHttpClientArgs());
+
+            var streamInterceptionHandler = Assert.IsType<StreamInterceptionHandler>(httpMessageHandler);
+            Assert.Equal(httpClientHandler, streamInterceptionHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void TestCreateGzipDeflateHandler_WithDelegatedHttpClientHandler()
+        {
+            var httpClientHandler = new TestDelegatingHandler(
+                new TestDelegatingHandler(
+                    new TestHttpClientHandler(false)
+                )
+            );
+            var httpClientFactory = new TestHttpClientFactory(httpClientHandler);
+
+            var httpMessageHandler = httpClientFactory.AccessibleCreateHandler(new CreateHttpClientArgs
+            {
+                GZipEnabled = true,
+            });
+
+            var gzipDeflateHandler = Assert.IsType<GzipDeflateHandler>(httpMessageHandler);
+            var streamInterceptionHandler = Assert.IsType<StreamInterceptionHandler>(gzipDeflateHandler.InnerHandler);
+            Assert.Equal(httpClientHandler, streamInterceptionHandler.InnerHandler);
+        }
+
+        [Fact]
+        public void TestCreateTwoWayDelegatingHandler_WithDelegatedHttpClientHandler()
+        {
+            var httpClientHandler = new TestDelegatingHandler(
+                new TestDelegatingHandler(
+                    new TestHttpClientHandler(true)
+                )
+            );
+            var httpClientFactory = new TestHttpClientFactory(httpClientHandler);
+
+            var httpMessageHandler = httpClientFactory.AccessibleCreateHandler(new CreateHttpClientArgs
+            {
+                GZipEnabled = true,
+            });
+
+            var twoWayDelegatingHandler = Assert.IsType<TwoWayDelegatingHandler>(httpMessageHandler);
+            Assert.Equal(httpClientHandler, twoWayDelegatingHandler.InnerHandler);
+        }
+
+        private class TestHttpClientHandler : HttpClientHandler
+        {
+            public TestHttpClientHandler(bool supportsAutomaticDecompression)
+            {
+                SupportsAutomaticDecompression = supportsAutomaticDecompression;
+            }
+
+            public override bool SupportsAutomaticDecompression { get; }
+        }
+
+        private class TestDelegatingHandler : DelegatingHandler
+        {
+            public TestDelegatingHandler(HttpMessageHandler innerHandler) : base(innerHandler)
+            {
+            }
+        }
+
+        private class TestHttpClientFactory : HttpClientFactory
+        {
+            private readonly HttpMessageHandler _httpMessageHandler;
+
+            public TestHttpClientFactory(HttpMessageHandler httpMessageHandler = null)
+            {
+                _httpMessageHandler = httpMessageHandler;
+            }
+
+            public HttpMessageHandler AccessibleCreateHandler(CreateHttpClientArgs args) => base.CreateHandler(args);
+
+            protected override HttpMessageHandler CreateClientHandler()
+            {
+                return _httpMessageHandler ?? base.CreateClientHandler();
+            }
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.cs
@@ -147,6 +147,11 @@ namespace Google.Apis.Tests.Apis.Upload
                         _httpListener.Close();
                         _httpListener = null;
                     }
+                    catch (HttpListenerException e) when (e.Message == "Address already in use")
+                    {
+                        _httpListener.Close();
+                        _httpListener = null;
+                    }
                 } while (_httpListener == null);
                 _httpTask = RunServer();
             }

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -4,7 +4,7 @@
     <!-- net452 is the earliest desktop version supported by xunit runner -->
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net452;net46</TargetFrameworks>
     <!-- On non-Windows platforms only net core can be built -->
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\google.apis.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>

--- a/Src/Support/Google.Apis.Tests/System.Net/AsyncStream.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/AsyncStream.cs
@@ -99,7 +99,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform

--- a/Src/Support/Google.Apis.Tests/System.Net/Extensions.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/Extensions.cs
@@ -42,7 +42,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform

--- a/Src/Support/Google.Apis.Tests/System.Net/HttpListener.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/HttpListener.cs
@@ -114,7 +114,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform

--- a/Src/Support/Google.Apis.Tests/System.Net/HttpListenerContext.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/HttpListenerContext.cs
@@ -32,7 +32,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform

--- a/Src/Support/Google.Apis.Tests/System.Net/HttpListenerException.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/HttpListenerException.cs
@@ -24,7 +24,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform

--- a/Src/Support/Google.Apis.Tests/System.Net/HttpListenerRequest.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/HttpListenerRequest.cs
@@ -105,7 +105,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform

--- a/Src/Support/Google.Apis.Tests/System.Net/HttpListenerResponse.cs
+++ b/Src/Support/Google.Apis.Tests/System.Net/HttpListenerResponse.cs
@@ -47,7 +47,7 @@ namespace System.Net
     }
 }
 
-#elif NET452 || NET46 || NETCOREAPP2_0
+#elif NET452 || NET46 || NETCOREAPP2_0 || NETCOREAPP3_1
 // Nothing required
 #else
 #error Unsupported platform


### PR DESCRIPTION
Hi, this PR allows using of [IHttpMessageHandlerFactory](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.ihttpmessagehandlerfactory?view=dotnet-plat-ext-5.0) to obtain `httpMessageHandler`.

`IHttpMessageHandlerFactory` can return `DelegatingHandler` instead of required `HttpClientHandler` (`DelegatingHandler` wraps `HttpClientHandler`).

This PR allows wallowing implementation:
```cs
public class CustomHttpClientFactory<TService> : HttpClientFactory
    where TService : class
{
    private readonly IHttpMessageHandlerFactory _httpMessageHandlerFactory;

    public CustomHttpClientFactory(IHttpMessageHandlerFactory httpMessageHandlerFactory)
    {
        _httpMessageHandlerFactory = httpMessageHandlerFactory;
    }

    protected override HttpMessageHandler CreateClientHandler() => _httpMessageHandlerFactory.CreateHandler(typeof(TService).Name);
}
```

Relaxing `HttpClientFactory.CreateClientHandler` to `HttpMessageHandler` is BC break