### PR TITLE
DO NOT MERGE: Regenerated clients with optional-repeated-enum-parameter workaround

### DIFF
--- a/Src/Generated/Google.Apis.Adsense.v2/Google.Apis.Adsense.v2.cs
+++ b/Src/Generated/Google.Apis.Adsense.v2/Google.Apis.Adsense.v2.cs
@@ -1943,6 +1943,10 @@ namespace Google.Apis.Adsense.v2
                 public virtual System.Nullable<DimensionsEnum> Dimensions { get; set; }
 
                 /// <summary>Dimensions to base the report on.</summary>
+                [Google.Apis.Util.RequestParameterAttribute("dimensions", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<DimensionsEnum> DimensionsList { get; set; }
+
+                /// <summary>Dimensions to base the report on.</summary>
                 public enum DimensionsEnum
                 {
                     /// <summary>Unspecified dimension.</summary>
@@ -2232,6 +2236,10 @@ namespace Google.Apis.Adsense.v2
                 /// <summary>Required. Reporting metrics.</summary>
                 [Google.Apis.Util.RequestParameterAttribute("metrics", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<MetricsEnum> Metrics { get; set; }
+
+                /// <summary>Required. Reporting metrics.</summary>
+                [Google.Apis.Util.RequestParameterAttribute("metrics", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<MetricsEnum> MetricsList { get; set; }
 
                 /// <summary>Required. Reporting metrics.</summary>
                 public enum MetricsEnum
@@ -2699,6 +2707,10 @@ namespace Google.Apis.Adsense.v2
                 public virtual System.Nullable<DimensionsEnum> Dimensions { get; set; }
 
                 /// <summary>Dimensions to base the report on.</summary>
+                [Google.Apis.Util.RequestParameterAttribute("dimensions", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<DimensionsEnum> DimensionsList { get; set; }
+
+                /// <summary>Dimensions to base the report on.</summary>
                 public enum DimensionsEnum
                 {
                     /// <summary>Unspecified dimension.</summary>
@@ -2988,6 +3000,10 @@ namespace Google.Apis.Adsense.v2
                 /// <summary>Required. Reporting metrics.</summary>
                 [Google.Apis.Util.RequestParameterAttribute("metrics", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<MetricsEnum> Metrics { get; set; }
+
+                /// <summary>Required. Reporting metrics.</summary>
+                [Google.Apis.Util.RequestParameterAttribute("metrics", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<MetricsEnum> MetricsList { get; set; }
 
                 /// <summary>Required. Reporting metrics.</summary>
                 public enum MetricsEnum

--- a/Src/Generated/Google.Apis.AndroidManagement.v1/Google.Apis.AndroidManagement.v1.cs
+++ b/Src/Generated/Google.Apis.AndroidManagement.v1/Google.Apis.AndroidManagement.v1.cs
@@ -691,6 +691,10 @@ namespace Google.Apis.AndroidManagement.v1
                 public virtual System.Nullable<WipeDataFlagsEnum> WipeDataFlags { get; set; }
 
                 /// <summary>Optional flags that control the device wiping behavior.</summary>
+                [Google.Apis.Util.RequestParameterAttribute("wipeDataFlags", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<WipeDataFlagsEnum> WipeDataFlagsList { get; set; }
+
+                /// <summary>Optional flags that control the device wiping behavior.</summary>
                 public enum WipeDataFlagsEnum
                 {
                     /// <summary>This value is ignored.</summary>

--- a/Src/Generated/Google.Apis.BigQueryDataTransfer.v1/Google.Apis.BigQueryDataTransfer.v1.cs
+++ b/Src/Generated/Google.Apis.BigQueryDataTransfer.v1/Google.Apis.BigQueryDataTransfer.v1.cs
@@ -856,6 +856,13 @@ namespace Google.Apis.BigQueryDataTransfer.v1
                             /// Message types to return. If not populated - INFO, WARNING and ERROR messages are
                             /// returned.
                             /// </summary>
+                            [Google.Apis.Util.RequestParameterAttribute("messageTypes", Google.Apis.Util.RequestParameterType.Query)]
+                            public virtual Google.Apis.Util.Repeatable<MessageTypesEnum> MessageTypesList { get; set; }
+
+                            /// <summary>
+                            /// Message types to return. If not populated - INFO, WARNING and ERROR messages are
+                            /// returned.
+                            /// </summary>
                             public enum MessageTypesEnum
                             {
                                 /// <summary>No severity specified.</summary>
@@ -1106,6 +1113,10 @@ namespace Google.Apis.BigQueryDataTransfer.v1
                         /// <summary>When specified, only transfer runs with requested states are returned.</summary>
                         [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<StatesEnum> States { get; set; }
+
+                        /// <summary>When specified, only transfer runs with requested states are returned.</summary>
+                        [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<StatesEnum> StatesList { get; set; }
 
                         /// <summary>When specified, only transfer runs with requested states are returned.</summary>
                         public enum StatesEnum
@@ -2018,6 +2029,12 @@ namespace Google.Apis.BigQueryDataTransfer.v1
                         /// <summary>
                         /// Message types to return. If not populated - INFO, WARNING and ERROR messages are returned.
                         /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("messageTypes", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<MessageTypesEnum> MessageTypesList { get; set; }
+
+                        /// <summary>
+                        /// Message types to return. If not populated - INFO, WARNING and ERROR messages are returned.
+                        /// </summary>
                         public enum MessageTypesEnum
                         {
                             /// <summary>No severity specified.</summary>
@@ -2264,6 +2281,10 @@ namespace Google.Apis.BigQueryDataTransfer.v1
                     /// <summary>When specified, only transfer runs with requested states are returned.</summary>
                     [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<StatesEnum> States { get; set; }
+
+                    /// <summary>When specified, only transfer runs with requested states are returned.</summary>
+                    [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
+                    public virtual Google.Apis.Util.Repeatable<StatesEnum> StatesList { get; set; }
 
                     /// <summary>When specified, only transfer runs with requested states are returned.</summary>
                     public enum StatesEnum

--- a/Src/Generated/Google.Apis.Bigquery.v2/Google.Apis.Bigquery.v2.cs
+++ b/Src/Generated/Google.Apis.Bigquery.v2/Google.Apis.Bigquery.v2.cs
@@ -1338,6 +1338,10 @@ namespace Google.Apis.Bigquery.v2
             public virtual System.Nullable<StateFilterEnum> StateFilter { get; set; }
 
             /// <summary>Filter for job state</summary>
+            [Google.Apis.Util.RequestParameterAttribute("stateFilter", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StateFilterEnum> StateFilterList { get; set; }
+
+            /// <summary>Filter for job state</summary>
             public enum StateFilterEnum
             {
                 /// <summary>Finished jobs</summary>

--- a/Src/Generated/Google.Apis.Blogger.v3/Google.Apis.Blogger.v3.cs
+++ b/Src/Generated/Google.Apis.Blogger.v3/Google.Apis.Blogger.v3.cs
@@ -577,6 +577,9 @@ namespace Google.Apis.Blogger.v3
             [Google.Apis.Util.RequestParameterAttribute("role", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<RoleEnum> Role { get; set; }
 
+            [Google.Apis.Util.RequestParameterAttribute("role", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<RoleEnum> RoleList { get; set; }
+
             public enum RoleEnum
             {
                 /// <summary></summary>
@@ -599,6 +602,10 @@ namespace Google.Apis.Blogger.v3
             /// <summary>Default value of status is LIVE.</summary>
             [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<StatusEnum> Status { get; set; }
+
+            /// <summary>Default value of status is LIVE.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusEnum> StatusList { get; set; }
 
             /// <summary>Default value of status is LIVE.</summary>
             public enum StatusEnum
@@ -1155,6 +1162,9 @@ namespace Google.Apis.Blogger.v3
             [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<StatusEnum> Status { get; set; }
 
+            [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusEnum> StatusList { get; set; }
+
             public enum StatusEnum
             {
                 /// <summary></summary>
@@ -1423,6 +1433,9 @@ namespace Google.Apis.Blogger.v3
 
             [Google.Apis.Util.RequestParameterAttribute("range", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<RangeEnum> Range { get; set; }
+
+            [Google.Apis.Util.RequestParameterAttribute("range", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<RangeEnum> RangeList { get; set; }
 
             public enum RangeEnum
             {
@@ -1724,6 +1737,9 @@ namespace Google.Apis.Blogger.v3
 
             [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<StatusEnum> Status { get; set; }
+
+            [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusEnum> StatusList { get; set; }
 
             public enum StatusEnum
             {
@@ -2269,6 +2285,9 @@ namespace Google.Apis.Blogger.v3
 
             [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<StatusEnum> Status { get; set; }
+
+            [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusEnum> StatusList { get; set; }
 
             public enum StatusEnum
             {
@@ -2847,6 +2866,9 @@ namespace Google.Apis.Blogger.v3
 
             [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<StatusEnum> Status { get; set; }
+
+            [Google.Apis.Util.RequestParameterAttribute("status", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusEnum> StatusList { get; set; }
 
             public enum StatusEnum
             {

--- a/Src/Generated/Google.Apis.Books.v1/Google.Apis.Books.v1.cs
+++ b/Src/Generated/Google.Apis.Books.v1/Google.Apis.Books.v1.cs
@@ -2247,6 +2247,10 @@ namespace Google.Apis.Books.v1
             public virtual System.Nullable<FeaturesEnum> Features { get; set; }
 
             /// <summary>List of features supported by the client, i.e., 'RENTALS'</summary>
+            [Google.Apis.Util.RequestParameterAttribute("features", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<FeaturesEnum> FeaturesList { get; set; }
+
+            /// <summary>List of features supported by the client, i.e., 'RENTALS'</summary>
             public enum FeaturesEnum
             {
                 /// <summary></summary>
@@ -4811,6 +4815,10 @@ namespace Google.Apis.Books.v1
                 public virtual System.Nullable<AcquireMethodEnum> AcquireMethod { get; set; }
 
                 /// <summary>How the book was acquired</summary>
+                [Google.Apis.Util.RequestParameterAttribute("acquireMethod", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<AcquireMethodEnum> AcquireMethodList { get; set; }
+
+                /// <summary>How the book was acquired</summary>
                 public enum AcquireMethodEnum
                 {
                     /// <summary></summary>
@@ -4870,6 +4878,13 @@ namespace Google.Apis.Books.v1
                 /// </summary>
                 [Google.Apis.Util.RequestParameterAttribute("processingState", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<ProcessingStateEnum> ProcessingState { get; set; }
+
+                /// <summary>
+                /// The processing state of the user uploaded volumes to be returned. Applicable only if the UPLOADED is
+                /// specified in the acquireMethod.
+                /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("processingState", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<ProcessingStateEnum> ProcessingStateList { get; set; }
 
                 /// <summary>
                 /// The processing state of the user uploaded volumes to be returned. Applicable only if the UPLOADED is
@@ -5230,6 +5245,10 @@ namespace Google.Apis.Books.v1
                 /// <summary>The processing state of the user uploaded volumes to be returned.</summary>
                 [Google.Apis.Util.RequestParameterAttribute("processingState", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<ProcessingStateEnum> ProcessingState { get; set; }
+
+                /// <summary>The processing state of the user uploaded volumes to be returned.</summary>
+                [Google.Apis.Util.RequestParameterAttribute("processingState", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<ProcessingStateEnum> ProcessingStateList { get; set; }
 
                 /// <summary>The processing state of the user uploaded volumes to be returned.</summary>
                 public enum ProcessingStateEnum

--- a/Src/Generated/Google.Apis.CivicInfo.v2/Google.Apis.CivicInfo.v2.cs
+++ b/Src/Generated/Google.Apis.CivicInfo.v2/Google.Apis.CivicInfo.v2.cs
@@ -505,6 +505,13 @@ namespace Google.Apis.CivicInfo.v2
             /// A list of office levels to filter by. Only offices that serve at least one of these levels will be
             /// returned. Divisions that don't contain a matching office will not be returned.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("levels", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<LevelsEnum> LevelsList { get; set; }
+
+            /// <summary>
+            /// A list of office levels to filter by. Only offices that serve at least one of these levels will be
+            /// returned. Divisions that don't contain a matching office will not be returned.
+            /// </summary>
             public enum LevelsEnum
             {
                 /// <summary></summary>
@@ -550,6 +557,13 @@ namespace Google.Apis.CivicInfo.v2
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("roles", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<RolesEnum> Roles { get; set; }
+
+            /// <summary>
+            /// A list of office roles to filter by. Only offices fulfilling one of these roles will be returned.
+            /// Divisions that don't contain a matching office will not be returned.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("roles", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<RolesEnum> RolesList { get; set; }
 
             /// <summary>
             /// A list of office roles to filter by. Only offices fulfilling one of these roles will be returned.
@@ -686,6 +700,13 @@ namespace Google.Apis.CivicInfo.v2
             /// A list of office levels to filter by. Only offices that serve at least one of these levels will be
             /// returned. Divisions that don't contain a matching office will not be returned.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("levels", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<LevelsEnum> LevelsList { get; set; }
+
+            /// <summary>
+            /// A list of office levels to filter by. Only offices that serve at least one of these levels will be
+            /// returned. Divisions that don't contain a matching office will not be returned.
+            /// </summary>
             public enum LevelsEnum
             {
                 /// <summary></summary>
@@ -739,6 +760,13 @@ namespace Google.Apis.CivicInfo.v2
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("roles", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<RolesEnum> Roles { get; set; }
+
+            /// <summary>
+            /// A list of office roles to filter by. Only offices fulfilling one of these roles will be returned.
+            /// Divisions that don't contain a matching office will not be returned.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("roles", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<RolesEnum> RolesList { get; set; }
 
             /// <summary>
             /// A list of office roles to filter by. Only offices fulfilling one of these roles will be returned.

--- a/Src/Generated/Google.Apis.Classroom.v1/Google.Apis.Classroom.v1.cs
+++ b/Src/Generated/Google.Apis.Classroom.v1/Google.Apis.Classroom.v1.cs
@@ -982,6 +982,13 @@ namespace Google.Apis.Classroom.v1
                 /// Restriction on the `state` of announcements returned. If this argument is left unspecified, the
                 /// default value is `PUBLISHED`.
                 /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("announcementStates", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<AnnouncementStatesEnum> AnnouncementStatesList { get; set; }
+
+                /// <summary>
+                /// Restriction on the `state` of announcements returned. If this argument is left unspecified, the
+                /// default value is `PUBLISHED`.
+                /// </summary>
                 public enum AnnouncementStatesEnum
                 {
                     /// <summary>No state specified. This is never returned.</summary>
@@ -1501,6 +1508,13 @@ namespace Google.Apis.Classroom.v1
                     /// </summary>
                     [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
                     public virtual System.Nullable<StatesEnum> States { get; set; }
+
+                    /// <summary>
+                    /// Requested submission states. If specified, returned student submissions match one of the
+                    /// specified submission states.
+                    /// </summary>
+                    [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
+                    public virtual Google.Apis.Util.Repeatable<StatesEnum> StatesList { get; set; }
 
                     /// <summary>
                     /// Requested submission states. If specified, returned student submissions match one of the
@@ -2452,6 +2466,13 @@ namespace Google.Apis.Classroom.v1
                 /// Restriction on the work status to return. Only courseWork that matches is returned. If unspecified,
                 /// items with a work status of `PUBLISHED` is returned.
                 /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("courseWorkStates", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<CourseWorkStatesEnum> CourseWorkStatesList { get; set; }
+
+                /// <summary>
+                /// Restriction on the work status to return. Only courseWork that matches is returned. If unspecified,
+                /// items with a work status of `PUBLISHED` is returned.
+                /// </summary>
                 public enum CourseWorkStatesEnum
                 {
                     /// <summary>No state specified. This is never returned.</summary>
@@ -3042,6 +3063,13 @@ namespace Google.Apis.Classroom.v1
                 /// </summary>
                 [Google.Apis.Util.RequestParameterAttribute("courseWorkMaterialStates", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<CourseWorkMaterialStatesEnum> CourseWorkMaterialStates { get; set; }
+
+                /// <summary>
+                /// Restriction on the work status to return. Only course work material that matches is returned. If
+                /// unspecified, items with a work status of `PUBLISHED` is returned.
+                /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("courseWorkMaterialStates", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<CourseWorkMaterialStatesEnum> CourseWorkMaterialStatesList { get; set; }
 
                 /// <summary>
                 /// Restriction on the work status to return. Only course work material that matches is returned. If
@@ -4611,6 +4639,13 @@ namespace Google.Apis.Classroom.v1
             /// Restricts returned courses to those in one of the specified states The default value is ACTIVE,
             /// ARCHIVED, PROVISIONED, DECLINED.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("courseStates", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<CourseStatesEnum> CourseStatesList { get; set; }
+
+            /// <summary>
+            /// Restricts returned courses to those in one of the specified states The default value is ACTIVE,
+            /// ARCHIVED, PROVISIONED, DECLINED.
+            /// </summary>
             public enum CourseStatesEnum
             {
                 /// <summary>No course state. No returned Course message will use this value.</summary>
@@ -5636,6 +5671,13 @@ namespace Google.Apis.Classroom.v1
                 /// </summary>
                 [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<StatesEnum> States { get; set; }
+
+                /// <summary>
+                /// If specified, only results with the specified `state` values are returned. Otherwise, results with a
+                /// `state` of `PENDING` are returned.
+                /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("states", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<StatesEnum> StatesList { get; set; }
 
                 /// <summary>
                 /// If specified, only results with the specified `state` values are returned. Otherwise, results with a

--- a/Src/Generated/Google.Apis.Dfareporting.v3_3/Google.Apis.Dfareporting.v3_3.cs
+++ b/Src/Generated/Google.Apis.Dfareporting.v3_3/Google.Apis.Dfareporting.v3_3.cs
@@ -1920,6 +1920,10 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<TypeEnum> Type { get; set; }
 
             /// <summary>Select only ads with these types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TypeEnum> TypeList { get; set; }
+
+            /// <summary>Select only ads with these types.</summary>
             public enum TypeEnum
             {
                 /// <summary></summary>
@@ -7687,6 +7691,10 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<TypesEnum> Types { get; set; }
 
             /// <summary>Select only creatives with these creative types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("types", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TypesEnum> TypesList { get; set; }
+
+            /// <summary>Select only creatives with these creative types.</summary>
             public enum TypesEnum
             {
                 /// <summary></summary>
@@ -9044,6 +9052,14 @@ namespace Google.Apis.Dfareporting.v3_3
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("eventTagTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<EventTagTypesEnum> EventTagTypes { get; set; }
+
+            /// <summary>
+            /// Select only event tags with the specified event tag types. Event tag types can be used to specify
+            /// whether to use a third-party pixel, a third-party JavaScript URL, or a third-party click-through URL for
+            /// either impression or click tracking.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("eventTagTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<EventTagTypesEnum> EventTagTypesList { get; set; }
 
             /// <summary>
             /// Select only event tags with the specified event tag types. Event tag types can be used to specify
@@ -11501,6 +11517,10 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<DirectoriesEnum> Directories { get; set; }
 
             /// <summary>Select only apps from these directories.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("directories", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<DirectoriesEnum> DirectoriesList { get; set; }
+
+            /// <summary>Select only apps from these directories.</summary>
             public enum DirectoriesEnum
             {
                 /// <summary></summary>
@@ -12750,6 +12770,10 @@ namespace Google.Apis.Dfareporting.v3_3
             public virtual System.Nullable<PricingTypesEnum> PricingTypes { get; set; }
 
             /// <summary>Select only placement groups with these pricing types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<PricingTypesEnum> PricingTypesList { get; set; }
+
+            /// <summary>Select only placement groups with these pricing types.</summary>
             public enum PricingTypesEnum
             {
                 /// <summary></summary>
@@ -13628,6 +13652,13 @@ namespace Google.Apis.Dfareporting.v3_3
             /// Tag formats to generate for these placements. *Note:* PLACEMENT_TAG_STANDARD can only be generated for
             /// 1x1 placements.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("tagFormats", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TagFormatsEnum> TagFormatsList { get; set; }
+
+            /// <summary>
+            /// Tag formats to generate for these placements. *Note:* PLACEMENT_TAG_STANDARD can only be generated for
+            /// 1x1 placements.
+            /// </summary>
             public enum TagFormatsEnum
             {
                 /// <summary></summary>
@@ -13918,6 +13949,15 @@ namespace Google.Apis.Dfareporting.v3_3
             /// APP and APP_INTERSTITIAL are for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering in
             /// in-stream video ads developed with the VAST standard.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("compatibilities", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<CompatibilitiesEnum> CompatibilitiesList { get; set; }
+
+            /// <summary>
+            /// Select only placements that are associated with these compatibilities. DISPLAY and DISPLAY_INTERSTITIAL
+            /// refer to rendering either on desktop or on mobile devices for regular or interstitial ads respectively.
+            /// APP and APP_INTERSTITIAL are for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering in
+            /// in-stream video ads developed with the VAST standard.
+            /// </summary>
             public enum CompatibilitiesEnum
             {
                 /// <summary></summary>
@@ -14020,6 +14060,10 @@ namespace Google.Apis.Dfareporting.v3_3
             /// <summary>Select only placements with these pricing types.</summary>
             [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<PricingTypesEnum> PricingTypes { get; set; }
+
+            /// <summary>Select only placements with these pricing types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<PricingTypesEnum> PricingTypesList { get; set; }
 
             /// <summary>Select only placements with these pricing types.</summary>
             public enum PricingTypesEnum

--- a/Src/Generated/Google.Apis.Dfareporting.v3_4/Google.Apis.Dfareporting.v3_4.cs
+++ b/Src/Generated/Google.Apis.Dfareporting.v3_4/Google.Apis.Dfareporting.v3_4.cs
@@ -1924,6 +1924,10 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<TypeEnum> Type { get; set; }
 
             /// <summary>Select only ads with these types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TypeEnum> TypeList { get; set; }
+
+            /// <summary>Select only ads with these types.</summary>
             public enum TypeEnum
             {
                 /// <summary></summary>
@@ -7691,6 +7695,10 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<TypesEnum> Types { get; set; }
 
             /// <summary>Select only creatives with these creative types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("types", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TypesEnum> TypesList { get; set; }
+
+            /// <summary>Select only creatives with these creative types.</summary>
             public enum TypesEnum
             {
                 /// <summary></summary>
@@ -9116,6 +9124,14 @@ namespace Google.Apis.Dfareporting.v3_4
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("eventTagTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<EventTagTypesEnum> EventTagTypes { get; set; }
+
+            /// <summary>
+            /// Select only event tags with the specified event tag types. Event tag types can be used to specify
+            /// whether to use a third-party pixel, a third-party JavaScript URL, or a third-party click-through URL for
+            /// either impression or click tracking.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("eventTagTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<EventTagTypesEnum> EventTagTypesList { get; set; }
 
             /// <summary>
             /// Select only event tags with the specified event tag types. Event tag types can be used to specify
@@ -11573,6 +11589,10 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<DirectoriesEnum> Directories { get; set; }
 
             /// <summary>Select only apps from these directories.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("directories", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<DirectoriesEnum> DirectoriesList { get; set; }
+
+            /// <summary>Select only apps from these directories.</summary>
             public enum DirectoriesEnum
             {
                 /// <summary></summary>
@@ -12822,6 +12842,10 @@ namespace Google.Apis.Dfareporting.v3_4
             public virtual System.Nullable<PricingTypesEnum> PricingTypes { get; set; }
 
             /// <summary>Select only placement groups with these pricing types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<PricingTypesEnum> PricingTypesList { get; set; }
+
+            /// <summary>Select only placement groups with these pricing types.</summary>
             public enum PricingTypesEnum
             {
                 /// <summary></summary>
@@ -13700,6 +13724,13 @@ namespace Google.Apis.Dfareporting.v3_4
             /// Tag formats to generate for these placements. *Note:* PLACEMENT_TAG_STANDARD can only be generated for
             /// 1x1 placements.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("tagFormats", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TagFormatsEnum> TagFormatsList { get; set; }
+
+            /// <summary>
+            /// Tag formats to generate for these placements. *Note:* PLACEMENT_TAG_STANDARD can only be generated for
+            /// 1x1 placements.
+            /// </summary>
             public enum TagFormatsEnum
             {
                 /// <summary></summary>
@@ -13990,6 +14021,15 @@ namespace Google.Apis.Dfareporting.v3_4
             /// APP and APP_INTERSTITIAL are for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering in
             /// in-stream video ads developed with the VAST standard.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("compatibilities", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<CompatibilitiesEnum> CompatibilitiesList { get; set; }
+
+            /// <summary>
+            /// Select only placements that are associated with these compatibilities. DISPLAY and DISPLAY_INTERSTITIAL
+            /// refer to rendering either on desktop or on mobile devices for regular or interstitial ads respectively.
+            /// APP and APP_INTERSTITIAL are for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering in
+            /// in-stream video ads developed with the VAST standard.
+            /// </summary>
             public enum CompatibilitiesEnum
             {
                 /// <summary></summary>
@@ -14092,6 +14132,10 @@ namespace Google.Apis.Dfareporting.v3_4
             /// <summary>Select only placements with these pricing types.</summary>
             [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<PricingTypesEnum> PricingTypes { get; set; }
+
+            /// <summary>Select only placements with these pricing types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<PricingTypesEnum> PricingTypesList { get; set; }
 
             /// <summary>Select only placements with these pricing types.</summary>
             public enum PricingTypesEnum

--- a/Src/Generated/Google.Apis.Dfareporting.v3_5/Google.Apis.Dfareporting.v3_5.cs
+++ b/Src/Generated/Google.Apis.Dfareporting.v3_5/Google.Apis.Dfareporting.v3_5.cs
@@ -1920,6 +1920,10 @@ namespace Google.Apis.Dfareporting.v3_5
             public virtual System.Nullable<TypeEnum> Type { get; set; }
 
             /// <summary>Select only ads with these types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TypeEnum> TypeList { get; set; }
+
+            /// <summary>Select only ads with these types.</summary>
             public enum TypeEnum
             {
                 /// <summary></summary>
@@ -7687,6 +7691,10 @@ namespace Google.Apis.Dfareporting.v3_5
             public virtual System.Nullable<TypesEnum> Types { get; set; }
 
             /// <summary>Select only creatives with these creative types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("types", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TypesEnum> TypesList { get; set; }
+
+            /// <summary>Select only creatives with these creative types.</summary>
             public enum TypesEnum
             {
                 /// <summary></summary>
@@ -9044,6 +9052,14 @@ namespace Google.Apis.Dfareporting.v3_5
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("eventTagTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<EventTagTypesEnum> EventTagTypes { get; set; }
+
+            /// <summary>
+            /// Select only event tags with the specified event tag types. Event tag types can be used to specify
+            /// whether to use a third-party pixel, a third-party JavaScript URL, or a third-party click-through URL for
+            /// either impression or click tracking.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("eventTagTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<EventTagTypesEnum> EventTagTypesList { get; set; }
 
             /// <summary>
             /// Select only event tags with the specified event tag types. Event tag types can be used to specify
@@ -11501,6 +11517,10 @@ namespace Google.Apis.Dfareporting.v3_5
             public virtual System.Nullable<DirectoriesEnum> Directories { get; set; }
 
             /// <summary>Select only apps from these directories.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("directories", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<DirectoriesEnum> DirectoriesList { get; set; }
+
+            /// <summary>Select only apps from these directories.</summary>
             public enum DirectoriesEnum
             {
                 /// <summary></summary>
@@ -12750,6 +12770,10 @@ namespace Google.Apis.Dfareporting.v3_5
             public virtual System.Nullable<PricingTypesEnum> PricingTypes { get; set; }
 
             /// <summary>Select only placement groups with these pricing types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<PricingTypesEnum> PricingTypesList { get; set; }
+
+            /// <summary>Select only placement groups with these pricing types.</summary>
             public enum PricingTypesEnum
             {
                 /// <summary></summary>
@@ -13628,6 +13652,13 @@ namespace Google.Apis.Dfareporting.v3_5
             /// Tag formats to generate for these placements. *Note:* PLACEMENT_TAG_STANDARD can only be generated for
             /// 1x1 placements.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("tagFormats", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TagFormatsEnum> TagFormatsList { get; set; }
+
+            /// <summary>
+            /// Tag formats to generate for these placements. *Note:* PLACEMENT_TAG_STANDARD can only be generated for
+            /// 1x1 placements.
+            /// </summary>
             public enum TagFormatsEnum
             {
                 /// <summary></summary>
@@ -13918,6 +13949,15 @@ namespace Google.Apis.Dfareporting.v3_5
             /// APP and APP_INTERSTITIAL are for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering in
             /// in-stream video ads developed with the VAST standard.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("compatibilities", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<CompatibilitiesEnum> CompatibilitiesList { get; set; }
+
+            /// <summary>
+            /// Select only placements that are associated with these compatibilities. DISPLAY and DISPLAY_INTERSTITIAL
+            /// refer to rendering either on desktop or on mobile devices for regular or interstitial ads respectively.
+            /// APP and APP_INTERSTITIAL are for rendering in mobile apps. IN_STREAM_VIDEO refers to rendering in
+            /// in-stream video ads developed with the VAST standard.
+            /// </summary>
             public enum CompatibilitiesEnum
             {
                 /// <summary></summary>
@@ -14020,6 +14060,10 @@ namespace Google.Apis.Dfareporting.v3_5
             /// <summary>Select only placements with these pricing types.</summary>
             [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<PricingTypesEnum> PricingTypes { get; set; }
+
+            /// <summary>Select only placements with these pricing types.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("pricingTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<PricingTypesEnum> PricingTypesList { get; set; }
 
             /// <summary>Select only placements with these pricing types.</summary>
             public enum PricingTypesEnum

--- a/Src/Generated/Google.Apis.Essentialcontacts.v1/Google.Apis.Essentialcontacts.v1.cs
+++ b/Src/Generated/Google.Apis.Essentialcontacts.v1/Google.Apis.Essentialcontacts.v1.cs
@@ -345,6 +345,13 @@ namespace Google.Apis.Essentialcontacts.v1
                 /// The categories of notifications to compute contacts for. If ALL is included in this list, contacts
                 /// subscribed to any notification category will be returned.
                 /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("notificationCategories", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<NotificationCategoriesEnum> NotificationCategoriesList { get; set; }
+
+                /// <summary>
+                /// The categories of notifications to compute contacts for. If ALL is included in this list, contacts
+                /// subscribed to any notification category will be returned.
+                /// </summary>
                 public enum NotificationCategoriesEnum
                 {
                     /// <summary>Notification category is unrecognized or unspecified.</summary>
@@ -929,6 +936,13 @@ namespace Google.Apis.Essentialcontacts.v1
                 /// The categories of notifications to compute contacts for. If ALL is included in this list, contacts
                 /// subscribed to any notification category will be returned.
                 /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("notificationCategories", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<NotificationCategoriesEnum> NotificationCategoriesList { get; set; }
+
+                /// <summary>
+                /// The categories of notifications to compute contacts for. If ALL is included in this list, contacts
+                /// subscribed to any notification category will be returned.
+                /// </summary>
                 public enum NotificationCategoriesEnum
                 {
                     /// <summary>Notification category is unrecognized or unspecified.</summary>
@@ -1508,6 +1522,13 @@ namespace Google.Apis.Essentialcontacts.v1
                 /// </summary>
                 [Google.Apis.Util.RequestParameterAttribute("notificationCategories", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<NotificationCategoriesEnum> NotificationCategories { get; set; }
+
+                /// <summary>
+                /// The categories of notifications to compute contacts for. If ALL is included in this list, contacts
+                /// subscribed to any notification category will be returned.
+                /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("notificationCategories", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<NotificationCategoriesEnum> NotificationCategoriesList { get; set; }
 
                 /// <summary>
                 /// The categories of notifications to compute contacts for. If ALL is included in this list, contacts

--- a/Src/Generated/Google.Apis.Gmail.v1/Google.Apis.Gmail.v1.cs
+++ b/Src/Generated/Google.Apis.Gmail.v1/Google.Apis.Gmail.v1.cs
@@ -1338,6 +1338,10 @@ namespace Google.Apis.Gmail.v1
                 public virtual System.Nullable<HistoryTypesEnum> HistoryTypes { get; set; }
 
                 /// <summary>History types to be returned by the function</summary>
+                [Google.Apis.Util.RequestParameterAttribute("historyTypes", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<HistoryTypesEnum> HistoryTypesList { get; set; }
+
+                /// <summary>History types to be returned by the function</summary>
                 public enum HistoryTypesEnum
                 {
                     /// <summary></summary>

--- a/Src/Generated/Google.Apis.Iam.v1/Google.Apis.Iam.v1.cs
+++ b/Src/Generated/Google.Apis.Iam.v1/Google.Apis.Iam.v1.cs
@@ -2957,6 +2957,13 @@ namespace Google.Apis.Iam.v1
                     /// Filters the types of keys the user wants to include in the list response. Duplicate key types
                     /// are not allowed. If no key type is provided, all keys are returned.
                     /// </summary>
+                    [Google.Apis.Util.RequestParameterAttribute("keyTypes", Google.Apis.Util.RequestParameterType.Query)]
+                    public virtual Google.Apis.Util.Repeatable<KeyTypesEnum> KeyTypesList { get; set; }
+
+                    /// <summary>
+                    /// Filters the types of keys the user wants to include in the list response. Duplicate key types
+                    /// are not allowed. If no key type is provided, all keys are returned.
+                    /// </summary>
                     public enum KeyTypesEnum
                     {
                         /// <summary>

--- a/Src/Generated/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
+++ b/Src/Generated/Google.Apis.ManufacturerCenter.v1/Google.Apis.ManufacturerCenter.v1.cs
@@ -430,6 +430,12 @@ namespace Google.Apis.ManufacturerCenter.v1
                 /// <summary>
                 /// The information to be included in the response. Only sections listed here will be returned.
                 /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("include", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<IncludeEnum> IncludeList { get; set; }
+
+                /// <summary>
+                /// The information to be included in the response. Only sections listed here will be returned.
+                /// </summary>
                 public enum IncludeEnum
                 {
                     /// <summary>Unknown, never used.</summary>
@@ -521,6 +527,12 @@ namespace Google.Apis.ManufacturerCenter.v1
                 /// </summary>
                 [Google.Apis.Util.RequestParameterAttribute("include", Google.Apis.Util.RequestParameterType.Query)]
                 public virtual System.Nullable<IncludeEnum> Include { get; set; }
+
+                /// <summary>
+                /// The information to be included in the response. Only sections listed here will be returned.
+                /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("include", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<IncludeEnum> IncludeList { get; set; }
 
                 /// <summary>
                 /// The information to be included in the response. Only sections listed here will be returned.

--- a/Src/Generated/Google.Apis.PagespeedInsights.v5/Google.Apis.PagespeedInsights.v5.cs
+++ b/Src/Generated/Google.Apis.PagespeedInsights.v5/Google.Apis.PagespeedInsights.v5.cs
@@ -315,6 +315,12 @@ namespace Google.Apis.PagespeedInsights.v5
             /// <summary>
             /// A Lighthouse category to run; if none are given, only Performance category will be run
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("category", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<CategoryEnum> CategoryList { get; set; }
+
+            /// <summary>
+            /// A Lighthouse category to run; if none are given, only Performance category will be run
+            /// </summary>
             public enum CategoryEnum
             {
                 /// <summary>Default UNDEFINED category.</summary>

--- a/Src/Generated/Google.Apis.PeopleService.v1/Google.Apis.PeopleService.v1.cs
+++ b/Src/Generated/Google.Apis.PeopleService.v1/Google.Apis.PeopleService.v1.cs
@@ -1014,6 +1014,12 @@ namespace Google.Apis.PeopleService.v1
             /// <summary>
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT if not set.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT if not set.
+            /// </summary>
             public enum SourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -1356,6 +1362,13 @@ namespace Google.Apis.PeopleService.v1
                 /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
                 /// READ_SOURCE_TYPE_PROFILE if not set.
                 /// </summary>
+                [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+                public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
+
+                /// <summary>
+                /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
+                /// READ_SOURCE_TYPE_PROFILE if not set.
+                /// </summary>
                 public enum SourcesEnum
                 {
                     /// <summary>Unspecified.</summary>
@@ -1657,6 +1670,13 @@ namespace Google.Apis.PeopleService.v1
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
             /// READ_SOURCE_TYPE_PROFILE if not set.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
+            /// READ_SOURCE_TYPE_PROFILE if not set.
+            /// </summary>
             public enum SourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -1802,6 +1822,13 @@ namespace Google.Apis.PeopleService.v1
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
             /// READ_SOURCE_TYPE_PROFILE if not set.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
+            /// READ_SOURCE_TYPE_PROFILE if not set.
+            /// </summary>
             public enum SourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -1922,6 +1949,13 @@ namespace Google.Apis.PeopleService.v1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SourcesEnum> Sources { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_PROFILE and
+            /// READ_SOURCE_TYPE_CONTACT if not set.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
 
             /// <summary>
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_PROFILE and
@@ -2058,6 +2092,13 @@ namespace Google.Apis.PeopleService.v1
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
             /// READ_SOURCE_TYPE_PROFILE if not set.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
+            /// READ_SOURCE_TYPE_PROFILE if not set.
+            /// </summary>
             public enum SourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -2165,6 +2206,13 @@ namespace Google.Apis.PeopleService.v1
             /// Optional. Additional data to merge into the directory sources if they are connected through verified
             /// join keys such as email addresses or phone numbers.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("mergeSources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<MergeSourcesEnum> MergeSourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. Additional data to merge into the directory sources if they are connected through verified
+            /// join keys such as email addresses or phone numbers.
+            /// </summary>
             public enum MergeSourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -2213,6 +2261,10 @@ namespace Google.Apis.PeopleService.v1
             /// <summary>Required. Directory sources to return.</summary>
             [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SourcesEnum> Sources { get; set; }
+
+            /// <summary>Required. Directory sources to return.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
 
             /// <summary>Required. Directory sources to return.</summary>
             public enum SourcesEnum
@@ -2373,6 +2425,12 @@ namespace Google.Apis.PeopleService.v1
             /// <summary>
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT if not set.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT if not set.
+            /// </summary>
             public enum SourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -2472,6 +2530,13 @@ namespace Google.Apis.PeopleService.v1
             /// Optional. Additional data to merge into the directory sources if they are connected through verified
             /// join keys such as email addresses or phone numbers.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("mergeSources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<MergeSourcesEnum> MergeSourcesList { get; set; }
+
+            /// <summary>
+            /// Optional. Additional data to merge into the directory sources if they are connected through verified
+            /// join keys such as email addresses or phone numbers.
+            /// </summary>
             public enum MergeSourcesEnum
             {
                 /// <summary>Unspecified.</summary>
@@ -2519,6 +2584,10 @@ namespace Google.Apis.PeopleService.v1
             /// <summary>Required. Directory sources to return.</summary>
             [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SourcesEnum> Sources { get; set; }
+
+            /// <summary>Required. Directory sources to return.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
 
             /// <summary>Required. Directory sources to return.</summary>
             public enum SourcesEnum
@@ -2666,6 +2735,13 @@ namespace Google.Apis.PeopleService.v1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<SourcesEnum> Sources { get; set; }
+
+            /// <summary>
+            /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and
+            /// READ_SOURCE_TYPE_PROFILE if not set.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("sources", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<SourcesEnum> SourcesList { get; set; }
 
             /// <summary>
             /// Optional. A mask of what source types to return. Defaults to READ_SOURCE_TYPE_CONTACT and

--- a/Src/Generated/Google.Apis.Script.v1/Google.Apis.Script.v1.cs
+++ b/Src/Generated/Google.Apis.Script.v1/Google.Apis.Script.v1.cs
@@ -470,6 +470,12 @@ namespace Google.Apis.Script.v1
             /// <summary>
             /// Optional field used to limit returned processes to those having one of the specified process statuses.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("userProcessFilter.statuses", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<UserProcessFilterStatusesEnum> UserProcessFilterStatusesList { get; set; }
+
+            /// <summary>
+            /// Optional field used to limit returned processes to those having one of the specified process statuses.
+            /// </summary>
             public enum UserProcessFilterStatusesEnum
             {
                 /// <summary>Unspecified status.</summary>
@@ -514,6 +520,12 @@ namespace Google.Apis.Script.v1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("userProcessFilter.types", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<UserProcessFilterTypesEnum> UserProcessFilterTypes { get; set; }
+
+            /// <summary>
+            /// Optional field used to limit returned processes to those having one of the specified process types.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("userProcessFilter.types", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<UserProcessFilterTypesEnum> UserProcessFilterTypesList { get; set; }
 
             /// <summary>
             /// Optional field used to limit returned processes to those having one of the specified process types.
@@ -566,6 +578,12 @@ namespace Google.Apis.Script.v1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("userProcessFilter.userAccessLevels", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<UserProcessFilterUserAccessLevelsEnum> UserProcessFilterUserAccessLevels { get; set; }
+
+            /// <summary>
+            /// Optional field used to limit returned processes to those having one of the specified user access levels.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("userProcessFilter.userAccessLevels", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<UserProcessFilterUserAccessLevelsEnum> UserProcessFilterUserAccessLevelsList { get; set; }
 
             /// <summary>
             /// Optional field used to limit returned processes to those having one of the specified user access levels.
@@ -768,6 +786,12 @@ namespace Google.Apis.Script.v1
             /// <summary>
             /// Optional field used to limit returned processes to those having one of the specified process statuses.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("scriptProcessFilter.statuses", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ScriptProcessFilterStatusesEnum> ScriptProcessFilterStatusesList { get; set; }
+
+            /// <summary>
+            /// Optional field used to limit returned processes to those having one of the specified process statuses.
+            /// </summary>
             public enum ScriptProcessFilterStatusesEnum
             {
                 /// <summary>Unspecified status.</summary>
@@ -812,6 +836,12 @@ namespace Google.Apis.Script.v1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("scriptProcessFilter.types", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ScriptProcessFilterTypesEnum> ScriptProcessFilterTypes { get; set; }
+
+            /// <summary>
+            /// Optional field used to limit returned processes to those having one of the specified process types.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("scriptProcessFilter.types", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ScriptProcessFilterTypesEnum> ScriptProcessFilterTypesList { get; set; }
 
             /// <summary>
             /// Optional field used to limit returned processes to those having one of the specified process types.
@@ -864,6 +894,12 @@ namespace Google.Apis.Script.v1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("scriptProcessFilter.userAccessLevels", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ScriptProcessFilterUserAccessLevelsEnum> ScriptProcessFilterUserAccessLevels { get; set; }
+
+            /// <summary>
+            /// Optional field used to limit returned processes to those having one of the specified user access levels.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("scriptProcessFilter.userAccessLevels", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ScriptProcessFilterUserAccessLevelsEnum> ScriptProcessFilterUserAccessLevelsList { get; set; }
 
             /// <summary>
             /// Optional field used to limit returned processes to those having one of the specified user access levels.

--- a/Src/Generated/Google.Apis.SemanticTile.v1/Google.Apis.SemanticTile.v1.cs
+++ b/Src/Generated/Google.Apis.SemanticTile.v1/Google.Apis.SemanticTile.v1.cs
@@ -760,6 +760,10 @@ namespace Google.Apis.SemanticTile.v1
             public virtual System.Nullable<TerrainFormatsEnum> TerrainFormats { get; set; }
 
             /// <summary>Terrain formats that the client understands.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("terrainFormats", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<TerrainFormatsEnum> TerrainFormatsList { get; set; }
+
+            /// <summary>Terrain formats that the client understands.</summary>
             public enum TerrainFormatsEnum
             {
                 /// <summary>An unknown or unspecified terrain format.</summary>

--- a/Src/Generated/Google.Apis.ServiceConsumerManagement.v1beta1/Google.Apis.ServiceConsumerManagement.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ServiceConsumerManagement.v1beta1/Google.Apis.ServiceConsumerManagement.v1beta1.cs
@@ -465,6 +465,15 @@ namespace Google.Apis.ServiceConsumerManagement.v1beta1
                         /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
                         /// set.
                         /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
                         public enum ForceOnlyEnum
                         {
                             /// <summary>Unspecified quota safety check.</summary>
@@ -575,6 +584,15 @@ namespace Google.Apis.ServiceConsumerManagement.v1beta1
                         /// </summary>
                         [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<ForceOnlyEnum> ForceOnly { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
 
                         /// <summary>
                         /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
@@ -767,6 +785,15 @@ namespace Google.Apis.ServiceConsumerManagement.v1beta1
                         /// </summary>
                         [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<ForceOnlyEnum> ForceOnly { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
 
                         /// <summary>
                         /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field

--- a/Src/Generated/Google.Apis.ServiceUsage.v1beta1/Google.Apis.ServiceUsage.v1beta1.cs
+++ b/Src/Generated/Google.Apis.ServiceUsage.v1beta1/Google.Apis.ServiceUsage.v1beta1.cs
@@ -569,6 +569,15 @@ namespace Google.Apis.ServiceUsage.v1beta1
                         /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
                         /// set.
                         /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
                         public enum ForceOnlyEnum
                         {
                             /// <summary>Unspecified quota safety check.</summary>
@@ -679,6 +688,15 @@ namespace Google.Apis.ServiceUsage.v1beta1
                         /// </summary>
                         [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<ForceOnlyEnum> ForceOnly { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
 
                         /// <summary>
                         /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
@@ -878,6 +896,15 @@ namespace Google.Apis.ServiceUsage.v1beta1
                         /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
                         /// set.
                         /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
                         public enum ForceOnlyEnum
                         {
                             /// <summary>Unspecified quota safety check.</summary>
@@ -1039,6 +1066,15 @@ namespace Google.Apis.ServiceUsage.v1beta1
                         /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
                         /// set.
                         /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
                         public enum ForceOnlyEnum
                         {
                             /// <summary>Unspecified quota safety check.</summary>
@@ -1149,6 +1185,15 @@ namespace Google.Apis.ServiceUsage.v1beta1
                         /// </summary>
                         [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<ForceOnlyEnum> ForceOnly { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
 
                         /// <summary>
                         /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
@@ -1341,6 +1386,15 @@ namespace Google.Apis.ServiceUsage.v1beta1
                         /// </summary>
                         [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<ForceOnlyEnum> ForceOnly { get; set; }
+
+                        /// <summary>
+                        /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field
+                        /// that ignores all the quota safety checks, the 'force_only' field ignores only the specified
+                        /// checks; other checks are still enforced. The 'force' and 'force_only' fields cannot both be
+                        /// set.
+                        /// </summary>
+                        [Google.Apis.Util.RequestParameterAttribute("forceOnly", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<ForceOnlyEnum> ForceOnlyList { get; set; }
 
                         /// <summary>
                         /// The list of quota safety checks to ignore before the override mutation. Unlike 'force' field

--- a/Src/Generated/Google.Apis.ShoppingContent.v2/Google.Apis.ShoppingContent.v2.cs
+++ b/Src/Generated/Google.Apis.ShoppingContent.v2/Google.Apis.ShoppingContent.v2.cs
@@ -4685,6 +4685,14 @@ namespace Google.Apis.ShoppingContent.v2
             /// `pendingShipment` and `partiallyShipped`, and `completed` is a shortcut for `shipped`,
             /// `partiallyDelivered`, `delivered`, `partiallyReturned`, `returned`, and `canceled`.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("statuses", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusesEnum> StatusesList { get; set; }
+
+            /// <summary>
+            /// Obtains orders that match any of the specified statuses. Please note that `active` is a shortcut for
+            /// `pendingShipment` and `partiallyShipped`, and `completed` is a shortcut for `shipped`,
+            /// `partiallyDelivered`, `delivered`, `partiallyReturned`, `returned`, and `canceled`.
+            /// </summary>
             public enum StatusesEnum
             {
                 /// <summary></summary>

--- a/Src/Generated/Google.Apis.ShoppingContent.v2_1/Google.Apis.ShoppingContent.v2_1.cs
+++ b/Src/Generated/Google.Apis.ShoppingContent.v2_1/Google.Apis.ShoppingContent.v2_1.cs
@@ -6016,6 +6016,13 @@ namespace Google.Apis.ShoppingContent.v2_1
             /// Obtains order returns that match any shipment state provided in this parameter. When this parameter is
             /// not provided, order returns are obtained regardless of their shipment states.
             /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("shipmentStates", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ShipmentStatesEnum> ShipmentStatesList { get; set; }
+
+            /// <summary>
+            /// Obtains order returns that match any shipment state provided in this parameter. When this parameter is
+            /// not provided, order returns are obtained regardless of their shipment states.
+            /// </summary>
             public enum ShipmentStatesEnum
             {
                 /// <summary>Return shipments with `new` state only.</summary>
@@ -6045,6 +6052,13 @@ namespace Google.Apis.ShoppingContent.v2_1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("shipmentStatus", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ShipmentStatusEnum> ShipmentStatus { get; set; }
+
+            /// <summary>
+            /// Obtains order returns that match any shipment status provided in this parameter. When this parameter is
+            /// not provided, order returns are obtained regardless of their shipment statuses.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("shipmentStatus", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ShipmentStatusEnum> ShipmentStatusList { get; set; }
 
             /// <summary>
             /// Obtains order returns that match any shipment status provided in this parameter. When this parameter is
@@ -6081,6 +6095,13 @@ namespace Google.Apis.ShoppingContent.v2_1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("shipmentTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ShipmentTypesEnum> ShipmentTypes { get; set; }
+
+            /// <summary>
+            /// Obtains order returns that match any shipment type provided in this parameter. When this parameter is
+            /// not provided, order returns are obtained regardless of their shipment types.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("shipmentTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ShipmentTypesEnum> ShipmentTypesList { get; set; }
 
             /// <summary>
             /// Obtains order returns that match any shipment type provided in this parameter. When this parameter is
@@ -7137,6 +7158,14 @@ namespace Google.Apis.ShoppingContent.v2_1
             /// </summary>
             [Google.Apis.Util.RequestParameterAttribute("statuses", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<StatusesEnum> Statuses { get; set; }
+
+            /// <summary>
+            /// Obtains orders that match any of the specified statuses. Please note that `active` is a shortcut for
+            /// `pendingShipment` and `partiallyShipped`, and `completed` is a shortcut for `shipped`,
+            /// `partiallyDelivered`, `delivered`, `partiallyReturned`, `returned`, and `canceled`.
+            /// </summary>
+            [Google.Apis.Util.RequestParameterAttribute("statuses", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<StatusesEnum> StatusesList { get; set; }
 
             /// <summary>
             /// Obtains orders that match any of the specified statuses. Please note that `active` is a shortcut for

--- a/Src/Generated/Google.Apis.TagManager.v2/Google.Apis.TagManager.v2.cs
+++ b/Src/Generated/Google.Apis.TagManager.v2/Google.Apis.TagManager.v2.cs
@@ -1348,6 +1348,10 @@ namespace Google.Apis.TagManager.v2
                         public virtual System.Nullable<TypeEnum> Type { get; set; }
 
                         /// <summary>The types of built-in variables to enable.</summary>
+                        [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<TypeEnum> TypeList { get; set; }
+
+                        /// <summary>The types of built-in variables to enable.</summary>
                         public enum TypeEnum
                         {
                             /// <summary></summary>
@@ -1865,6 +1869,10 @@ namespace Google.Apis.TagManager.v2
                         /// <summary>The types of built-in variables to delete.</summary>
                         [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
                         public virtual System.Nullable<TypeEnum> Type { get; set; }
+
+                        /// <summary>The types of built-in variables to delete.</summary>
+                        [Google.Apis.Util.RequestParameterAttribute("type", Google.Apis.Util.RequestParameterType.Query)]
+                        public virtual Google.Apis.Util.Repeatable<TypeEnum> TypeList { get; set; }
 
                         /// <summary>The types of built-in variables to delete.</summary>
                         public enum TypeEnum

--- a/Src/Generated/Google.Apis.ToolResults.v1beta3/Google.Apis.ToolResults.v1beta3.cs
+++ b/Src/Generated/Google.Apis.ToolResults.v1beta3/Google.Apis.ToolResults.v1beta3.cs
@@ -1442,6 +1442,12 @@ namespace Google.Apis.ToolResults.v1beta3
                             /// <summary>
                             /// Specify one or more PerfMetricType values such as CPU to filter the result
                             /// </summary>
+                            [Google.Apis.Util.RequestParameterAttribute("filter", Google.Apis.Util.RequestParameterType.Query)]
+                            public virtual Google.Apis.Util.Repeatable<FilterEnum> FilterList { get; set; }
+
+                            /// <summary>
+                            /// Specify one or more PerfMetricType values such as CPU to filter the result
+                            /// </summary>
                             public enum FilterEnum
                             {
                                 /// <summary></summary>

--- a/Src/Generated/Google.Apis.WebRisk.v1/Google.Apis.WebRisk.v1.cs
+++ b/Src/Generated/Google.Apis.WebRisk.v1/Google.Apis.WebRisk.v1.cs
@@ -323,6 +323,10 @@ namespace Google.Apis.WebRisk.v1
             public virtual System.Nullable<ThreatTypesEnum> ThreatTypes { get; set; }
 
             /// <summary>Required. The ThreatLists to search in. Multiple ThreatLists may be specified.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("threatTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ThreatTypesEnum> ThreatTypesList { get; set; }
+
+            /// <summary>Required. The ThreatLists to search in. Multiple ThreatLists may be specified.</summary>
             public enum ThreatTypesEnum
             {
                 /// <summary>No entries should match this threat type. This threat type is unused.</summary>
@@ -917,6 +921,10 @@ namespace Google.Apis.WebRisk.v1
             public virtual System.Nullable<ConstraintsSupportedCompressionsEnum> ConstraintsSupportedCompressions { get; set; }
 
             /// <summary>The compression types supported by the client.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("constraints.supportedCompressions", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ConstraintsSupportedCompressionsEnum> ConstraintsSupportedCompressionsList { get; set; }
+
+            /// <summary>The compression types supported by the client.</summary>
             public enum ConstraintsSupportedCompressionsEnum
             {
                 /// <summary>Unknown.</summary>
@@ -1067,6 +1075,10 @@ namespace Google.Apis.WebRisk.v1
             /// <summary>Required. The ThreatLists to search in. Multiple ThreatLists may be specified.</summary>
             [Google.Apis.Util.RequestParameterAttribute("threatTypes", Google.Apis.Util.RequestParameterType.Query)]
             public virtual System.Nullable<ThreatTypesEnum> ThreatTypes { get; set; }
+
+            /// <summary>Required. The ThreatLists to search in. Multiple ThreatLists may be specified.</summary>
+            [Google.Apis.Util.RequestParameterAttribute("threatTypes", Google.Apis.Util.RequestParameterType.Query)]
+            public virtual Google.Apis.Util.Repeatable<ThreatTypesEnum> ThreatTypesList { get; set; }
 
             /// <summary>Required. The ThreatLists to search in. Multiple ThreatLists may be specified.</summary>
             public enum ThreatTypesEnum


### PR DESCRIPTION
Up for discussion:

- An additional "remarks" XML doc for both the existing and new property
- The property name (`RepeatableXyz` instead of `XyzList` perhaps?)