### PR TITLE
Fix docfx build

### DIFF
--- a/DocfxFunctions.sh
+++ b/DocfxFunctions.sh
@@ -3,8 +3,12 @@
 
 declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
-declare -r DOCFX_VERSION=2.39.1
+declare -r DOCFX_VERSION=2.56.6
 declare -r DOCFX=$TOOL_PACKAGES/docfx.$DOCFX_VERSION/docfx.exe
+
+# Appears to fix some issues in docfx.
+# Unfortunately docfx is a bit "magical" in that respect :(
+export VSINSTALLDIR=
 
 install_docfx() {
   if [[ ! -f $DOCFX ]]


### PR DESCRIPTION
Looks like older versions of docfx didn't like .NET Core SDK 3.1 (or
minor updates to it)