### PR TITLE
ci: Stop updating xunit.runner.visualstudio.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,17 @@
         "Microsoft.AspNetCore."
       ],
       "allowedVersions": "<3.1.0"
+    },
+    {
+      "matchPaths": [
+        "Src/Support/Google.Apis.Tests/**",
+        "Src/Support/Google.Apis.Auth.Tests/**",
+        "Src/Support/IntegrationTests/**"
+      ],
+      "matchPackageNames": [
+        "xunit.runner.visualstudio"
+      ],
+      "allowedVersions": "<2.4.4"
     }
   ],
   "schedule": ["before 8am every weekday"],

--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
     <Compile Include="..\..\Generated\Google.Apis.Translate.v2\Google.Apis.Translate.v2.cs" Link="Apis\Services\Google.Apis.Translate.v2.cs" />

--- a/Src/Support/IntegrationTests/IntegrationTests.csproj
+++ b/Src/Support/IntegrationTests/IntegrationTests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
     <ProjectReference Include="..\Google.Apis.Tests\Google.Apis.Tests.csproj" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />


### PR DESCRIPTION
It dropped support for frameworks we still target.
This reverts #2113