### PR TITLE
fix: disabling self-signed jwt for domain wide delegation

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
@@ -334,28 +334,6 @@ TOgrHXgWf1cxYf5cB8DfC3NoaYZ4D3Wh9Qjn3cl36CXfSKEnPK49DkrGZz1avAjV
             Assert.Equal(fakeAccessToken, httpHandler.RequestHeaders.Authorization.Parameter);
         }
 
-        /// <summary>
-        /// Returns an access token, we don't care about the token in the following tests,
-        /// but we need token fetching to work because that's a prerequisite for being
-        /// able to perform authenticated requests.
-        /// </summary>
-        private class FetchesTokenMessageHandler : CountableMessageHandler
-        {
-            protected override Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken taskCancellationToken) =>
-                Task.FromResult(new HttpResponseMessage()
-                {
-                    Content = new StringContent(
-                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
-                        {
-                            AccessToken = "a",
-                            RefreshToken = "r",
-                            ExpiresInSeconds = 100,
-                            Scope = "b"
-                        }),
-                        Encoding.UTF8)
-                });
-        }
-
         public static IEnumerable<object[]> CredentialsForTesting
         {
             get

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/GoogleCredentialTests.cs
@@ -264,7 +264,7 @@ TOgrHXgWf1cxYf5cB8DfC3NoaYZ4D3Wh9Qjn3cl36CXfSKEnPK49DkrGZz1avAjV
         }
 
         [Fact]
-        public async Task FromServiceAccountCredential_FetchesOicdToken()
+        public async Task FromServiceAccountCredential_FetchesOidcToken()
         {
             // A little bit after the tokens returned from OidcTokenFakes were issued.
             var clock = new MockClock(new DateTime(2020, 5, 13, 15, 0, 0, 0, DateTimeKind.Utc));

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ServiceAccountCredentialTests.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Http;
 using Google.Apis.Json;
 using Google.Apis.Tests.Mocks;
@@ -23,6 +24,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using static Google.Apis.Auth.JsonWebSignature;
@@ -335,6 +338,7 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             var initializer = new ServiceAccountCredential.Initializer("some-id")
             {
                 UseJwtAccessWithScopes = useJwtAccessWithScopes,
+                User = "user1",
                 Clock = clock
             }.FromPrivateKey(PrivateKey);
             var cred = new ServiceAccountCredential(initializer);
@@ -352,11 +356,14 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
         public async Task JwtScopes_UseScopes()
         {
             var clock = new MockClock(new DateTime(2016, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            var handler = new FetchesTokenMessageHandler();
             var initializer = new ServiceAccountCredential.Initializer("some-id")
             {
                 UseJwtAccessWithScopes = true,
                 Scopes = new[] { "scope1", "scope2" },
-                Clock = clock
+                Clock = clock,
+                User = "user1",
+                HttpClientFactory = new MockHttpClientFactory(handler)
             }.FromPrivateKey(PrivateKey);
             var cred = new ServiceAccountCredential(initializer);
             Assert.True(cred.HasExplicitScopes); // Must be true for the remainder of this test to be valid.
@@ -366,6 +373,29 @@ ZUp8AsbVqF6rbLiiUfJMo2btGclQu4DEVyS+ymFA65tXDLUuR9EDqJYdqHNZJ5B8
             string payload = System.Text.Encoding.UTF8.GetString(decoded);
             Assert.Contains("\"scope\":\"scope1 scope2\"", payload);
             Assert.DoesNotContain("aud", payload);
+        }
+
+
+        /// <summary>
+        /// Returns an access token, we don't care about the token in the following tests,
+        /// but we need token fetching to work because that's a prerequisite for being
+        /// able to perform authenticated requests.
+        /// </summary>
+        private class FetchesTokenMessageHandler : CountableMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken taskCancellationToken) =>
+                Task.FromResult(new HttpResponseMessage()
+                {
+                    Content = new StringContent(
+                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
+                        {
+                            AccessToken = "a",
+                            RefreshToken = "r",
+                            ExpiresInSeconds = 100,
+                            Scope = "b"
+                        }),
+                        Encoding.UTF8)
+                });
         }
 
         private class DummyAccessMethod : IAccessMethod

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/TokenFakes.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/TokenFakes.cs
@@ -21,6 +21,7 @@ using Google.Apis.Tests.Mocks;
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -135,5 +136,27 @@ namespace Google.Apis.Auth.Tests.OAuth2
             };
             return response;
         }
+    }
+
+    /// <summary>
+    /// Returns some access token, when we don't care about the token in the following tests,
+    /// but we need token fetching to work because that's a prerequisite for being
+    /// able to perform authenticated requests.
+    /// </summary>
+    internal class FetchesTokenMessageHandler : CountableMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken taskCancellationToken) =>
+            Task.FromResult(new HttpResponseMessage()
+            {
+                Content = new StringContent(
+                    NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
+                    {
+                        AccessToken = "a",
+                        RefreshToken = "r",
+                        ExpiresInSeconds = 100,
+                        Scope = "b"
+                    }),
+                    Encoding.UTF8)
+            });
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
@@ -297,7 +297,7 @@ namespace Google.Apis.Auth.OAuth2
                 throw new GoogleApiException(TokenServerUrl, "Invalid OAuth scope or ID token audience provided. " +
                     "A valid authUri and/or OAuth scope is required to proceed.");
             }
-            if (HasExplicitScopes && !UseJwtAccessWithScopes)
+            if (User != null || HasExplicitScopes && !UseJwtAccessWithScopes)
             {
                 return await base.GetAccessTokenForRequestAsync(authUri, cancellationToken).ConfigureAwait(false);
             }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs
@@ -297,7 +297,7 @@ namespace Google.Apis.Auth.OAuth2
                 throw new GoogleApiException(TokenServerUrl, "Invalid OAuth scope or ID token audience provided. " +
                     "A valid authUri and/or OAuth scope is required to proceed.");
             }
-            if (User != null || HasExplicitScopes && !UseJwtAccessWithScopes)
+            if (User != null || (HasExplicitScopes && !UseJwtAccessWithScopes))
             {
                 return await base.GetAccessTokenForRequestAsync(authUri, cancellationToken).ConfigureAwait(false);
             }

--- a/Src/Support/IntegrationTests/ServiceAccountTests.cs
+++ b/Src/Support/IntegrationTests/ServiceAccountTests.cs
@@ -59,6 +59,34 @@ namespace IntegrationTests
         }
 
         [Fact]
+        public void ServiceCredential_UserDisableJwt()
+        {
+            // This is testing that a service-credential successfully authenticates to a Cloud Service.
+            // If authentication fails, an exception will be thrown, failing the test.
+
+            GoogleCredential credential = Helper.GetServiceCredential().CreateScoped(StorageService.Scope.DevstorageFullControl).CreateWithUser("User");
+            ServiceAccountCredential serviceCredential = (ServiceAccountCredential)credential.UnderlyingCredential;
+
+            credential = GoogleCredential.FromServiceAccountCredential(serviceCredential.WithUseJwtAccessWithScopes(true));
+
+            StorageService client = new StorageService(new BaseClientService.Initializer
+            {
+                HttpClientInitializer = credential,
+                ApplicationName = "IntegrationTest"
+            });
+
+            // Check an access token is available.
+            var ok = credential.UnderlyingCredential.GetAccessTokenForRequestAsync().Result;
+            Assert.NotNull(ok);
+
+            // Following line will throw if authentication fails.
+            Buckets buckets = client.Buckets.List(Helper.GetProjectId()).Execute();
+
+            // A final sanity-check.
+            Assert.NotNull(buckets.Items);
+        }
+
+        [Fact]
         public async Task JwtAccessToken_Http()
         {
             // See: https://developers.google.com/identity/protocols/oauth2/service-account#jwt-auth

--- a/Src/Support/IntegrationTests/ServiceAccountTests.cs
+++ b/Src/Support/IntegrationTests/ServiceAccountTests.cs
@@ -59,34 +59,6 @@ namespace IntegrationTests
         }
 
         [Fact]
-        public void ServiceCredential_UserDisableJwt()
-        {
-            // This is testing that a service-credential successfully authenticates to a Cloud Service.
-            // If authentication fails, an exception will be thrown, failing the test.
-
-            GoogleCredential credential = Helper.GetServiceCredential().CreateScoped(StorageService.Scope.DevstorageFullControl).CreateWithUser("User");
-            ServiceAccountCredential serviceCredential = (ServiceAccountCredential)credential.UnderlyingCredential;
-
-            credential = GoogleCredential.FromServiceAccountCredential(serviceCredential.WithUseJwtAccessWithScopes(true));
-
-            StorageService client = new StorageService(new BaseClientService.Initializer
-            {
-                HttpClientInitializer = credential,
-                ApplicationName = "IntegrationTest"
-            });
-
-            // Check an access token is available.
-            var ok = credential.UnderlyingCredential.GetAccessTokenForRequestAsync().Result;
-            Assert.NotNull(ok);
-
-            // Following line will throw if authentication fails.
-            Buckets buckets = client.Buckets.List(Helper.GetProjectId()).Execute();
-
-            // A final sanity-check.
-            Assert.NotNull(buckets.Items);
-        }
-
-        [Fact]
         public async Task JwtAccessToken_Http()
         {
             // See: https://developers.google.com/identity/protocols/oauth2/service-account#jwt-auth


### PR DESCRIPTION
The self-signed JWT is not supported with domain delegation. Therefore disabling the self-signed JWT in that case.