### PR TITLE
chore: Fix Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,8 @@
     ":disableDependencyDashboard"
   ],
   "ignorePaths": [
-    "Src/Generated/**",
+    "Src/Generated/**"
   ],
-  "schedule": ["before 8am"],
+  "schedule": ["before 8am every weekday"],
   "timezone": "Europe/London"
 }


### PR DESCRIPTION
I'd forgotten that JSON prohibits trailing commas (many libraries
permit it, and it makes for cleaner diffs).

Fixes #1932

Additionally, let's not trigger Renovate PRs on weekends.