### PR TITLE
Allow deriving classes to override OpenBrowser

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/LocalServerCodeReceiverTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/LocalServerCodeReceiverTests.cs
@@ -15,8 +15,11 @@ limitations under the License.
 */
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Requests;
 using Google.Apis.Tests.Mocks;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Apis.Auth.Tests.OAuth2
@@ -250,6 +253,20 @@ namespace Google.Apis.Auth.Tests.OAuth2
             Assert.Equal(expectedTemplate, uri1);
             Assert.Equal(expectedTemplate, uri2);
             Assert.Equal(expectedTemplate, uri3);
+        }
+
+        [Fact]
+        public async Task OpenBrowser_ThrowsExceptionOnFailure()
+        {
+            var codeReceiver = new FailingLocalServerCodeReceiver();
+            var authorizationUrl = new AuthorizationCodeRequestUrl(new Uri("https://example.com/"));
+            await Assert.ThrowsAsync<NotSupportedException>(() => 
+                codeReceiver.ReceiveCodeAsync(authorizationUrl, CancellationToken.None));
+        }
+
+        private class FailingLocalServerCodeReceiver : LocalServerCodeReceiver
+        {
+            protected override bool OpenBrowser(string url) => false;
         }
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/LocalServerCodeReceiver.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/LocalServerCodeReceiver.cs
@@ -517,9 +517,13 @@ namespace Google.Apis.Auth.OAuth2
 #else
 #error Unsupported target
 #endif
-
+        /// <summary>
+        /// Open a browser and navigate to a URL.
+        /// </summary>
+        /// <param name="url">URL to navigate to</param>
+        /// <returns>true if browser was launched successfully, false otherwise</returns>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
-        private bool OpenBrowser(string url)
+        protected virtual bool OpenBrowser(string url)
         {
             // See https://github.com/dotnet/corefx/issues/10361
             // This is best-effort only, but should work most of the time.
@@ -544,7 +548,7 @@ namespace Google.Apis.Auth.OAuth2
             return false;
         }
 #elif NET45 || NET461
-        private bool OpenBrowser(string url)
+        protected virtual bool OpenBrowser(string url)
         {
             Process.Start(url);
             return true;
@@ -552,7 +556,7 @@ namespace Google.Apis.Auth.OAuth2
 #else
 #error Unsupported target
 #endif
-    
+
         internal class CallbackUriChooser
         {
             /// <summary>Localhost callback URI, expects a port parameter.</summary>


### PR DESCRIPTION
LocalServerCodeReceiver uses a best-effort mechanism
to open a browser. This behavior might not be appropriate
in all environments. Allow deriving classes to override
the method to customize the behavior.