### PR TITLE
feat: Allows specifying a proxy on a GoogleCredential.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ComputeCredentialTests.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Http;
 using Google.Apis.Tests.Mocks;
 using System;
 using System.Threading.Tasks;
@@ -40,6 +41,19 @@ namespace Google.Apis.Auth.Tests.OAuth2
             // Two subsequent invocations should return the same task.
             Assert.Same(ComputeCredential.IsRunningOnComputeEngine(),
                 ComputeCredential.IsRunningOnComputeEngine());
+        }
+
+        [Fact]
+        public void WithHttpClientFactory()
+        {
+            var credential = new ComputeCredential();
+            var factory = new HttpClientFactory();
+            var credentialWithFactory = Assert.IsType<ComputeCredential>(((IGoogleCredential)credential).WithHttpClientFactory(factory));
+
+            Assert.NotSame(credential, credentialWithFactory);
+            Assert.NotSame(credential.HttpClient, credentialWithFactory.HttpClient);
+            Assert.NotSame(credential.HttpClientFactory, credentialWithFactory.HttpClientFactory);
+            Assert.Same(factory, credentialWithFactory.HttpClientFactory);
         }
 
         [Fact]

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/AuthorizationCodeFlowTests.cs
@@ -86,6 +86,20 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
 
         #endregion
 
+        [Fact]
+        public void WithHttpClientFactory()
+        {
+            var flow = CreateFlow();
+            var factory = new HttpClientFactory();
+            var flowWithFactory = Assert.IsType<AuthorizationCodeFlow>(
+                ((IHttpAuthorizationFlow)flow).WithHttpClientFactory(factory));
+
+            Assert.NotSame(flow, flowWithFactory);
+            Assert.NotSame(flow.HttpClient, flowWithFactory.HttpClient);
+            Assert.NotSame(flow.HttpClientFactory, flowWithFactory.HttpClientFactory);
+            Assert.Same(factory, flowWithFactory.HttpClientFactory);
+        }
+
         #region LoadToken
 
         [Fact]

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Flows/GoogleAuthorizationCodeFlowTests.cs
@@ -14,20 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Moq;
-
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Auth.OAuth2.Requests;
-using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Http;
-using Google.Apis.Util.Store;
-using Google.Apis.Auth.OAuth2;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Google.Apis.Auth.Tests.OAuth2.Flows
@@ -75,7 +66,21 @@ namespace Google.Apis.Auth.Tests.OAuth2.Flows
             Assert.Equal(initializer.Nonce, flow.Nonce);
             Assert.Equal(initializer.UserDefinedQueryParams, flow.UserDefinedQueryParams);
         }
-        
+
+        [Fact]
+        public void WithHttpClientFactory()
+        {
+            var flow = new GoogleAuthorizationCodeFlow(initializer);
+            var factory = new HttpClientFactory();
+            var flowWithFactory = Assert.IsType<GoogleAuthorizationCodeFlow>(
+                ((IHttpAuthorizationFlow)flow).WithHttpClientFactory(factory));
+
+            Assert.NotSame(flow, flowWithFactory);
+            Assert.NotSame(flow.HttpClient, flowWithFactory.HttpClient);
+            Assert.NotSame(flow.HttpClientFactory, flowWithFactory.HttpClientFactory);
+            Assert.Same(factory, flowWithFactory.HttpClientFactory);
+        }
+
         [Fact]
         public void CreateAuthorizationCodeRequestTest()
         {

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ImpersonatedCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ImpersonatedCredentialTests.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
 using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Http;
 using Google.Apis.Json;
 using Google.Apis.Tests.Mocks;
 using Google.Apis.Util;
@@ -124,6 +125,21 @@ namespace Google.Apis.Auth.Tests.OAuth2
             var initializer = new ImpersonatedCredential.Initializer(sourceCredential, options);
             var ex = Assert.Throws<InvalidOperationException>(() => new ImpersonatedCredential(initializer));
             Assert.Equal("The underlying credential of source credential must be UserCredential or ServiceAccountCredential.", ex.Message);
+        }
+
+        [Fact]
+        public void WithHttpClientFactory()
+        {
+            var sourceCredential = CreateSourceCredential();
+            var credential = new ImpersonatedCredential(
+                new ImpersonatedCredential.Initializer(sourceCredential, new ImpersonationOptions("principal", null, null, null)));
+            var factory = new HttpClientFactory();
+            var credentialWithFactory = Assert.IsType<ImpersonatedCredential>(((IGoogleCredential)credential).WithHttpClientFactory(factory));
+
+            Assert.NotSame(credential, credentialWithFactory);
+            Assert.NotSame(credential.HttpClient, credentialWithFactory.HttpClient);
+            Assert.NotSame(credential.HttpClientFactory, credentialWithFactory.HttpClientFactory);
+            Assert.Same(factory, credentialWithFactory.HttpClientFactory);
         }
 
         [Fact]

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
@@ -379,6 +379,19 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         }
 
         [Fact]
+        public void WithHttpClientFactory()
+        {
+            var credential = new ServiceAccountCredential(new ServiceAccountCredential.Initializer("MyId").FromPrivateKey(PrivateKey));
+            var factory = new HttpClientFactory();
+            var credentialWithFactory = Assert.IsType<ServiceAccountCredential>(((IGoogleCredential)credential).WithHttpClientFactory(factory));
+
+            Assert.NotSame(credential, credentialWithFactory);
+            Assert.NotSame(credential.HttpClient, credentialWithFactory.HttpClient);
+            Assert.NotSame(credential.HttpClientFactory, credentialWithFactory.HttpClientFactory);
+            Assert.Same(factory, credentialWithFactory.HttpClientFactory);
+        }
+
+        [Fact]
         public async Task FetchesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.

--- a/Src/Support/Google.Apis.Auth/OAuth2/AccessTokenCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/AccessTokenCredential.cs
@@ -60,6 +60,9 @@ namespace Google.Apis.Auth.OAuth2
         IGoogleCredential IGoogleCredential.WithUserForDomainWideDelegation(string user) =>
             throw new InvalidOperationException($"{nameof(AccessTokenCredential)} does not support Domain-Wide Delegation");
 
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithHttpClientFactory(IHttpClientFactory httpClientFactory) => this;
+
         public void Initialize(ConfigurableHttpClient httpClient) =>
             httpClient.MessageHandler.Credential = this;
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Http;
 using Google.Apis.Util;
 using System;
 using System.Collections.Generic;
@@ -118,6 +119,10 @@ namespace Google.Apis.Auth.OAuth2
         /// <inheritdoc/>
         IGoogleCredential IGoogleCredential.WithUserForDomainWideDelegation(string user) =>
             throw new InvalidOperationException($"{nameof(ComputeCredential)} does not support Domain-Wide Delegation");
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            new ComputeCredential(new Initializer(this) { HttpClientFactory = httpClientFactory });
 
         #region ServiceCredential overrides
 

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/IHttpAuthorizationFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/IHttpAuthorizationFlow.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Http;
+
+namespace Google.Apis.Auth.OAuth2.Flows
+{
+    /// <summary>
+    /// Authorization flow that performs HTTP operations, for instance,
+    /// for obtaining or refreshing tokens.
+    /// </summary>
+    internal interface IHttpAuthorizationFlow : IAuthorizationCodeFlow
+    {
+        /// <summary>
+        /// Return a new instance of the same type as this but that uses the
+        /// given HTTP client factory.
+        /// </summary>
+        /// <param name="httpClientFactory">The http client factory to be used by the new instance.
+        /// May be null, in which case the default <see cref="HttpClientFactory"/> will be used.</param>
+        /// <returns>A new instance with the same type as this but that will use <paramref name="httpClientFactory"/>
+        /// to obtain an <see cref="ConfigurableHttpClient"/> to be used for token related operations.</returns>
+        IHttpAuthorizationFlow WithHttpClientFactory(IHttpClientFactory httpClientFactory);
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -283,6 +283,14 @@ namespace Google.Apis.Auth.OAuth2
         public virtual GoogleCredential CreateWithQuotaProject(string quotaProject) =>
             new GoogleCredential(credential.WithQuotaProject(quotaProject));
 
+        /// <summary>
+        /// Creates a copy of this credential with the specified HTTP client factory.
+        /// </summary>
+        /// <param name="factory">The HTTP client factory to be used by the new credential.
+        /// May be null, in which case the default <see cref="HttpClientFactory"/> will be used.</param>
+        public virtual GoogleCredential CreateWithHttpClientFactory(IHttpClientFactory factory) =>
+            new GoogleCredential(credential.WithHttpClientFactory(factory));
+
         void IConfigurableHttpClientInitializer.Initialize(ConfigurableHttpClient httpClient)
         {
             credential.Initialize(httpClient);

--- a/Src/Support/Google.Apis.Auth/OAuth2/IGoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/IGoogleCredential.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Http;
 using System;
 using System.Collections.Generic;
 
@@ -69,5 +70,15 @@ namespace Google.Apis.Auth.OAuth2
         // work only with credentials that support domain wide delegation. This interface would
         // behave similar to IOIdcTokenProvider and IBlogSigner.
         IGoogleCredential WithUserForDomainWideDelegation(string user);
+
+        /// <summary>
+        /// Return a new instance of the same type as this but that uses the
+        /// given HTTP client factory.
+        /// </summary>
+        /// <param name="httpClientFactory">The http client factory to be used by the new instance.
+        /// May be null in which case the default <see cref="HttpClientFactory"/> will be used.</param>
+        /// <returns>A new instance with the same type as this but that will use <paramref name="httpClientFactory"/>
+        /// to obtain an <see cref="ConfigurableHttpClient"/> to be used for token and other operations.</returns>
+        IGoogleCredential WithHttpClientFactory(IHttpClientFactory httpClientFactory);
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ImpersonatedCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ImpersonatedCredential.cs
@@ -16,6 +16,7 @@ limitations under the License.
 
 using Google.Apis.Auth.OAuth2.Requests;
 using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Http;
 using Google.Apis.Json;
 using Google.Apis.Util;
 using System;
@@ -109,6 +110,10 @@ namespace Google.Apis.Auth.OAuth2
         /// <inheritdoc/>
         IGoogleCredential IGoogleCredential.WithUserForDomainWideDelegation(string user) =>
             throw new InvalidOperationException($"{nameof(ImpersonatedCredential)} does not support Domain-Wide Delegation");
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            new ImpersonatedCredential(new Initializer(this) { HttpClientFactory = httpClientFactory });
 
         /// <inheritdoc/>
         public override async Task<bool> RequestAccessTokenAsync(CancellationToken taskCancellationToken)

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using Google.Apis.Auth.OAuth2.Requests;
 using Google.Apis.Json;
 using Google.Apis.Util;
+using Google.Apis.Http;
 
 #if NETSTANDARD1_3 || NETSTANDARD2_0
 using RsaKey = System.Security.Cryptography.RSA;
@@ -220,6 +221,10 @@ namespace Google.Apis.Auth.OAuth2
         /// <inheritdoc/>
         IGoogleCredential IGoogleCredential.WithUserForDomainWideDelegation(string user) =>
             new ServiceAccountCredential(new Initializer(this) { User = user });
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            new ServiceAccountCredential(new Initializer(this) { HttpClientFactory = httpClientFactory });
 
         /// <summary>
         /// Requests a new token as specified in 

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -14,16 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Http;
+using Google.Apis.Logging;
+using Google.Apis.Util;
 using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Google.Apis.Auth.OAuth2.Responses;
-using Google.Apis.Http;
-using Google.Apis.Logging;
-using Google.Apis.Util;
 
 namespace Google.Apis.Auth.OAuth2
 {
@@ -153,8 +152,8 @@ namespace Google.Apis.Auth.OAuth2
                     new ExponentialBackOffInitializer(initializer.DefaultExponentialBackOffPolicy,
                         () => new BackOffHandler(new ExponentialBackOff())));
             }
-            HttpClientFactory = initializer.HttpClientFactory;
-            HttpClient = (initializer.HttpClientFactory ?? new HttpClientFactory()).CreateHttpClient(httpArgs);
+            HttpClientFactory = initializer.HttpClientFactory ?? new HttpClientFactory();
+            HttpClient = HttpClientFactory.CreateHttpClient(httpArgs);
             _refreshManager = new TokenRefreshManager(RequestAccessTokenAsync, Clock, Logger);
 
             QuotaProject = initializer.QuotaProject;

--- a/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UserCredential.cs
@@ -94,6 +94,12 @@ namespace Google.Apis.Auth.OAuth2
         IGoogleCredential IGoogleCredential.WithUserForDomainWideDelegation(string user) =>
             throw new InvalidOperationException($"{nameof(UserCredential)} does not support Domain-Wide Delegation");
 
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            Flow is IHttpAuthorizationFlow httpFlow
+            ? new UserCredential(httpFlow.WithHttpClientFactory(httpClientFactory), UserId, Token, QuotaProject)
+            : throw new InvalidOperationException($"{Flow.GetType().FullName} does not support an HTTP client factory to be set");
+
         #region IHttpExecuteInterceptor
 
         /// <summary>

--- a/Src/Support/Google.Apis.Tests/Apis/Http/HttpClientFactoryTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/HttpClientFactoryTest.cs
@@ -1,0 +1,61 @@
+﻿// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Http;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Xunit;
+
+namespace Google.Apis.Tests.Apis.Http
+{
+    public class HttpClientFactoryTest
+    {
+        [Fact]
+        public void WithProxy()
+        {
+            var proxy = new DummyWebProxy();
+            var factory = new DummyHttpClientFactory(proxy);
+
+            var httpClientHandler = factory.CreateClientHandler();
+
+            Assert.Same(proxy, httpClientHandler.Proxy);
+        }
+
+        private class DummyHttpClientFactory : HttpClientFactory
+        {
+            public DummyHttpClientFactory(IWebProxy proxy):base(proxy)
+            { }
+
+            // Hiding base just to make this one public for testing purposes.
+            public new HttpClientHandler CreateClientHandler() => base.CreateClientHandler();
+        }
+
+        /// <summary>
+        /// Dummy implementation because System.Net.WebProxy is not available in
+        /// netcoreapp1.*
+        /// </summary>
+        private class DummyWebProxy : IWebProxy
+        {
+            public ICredentials Credentials { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public Uri GetProxy(Uri destination) => throw new NotImplementedException();
+            
+
+            public bool IsBypassed(Uri host) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Closes #1547

@jskeet a proposal to allow setting a proxy on GoogleCredential. Once we've agreed, I'll add the tests I can (probably unit only).