### PR TITLE
fix: Observes exceptions in refresh token tasks

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/TokenRefreshManager.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/TokenRefreshManager.cs
@@ -119,17 +119,8 @@ namespace Google.Apis.Auth.OAuth2
                     }
                 }
             }
-            // Otherwise block on refresh task.
-            if (cancellationToken.CanBeCanceled)
-            {
-                // Reasonably simple way of creating a task that can be cancelled, based on another task.
-                // (It would be nice if this were simpler.)
-                refreshTask = refreshTask.ContinueWith(
-                    task => ResultWithUnwrappedExceptions(task),
-                    cancellationToken,
-                    TaskContinuationOptions.None,
-                    TaskScheduler.Default);
-            }
+
+            refreshTask = refreshTask.WithCancellationToken(cancellationToken);
             return (await refreshTask.ConfigureAwait(false)).AccessToken;
         }
 


### PR DESCRIPTION
The new test (almost) never passed before making the changes in `TokenRefreshManager` and is always green after.