### PR TITLE
feat: Adds partial support for Workload Identity Federation

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/TokenFakes.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/TokenFakes.cs
@@ -19,6 +19,7 @@ using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Json;
 using Google.Apis.Tests.Mocks;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -167,5 +168,19 @@ namespace Google.Apis.Auth.Tests.OAuth2
     {
         protected override Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken) =>
             throw new HttpRequestException("Couldn't reach server.");
+    }
+
+    /// <summary>
+    /// Message handler that accepts a list of delegates to be used sequentially on incoming requests.
+    /// </summary>
+    internal class DelegatedMessageHandler : CountableMessageHandler
+    {
+        private Func<HttpRequestMessage, Task<HttpResponseMessage>>[] _delegates;
+
+        internal DelegatedMessageHandler(params Func<HttpRequestMessage, Task<HttpResponseMessage>>[] delegates) => _delegates = delegates;
+
+        protected override Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage request, CancellationToken taskCancellationToken) =>
+            // At this point our call has already been counted.
+            _delegates[Calls - 1](request);
     }
 }

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/UrlSourcedExternalAccountCredentialsTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/UrlSourcedExternalAccountCredentialsTests.cs
@@ -1,0 +1,220 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Json;
+using Google.Apis.Tests.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    public class UrlSourcedExternalAccountCredentialsTests
+    {
+        private const string SubjectTokenUrl = "https://dummy.subject.token.url/";
+
+        private const string SubjectTokenText = "dummy_subject_token";
+        private const string SubjectTokenJsonField = "subject_token_field";
+        private static readonly string SubjectTokenJson = $@"{{""{SubjectTokenJsonField}"": ""{SubjectTokenText}""}}";
+
+        private const string TokenUrl = "https://dummy.token.url/";
+        private const string GrantTypeClaim = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange";
+        private const string RequestedTokenTypeClaim = "requested_token_type=urn:ietf:params:oauth:token-type:access_token";
+        private const string Audience = "dummy_audience";
+        private const string SubjectTokenType = "dummy_token_type";
+
+        private const string AccessToken = "dummy_access_token";
+        private const string RefreshedAccessToken = "dummy_refreshed_access_token";
+
+        [Fact]
+        public async Task FetchesAccessToken()
+        {
+            const string clientId = "dummy_client_ID";
+            const string clientSecret = "dummy_client_secret";
+            const string scope = "dummy_scope";
+            const string quotaProject = "dummy_project_id";
+
+            var messageHandler = new DelegatedMessageHandler(ValidateSubjectTokenRequest, ValidateAccessTokenRequest);
+
+            var credential = new UrlSourcedExternalAccountCredential(
+                new UrlSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, SubjectTokenUrl)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    Headers = new Dictionary<string, string>
+                    {
+                        {"key1", "value1"},
+                        {"key2", "value2"}
+                    },
+                    ClientId = clientId,
+                    ClientSecret = clientSecret,
+                    Scopes = new string[] { scope },
+                    QuotaProject = quotaProject
+                });
+
+            var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
+
+            Assert.Equal(AccessToken, token.AccessToken);
+            var header = Assert.Single(token.Headers);
+            Assert.Equal("x-goog-user-project", header.Key);
+            var headerValue = Assert.Single(header.Value);
+            Assert.Equal(quotaProject, headerValue);
+
+            Assert.Equal(2, messageHandler.Calls);
+
+            static Task<HttpResponseMessage> ValidateSubjectTokenRequest(HttpRequestMessage subjectTokenRequest)
+            {
+                Assert.Equal(SubjectTokenUrl, subjectTokenRequest.RequestUri.ToString());
+                Assert.Equal(HttpMethod.Get, subjectTokenRequest.Method);
+
+                Assert.Contains(subjectTokenRequest.Headers, header => header.Key == "key1" && header.Value.Single() == "value1");
+                Assert.Contains(subjectTokenRequest.Headers, header => header.Key == "key2" && header.Value.Single() == "value2");
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(SubjectTokenText)
+                });
+            }
+
+            static async Task<HttpResponseMessage> ValidateAccessTokenRequest(HttpRequestMessage accessTokenRequest)
+            {
+                Assert.Equal(TokenUrl, accessTokenRequest.RequestUri.ToString());
+                Assert.Equal(HttpMethod.Post, accessTokenRequest.Method);
+
+                Assert.Equal("Basic", accessTokenRequest.Headers.Authorization.Scheme);
+                Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}")), accessTokenRequest.Headers.Authorization.Parameter);
+
+                string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
+
+                Assert.Contains(GrantTypeClaim, contentText);
+                Assert.Contains(RequestedTokenTypeClaim, contentText);
+                Assert.Contains($"audience={Audience}", contentText);
+                Assert.Contains($"subject_token_type={SubjectTokenType}", contentText);
+                Assert.Contains($"subject_token={SubjectTokenText}", contentText);
+                Assert.Contains($"scope={scope}", contentText);
+
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(
+                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
+                        {
+                            AccessToken = AccessToken,
+                            ExpiresInSeconds = 24 * 60 * 60,
+                        }), Encoding.UTF8)
+                };
+            }
+        }
+
+        [Fact]
+        public async Task FetchesAccessToken_JsonSubjectToken()
+        {
+            var messageHandler = new DelegatedMessageHandler(SubjectTokenAsJson, ValidateAccessTokenFromJsonSubjectTokenRequest);
+
+            var credential = new UrlSourcedExternalAccountCredential(
+                new UrlSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, SubjectTokenUrl)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    SubjectTokenJsonFieldName = SubjectTokenJsonField
+                });
+
+            Assert.Equal(AccessToken, await credential.GetAccessTokenForRequestAsync());
+
+            Assert.Equal(2, messageHandler.Calls);
+
+            static Task<HttpResponseMessage> SubjectTokenAsJson(HttpRequestMessage subjectTokenRequest)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(SubjectTokenJson)
+                });
+            }
+
+            static async Task<HttpResponseMessage> ValidateAccessTokenFromJsonSubjectTokenRequest(HttpRequestMessage accessTokenRequest)
+            {
+                string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
+
+                // Even if the subject token was returned as a JSON, the access token request should receive the token value only.
+                Assert.Contains($"subject_token={SubjectTokenText}", contentText);
+
+                return new HttpResponseMessage()
+                {
+                    Content = new StringContent(
+                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
+                        {
+                            AccessToken = AccessToken,
+                            ExpiresInSeconds = 24 * 60 * 60,
+                        }), Encoding.UTF8)
+                };
+            }
+        }
+
+        [Fact]
+        public async Task RefreshesAccessToken()
+        {
+            var messageHandler = new DelegatedMessageHandler(SubjectTokenRequest, AccessTokenRequest, SubjectTokenRequest, RefreshTokenRequest);
+            var clock = new MockClock(DateTime.UtcNow);
+
+            var credential = new UrlSourcedExternalAccountCredential(
+                new UrlSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, SubjectTokenUrl)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    Clock = clock
+                });
+
+            Assert.Equal(AccessToken, await credential.GetAccessTokenForRequestAsync());
+
+            clock.UtcNow = clock.UtcNow.AddDays(2);
+
+            Assert.Equal(RefreshedAccessToken, await credential.GetAccessTokenForRequestAsync());
+
+            Assert.Equal(4, messageHandler.Calls);
+
+            static Task<HttpResponseMessage> SubjectTokenRequest(HttpRequestMessage subjectTokenRequest) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(SubjectTokenText)
+                });
+
+            static Task<HttpResponseMessage> AccessTokenRequest(HttpRequestMessage accessTokenRequest) =>
+                Task.FromResult(new HttpResponseMessage()
+                {
+                    Content = new StringContent(
+                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
+                        {
+                            AccessToken = AccessToken,
+                            ExpiresInSeconds = 24 * 60 * 60,
+                        }), Encoding.UTF8)
+                });
+
+            static Task<HttpResponseMessage> RefreshTokenRequest(HttpRequestMessage accessTokenRequest) =>
+                Task.FromResult(new HttpResponseMessage()
+                {
+                    Content = new StringContent(
+                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
+                        {
+                            AccessToken = RefreshedAccessToken,
+                            ExpiresInSeconds = 24 * 60 * 60,
+                        }), Encoding.UTF8)
+                });
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
@@ -210,6 +210,7 @@ namespace Google.Apis.Auth.OAuth2
             {
                 JsonCredentialParameters.AuthorizedUserCredentialType => new GoogleCredential(CreateUserCredentialFromParameters(credentialParameters)),
                 JsonCredentialParameters.ServiceAccountCredentialType => GoogleCredential.FromServiceAccountCredential(CreateServiceAccountCredentialFromParameters(credentialParameters)),
+                JsonCredentialParameters.ExternalAccountCredentialType => new GoogleCredential(CreateExternalCredentialFromParametes(credentialParameters)),
                 _ => throw new InvalidOperationException($"Error creating credential from JSON or JSON parameters. Unrecognized credential type {credentialParameters.Type}."),
             };
 
@@ -258,6 +259,36 @@ namespace Google.Apis.Auth.OAuth2
                 KeyId = credentialParameters.PrivateKeyId
             };
             return new ServiceAccountCredential(initializer.FromPrivateKey(credentialParameters.PrivateKey));
+        }
+
+        /// <summary>
+        /// Creates an external account credential from JSON data.
+        /// </summary>
+        private static IGoogleCredential CreateExternalCredentialFromParametes(JsonCredentialParameters parameters)
+        {
+            if (parameters.Type != JsonCredentialParameters.ExternalAccountCredentialType || parameters.CredentialSourceConfig is null)
+            {
+                throw new InvalidOperationException("JSON data does not represent a valid external account credential.");
+            }
+
+            // Build the external credential of the correct type.
+            // The order in which these checks are performed is relevant, see https://google.aip.dev/auth/4117.
+            if (!string.IsNullOrEmpty(parameters.CredentialSourceConfig.EnvironmentId))
+            {
+                throw new NotImplementedException("AWS external credentials not yet supported.");
+            }
+            else if (!string.IsNullOrEmpty(parameters.CredentialSourceConfig.File))
+            {
+                throw new NotImplementedException("File-sourced credentials not yet supported.");
+            }
+            else if (!string.IsNullOrEmpty(parameters.CredentialSourceConfig.Url))
+            {
+                throw new NotImplementedException("Url-sourced credentials not yet supported.");
+            }
+            else
+            {
+                throw new InvalidOperationException("Unrecognized external credential configuration");
+            }
         }
 
         /// <summary> 

--- a/Src/Support/Google.Apis.Auth/OAuth2/DirectUseExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/DirectUseExternalAccountCredential.cs
@@ -1,0 +1,193 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2.Requests;
+using Google.Apis.Http;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Base class for external account credentials used directly, i.e. without impersonation.
+    /// </summary>
+    internal abstract class DirectUseExternalAccountCredential : ServiceCredential, IExternalAccountCredential, IGoogleCredential
+    {
+        /// <summary>
+        /// Initializer for <see cref="DirectUseExternalAccountCredential"/>.
+        /// </summary>
+        new public class Initializer : ServiceCredential.Initializer
+        {
+            /// <summary>
+            /// The STS audience which contains the resource name for the
+            /// workload identity pool or the workforce pool
+            /// and the provider identifier in that pool.
+            /// </summary>
+            public string Audience { get; }
+
+            /// <summary>
+            /// The STS subject token type based on the OAuth 2.0 token exchange spec.
+            /// </summary>
+            public string SubjectTokenType { get; }
+
+            /// <summary>
+            /// The endpoint used to retrieve the account related information (eg. email, username, uid, etc).
+            /// This is needed for gCloud session account identification.
+            /// </summary>
+            public string TokenInfoUrl { get; set; }
+
+            /// <summary>
+            /// The Client ID.
+            /// </summary>
+            /// <remarks>
+            /// Client ID and client secret are currently only required if the token info endpoint
+            /// needs to be called with the generated GCP access token.
+            /// When provided, STS will be called with additional basic authentication using
+            /// ClientId as username and ClientSecret as password.
+            /// </remarks>
+            public string ClientId { get; set; }
+
+            /// <summary>
+            /// The client secret.
+            /// </summary>
+            /// <remarks>
+            /// Client ID and client secret are currently only required if the token info endpoint
+            /// needs to be called with the generated GCP access token.
+            /// When provided, STS will be called with additional basic authentication using
+            /// ClientId as username and ClientSecret as password.
+            /// </remarks>
+            public string ClientSecret { get; set; }
+
+            internal Initializer(string tokenUrl, string audience, string subjectTokenType) : base(tokenUrl)
+            {
+                Audience = audience;
+                SubjectTokenType = subjectTokenType;
+            }
+
+            internal Initializer(Initializer other) : base(other)
+            {
+                Audience = other.Audience;
+                SubjectTokenType = other.SubjectTokenType;
+                TokenInfoUrl = other.TokenInfoUrl;
+                ClientId = other.ClientId;
+                ClientSecret = other.ClientSecret;
+            }
+
+            internal Initializer(DirectUseExternalAccountCredential other) : base(other)
+            {
+                Audience = other.Configuration.Audience;
+                SubjectTokenType = other.Configuration.SubjectTokenType;
+                TokenInfoUrl = other.Configuration.TokenInfoUrl;
+                ClientId = other.Configuration.ClientId;
+                ClientSecret = other.Configuration.ClientSecret;
+            }
+        }
+
+        /// <inheritdoc/>
+        bool IGoogleCredential.HasExplicitScopes => HasExplicitScopes;
+
+        /// <inheritdoc/>
+        public bool SupportsExplicitScopes => true;
+
+        /// <inheritdoc/>
+        public ExternalAccountConfiguration Configuration { get; } 
+
+        internal DirectUseExternalAccountCredential(Initializer initializer) : base(initializer) =>
+
+            Configuration = new DirectUseExternalCredentialConfiguration(
+                this, initializer.Audience, initializer.SubjectTokenType, initializer.TokenInfoUrl, initializer.ClientId, initializer.ClientSecret);
+
+        /// <summary>
+        /// Gets the subject token to be exchanged for the access token.
+        /// </summary>
+        protected abstract Task<string> GetSubjectTokenAsync(CancellationToken taskCancellationToken);
+
+        /// <inheritdoc/>
+        public async override Task<bool> RequestAccessTokenAsync(CancellationToken taskCancellationToken)
+        {
+            GoogleWifStsTokenRequest request = new GoogleWifStsTokenRequest
+            {
+                Audience = Configuration.Audience,
+                Scope = HasExplicitScopes ? string.Join(" ", Scopes) : null,
+                SubjectToken = await GetSubjectTokenAsync(taskCancellationToken).ConfigureAwait(false),
+                SubjectTokenType = Configuration.SubjectTokenType,
+                ClientId = Configuration.ClientId,
+                ClientSecret = Configuration.ClientSecret,
+            };
+
+            var newToken = await request
+                .ExecuteAsync(HttpClient, TokenServerUrl, Clock, Logger, taskCancellationToken)
+                .ConfigureAwait(false);
+            Token = newToken;
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public abstract IGoogleCredential WithQuotaProject(string quotaProject);
+
+        /// <inheritdoc/>
+        public abstract IGoogleCredential MaybeWithScopes(IEnumerable<string> scopes);
+
+        /// <inheritdoc/>
+        public IGoogleCredential WithUserForDomainWideDelegation(string user) =>
+            throw new InvalidOperationException($"{nameof(IExternalAccountCredential)} does not support Domain-Wide Delegation");
+
+        /// <inheritdoc/>
+        public abstract IGoogleCredential WithHttpClientFactory(IHttpClientFactory httpClientFactory);
+
+        private class DirectUseExternalCredentialConfiguration : ExternalAccountConfiguration
+        {
+            DirectUseExternalAccountCredential _credential;
+
+            internal DirectUseExternalCredentialConfiguration(
+                DirectUseExternalAccountCredential credential, string audience, string subjectTokenType, string tokenInfoUrl, string clientId, string clientSecret)
+            {
+                _credential = credential;
+                Audience = audience;
+                SubjectTokenType = subjectTokenType;
+                TokenInfoUrl = tokenInfoUrl;
+                ClientId = clientId;
+                ClientSecret = clientSecret;
+            }
+
+            /// <inheritdoc/>
+            public override string Audience { get; }
+
+            /// <inheritdoc/>
+            public override string SubjectTokenType { get; }
+
+            /// <inheritdoc/>
+            public override string TokenUrl => _credential.TokenServerUrl;
+
+            /// <inheritdoc/>
+            public override string ServiceAccountImpersonationUrl => null;
+
+            /// <inheritdoc/>
+            public override string TokenInfoUrl { get; }
+
+            /// <inheritdoc/>
+            public override string QuotaProject => _credential.QuotaProject;
+
+            /// <inheritdoc/>
+            public override string ClientId { get; }
+
+            /// <inheritdoc/>
+            public override string ClientSecret { get; }
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/ExternalAccountConfiguration.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ExternalAccountConfiguration.cs
@@ -1,0 +1,84 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Holds the configuration for an external account credential.
+    /// </summary>
+    public abstract class ExternalAccountConfiguration
+    {
+        private protected ExternalAccountConfiguration() { }
+
+        /// <summary>
+        /// The STS audience which contains the resource name for the
+        /// workload identity pool or the workforce pool
+        /// and the provider identifier in that pool.
+        /// </summary>
+        public abstract string Audience { get; }
+
+        /// <summary>
+        /// The STS subject token type based on the OAuth 2.0 token exchange spec.
+        /// </summary>
+        public abstract string SubjectTokenType { get; }
+
+        /// <summary>
+        /// The STS token exchange endpoint.
+        /// </summary>
+        public abstract string TokenUrl { get; }
+
+        /// <summary>
+        /// This is the URL for the service account impersonation request.
+        /// If this is not available, the STS-returned access token
+        /// should be directly used without impersonation.
+        /// </summary>
+        public abstract string ServiceAccountImpersonationUrl { get; }
+
+        /// <summary>
+        /// The endpoint used to retrieve the account related information (eg. email, username, uid, etc).
+        /// This is needed for gCloud session account identification.
+        /// </summary>
+        public abstract string TokenInfoUrl { get; }
+
+        /// <summary>
+        /// The ID of the project associated to this credential for the purposes of
+        /// quota calculation and billing. May be null.
+        /// </summary>
+        public abstract string QuotaProject { get; }
+
+        /// <summary>
+        /// The Client ID.
+        /// </summary>
+        /// <remarks>
+        /// Client ID and Client secret are currently only required if the token info endpoint
+        /// needs to be called with the generated GCP access token.
+        /// When provided, STS will be called with additional basic authentication using
+        /// ClientId as username and ClientSecret as password.
+        /// </remarks>
+        public abstract string ClientId { get; }
+
+        /// <summary>
+        /// The client secret.
+        /// </summary>
+        /// <remarks>
+        /// Client ID and Client secret are currently only required if the token info endpoint
+        /// needs to be called with the generated GCP access token.
+        /// When provided, STS will be called with additional basic authentication using
+        /// ClientId as username and ClientSecret as password.
+        /// </remarks>
+        public abstract string ClientSecret { get; }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -352,8 +352,13 @@ namespace Google.Apis.Auth.OAuth2
         /// can be scoped on demand. When using a <see cref="UserCredential"/> the credential needs to have been obtained
         /// with the required scope, else, when attempting and impersonated request, you'll receive an authorization error.
         /// </remarks>
-        public GoogleCredential Impersonate(ImpersonatedCredential.Initializer initializer) =>
-            new GoogleCredential(ImpersonatedCredential.Create(this, initializer));
+        public GoogleCredential Impersonate(ImpersonatedCredential.Initializer initializer)
+        {
+            // We copy the initializer so we can safely modify it.
+            initializer = new ImpersonatedCredential.Initializer(initializer);
+            initializer.SetSourceCredentialFrom(this);
+            return new GoogleCredential(new ImpersonatedCredential(initializer));
+        }
 
         /// <summary>Creates a <c>GoogleCredential</c> wrapping a <see cref="ServiceAccountCredential"/>.</summary>
         public static GoogleCredential FromServiceAccountCredential(ServiceAccountCredential credential)

--- a/Src/Support/Google.Apis.Auth/OAuth2/IExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/IExternalAccountCredential.cs
@@ -1,0 +1,36 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+
+namespace Google.Apis.Auth.OAuth2
+{
+
+    /// <summary>
+    /// An external account credential to support Workload Identity Federation.
+    /// You can read about Workload Identity Federation in
+    /// https://cloud.google.com/iam/docs/workload-identity-federation and
+    /// https://google.aip.dev/auth/4117.
+    /// </summary>
+    public interface IExternalAccountCredential: ICredential, ITokenAccessWithHeaders,
+        IHttpExecuteInterceptor, IHttpUnsuccessfulResponseHandler
+    {
+        /// <summary>
+        /// The configuration of this external account credential.
+        /// </summary>
+        ExternalAccountConfiguration Configuration { get; }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/ImpersonatedCredentialBase.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ImpersonatedCredentialBase.cs
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2.Requests;
+using Google.Apis.Util;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// Basic impersonated credential which obtains impersonated access tokens.
+    /// </summary>
+    public abstract class ImpersonatedCredentialBase : ServiceCredential
+    {
+        internal static readonly string[] ImpersonationScopes = new string[] { GoogleAuthConsts.IamScope };
+
+        /// <summary>An initializer class for the impersonated credential. </summary>
+        new public abstract class Initializer : ServiceCredential.Initializer
+        {
+            /// <summary>
+            /// Gets or sets for how long the delegated credential should be valid, in seconds.
+            /// Defaults to 1 hour or 3600 seconds which is also the default maximum lifetime.
+            /// To extend the maximum lifetime for these tokens to 12 hours (43,200 seconds),
+            /// add the service account to an organization policy that includes the
+            /// constraints/iam.allowServiceAccountCredentialLifetimeExtension list constraint.
+            /// </summary>
+            public TimeSpan Lifetime { get; set; }
+
+            /// <summary>
+            /// Gets or sets the source credential used to acquire the impersonated credentials.
+            /// </summary>
+            internal ICredential SourceCredential => HttpClientInitializers.OfType<ICredential>().SingleOrDefault();
+
+            /// <summary>
+            /// Sets the source credential to a credential scoped for impersonation created from <paramref name="credential"/>.
+            /// </summary>
+            internal virtual void SetSourceCredentialFrom(ICredential credential)
+            {
+                // We scope the new credential for impersonation, as it needs some IAM specific scopes.
+                // We don't care about the scopes that it previously had as the impersonated credential
+                // will be scoped itself.
+                var newCredential = ValidateAndScopeForImpersonation(credential);
+
+                // Now, after validating the new credential, we can remove the old one,
+                // even if the new credential is null, as that would indicate "no source credential".
+                HttpClientInitializers.Remove(SourceCredential);
+
+                // Now we can finally set the new IAM scoped credential.
+                if (newCredential is object)
+                {
+                    HttpClientInitializers.Add(newCredential);
+                }
+            }
+
+            /// <summary>Constructs a new initializer.</summary>
+            internal Initializer(string tokenServerUrl)
+                : base(tokenServerUrl.ThrowIfNull(nameof(tokenServerUrl))) =>
+                Lifetime = TimeSpan.FromHours(1);
+
+            internal Initializer(ImpersonatedCredentialBase other) : base(other) =>
+                Lifetime = other.Lifetime;
+
+            internal Initializer(Initializer other) : base(other) =>
+                Lifetime = other.Lifetime;
+
+            /// <summary>
+            /// Validates <paramref name="credential"/> as a valid source credential and
+            /// returns a new credential, based on <paramref name="credential"/> but scoped for
+            /// impersonation.
+            /// </summary>
+            /// <param name="credential">The credential to validate and build a scoped one from.
+            /// May be null, in which case this method will return null.
+            /// this</param>
+            private protected abstract ICredential ValidateAndScopeForImpersonation(ICredential credential);
+        }
+
+        /// <summary>
+        /// Gets for how long the delegated credential should be valid, in seconds.
+        /// Defaults to 1 hour or 3600 seconds which is also the default maximum lifetime.
+        /// To extend the maximum lifetime for these tokens to 12 hours (43,200 seconds),
+        /// add the service account to an organization policy that includes the
+        /// constraints/iam.allowServiceAccountCredentialLifetimeExtension list constraint.
+        /// </summary>
+        public TimeSpan Lifetime { get; }
+
+        /// <summary>
+        /// Gets the source credential used to acquire the impersonated credentials.
+        /// </summary>
+        internal ICredential SourceCredential => HttpClientInitializers.OfType<IGoogleCredential>().Single();
+
+        private protected ImpersonatedCredentialBase(Initializer initializer) : base(initializer)
+        {
+            if (initializer.SourceCredential is null)
+            {
+                throw new ArgumentException(nameof(initializer.SourceCredential));
+            }
+            if (initializer.Lifetime < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initializer.Lifetime), $"Must be greater or equal to {nameof(TimeSpan.Zero)}");
+            }
+            Lifetime = initializer.Lifetime;
+        }
+
+        /// <inheritdoc/>
+        public override async Task<bool> RequestAccessTokenAsync(CancellationToken taskCancellationToken)
+        {
+            var request = CreateImpersonationAccessTokenRequest();
+
+            Token = await request.ExecuteAsync(HttpClient, TokenServerUrl, Clock, Logger, taskCancellationToken)
+                .ConfigureAwait(false);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Creates the request for obtaining the impersonated access token.
+        /// Derived classes should override this if they need to add more information to the request.
+        /// </summary>
+        internal virtual ImpersonationAccessTokenRequest CreateImpersonationAccessTokenRequest() =>
+            new ImpersonationAccessTokenRequest
+            {
+                Scopes = Scopes,
+                Lifetime = $"{(int)Lifetime.TotalSeconds}s"
+            };
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/ImpersonatedExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ImpersonatedExternalAccountCredential.cs
@@ -1,0 +1,134 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+using System;
+using System.Collections.Generic;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// External account credential that impersonates a service account.
+    /// </summary>
+    internal class ImpersonatedExternalAccountCredential : ImpersonatedCredentialBase, IExternalAccountCredential, IGoogleCredential
+    {
+        new internal class Initializer : ImpersonatedCredentialBase.Initializer
+        {
+            /// <summary>
+            /// Gets or sets the source credential used to acquire the impersonated credentials.
+            /// </summary>
+            internal new DirectUseExternalAccountCredential SourceCredential => base.SourceCredential as DirectUseExternalAccountCredential;
+
+            /// <inheritdoc/>
+            internal override void SetSourceCredentialFrom(ICredential credential)
+            {
+                base.SetSourceCredentialFrom(credential);
+
+                // It's safe to do this as on an ImpersonatedExternalAccountCredential
+                // the scopes of the impersonated token should be those of the underlying
+                // DirectUseExternalAccountCredential
+                Scopes = (credential as DirectUseExternalAccountCredential)?.Scopes;
+            }
+
+            /// <summary>
+            /// This is the URL for the service account impersonation request.
+            /// If this is not available, the STS returned access token
+            /// should be directly used without impersonation.
+            /// </summary>
+            public string ServiceAccountImpersonationUrl => TokenServerUrl;
+
+            /// <summary>Constructs a new initializer.</summary>
+            /// <param name="serviceAccountImpersonationUrl">The URL to obtain the impersonated access token from. Must not be null.</param>
+            public Initializer(string serviceAccountImpersonationUrl)
+                : base(serviceAccountImpersonationUrl)
+            { }
+
+            internal Initializer(ImpersonatedExternalAccountCredential other) : base(other)
+            { }
+
+            internal Initializer(Initializer other) : base(other)
+            { }
+
+            /// <inheritdoc/>
+            private protected override ICredential ValidateAndScopeForImpersonation(ICredential credential) => credential switch
+            {
+                null => null,
+                DirectUseExternalAccountCredential externalCred => externalCred.MaybeWithScopes(ImpersonationScopes),
+                _ => throw new InvalidOperationException(
+                    $"Only {nameof(DirectUseExternalAccountCredential)} may be used as the source credential for {nameof(ImpersonatedExternalAccountCredential)}")
+            };
+        }
+
+        internal ImpersonatedExternalAccountCredential(Initializer initializer) : base(initializer) =>
+            Configuration = new ImpersonatedExternalCredentialConfiguration(this);
+
+        /// <inheritdoc/>
+        internal new DirectUseExternalAccountCredential SourceCredential => base.SourceCredential as DirectUseExternalAccountCredential;
+
+        /// <inheritdoc/>
+        bool IGoogleCredential.HasExplicitScopes => HasExplicitScopes;
+
+        /// <inheritdoc/>
+        bool IGoogleCredential.SupportsExplicitScopes => true;
+
+        /// <inheritdoc/>
+        public ExternalAccountConfiguration Configuration { get; }
+
+        public IGoogleCredential MaybeWithScopes(IEnumerable<string> scopes) =>
+            new ImpersonatedExternalAccountCredential(new Initializer(this) { Scopes = scopes });
+
+        public IGoogleCredential WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            new ImpersonatedExternalAccountCredential(new Initializer(this) { HttpClientFactory = httpClientFactory });
+
+        public IGoogleCredential WithQuotaProject(string quotaProject) =>
+            new ImpersonatedExternalAccountCredential(new Initializer(this) { QuotaProject = quotaProject });
+
+        public IGoogleCredential WithUserForDomainWideDelegation(string user) =>
+            throw new InvalidOperationException($"{nameof(IExternalAccountCredential)} does not support Domain-Wide Delegation");
+
+        private class ImpersonatedExternalCredentialConfiguration : ExternalAccountConfiguration
+        {
+            private readonly ImpersonatedExternalAccountCredential _credential;
+
+            internal ImpersonatedExternalCredentialConfiguration(ImpersonatedExternalAccountCredential credential) =>
+                _credential = credential;
+
+            /// <inheritdoc/>
+            public override string Audience => _credential.SourceCredential.Configuration.Audience;
+
+            /// <inheritdoc/>
+            public override string SubjectTokenType => _credential.SourceCredential.Configuration.SubjectTokenType;
+
+            /// <inheritdoc/>
+            public override string TokenUrl => _credential.SourceCredential.Configuration.TokenUrl;
+
+            /// <inheritdoc/>
+            public override string ServiceAccountImpersonationUrl => _credential.TokenServerUrl;
+
+            /// <inheritdoc/>
+            public override string TokenInfoUrl => _credential.SourceCredential.Configuration.TokenInfoUrl;
+
+            /// <inheritdoc/>
+            public override string QuotaProject => _credential.QuotaProject;
+
+            /// <inheritdoc/>
+            public override string ClientId => _credential.SourceCredential.Configuration.ClientId;
+
+            /// <inheritdoc/>
+            public override string ClientSecret => _credential.SourceCredential.Configuration.ClientSecret;
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
 namespace Google.Apis.Auth.OAuth2
 {
     /// <summary>
@@ -34,63 +37,169 @@ namespace Google.Apis.Auth.OAuth2
         /// </summary>
         public const string ServiceAccountCredentialType = "service_account";
 
+        /// <summary>
+        /// See https://cloud.google.com/iam/docs/workload-identity-federation on how
+        /// to create external account credentials.
+        /// </summary>
+        public const string ExternalAccountCredentialType = "external_account";
+
         /// <summary>Type of the credential.</summary>
-        [Newtonsoft.Json.JsonProperty("type")]
+        [JsonProperty("type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Project ID associated with this credential.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("project_id")]
+        [JsonProperty("project_id")]
         public string ProjectId { get; set; }
 
         /// <summary>
         /// Project ID associated with this credential for the purposes
         /// of quota calculations and billing.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("quota_project_id")]
+        [JsonProperty("quota_project_id")]
         public string QuotaProject { get; set; }
 
         /// <summary>
         /// Client Id associated with UserCredential created by
-        /// <a href="https://cloud.google.com/sdk/gcloud/reference/auth/login">GCloud Auth Login</a>.
+        /// <a href="https://cloud.google.com/sdk/gcloud/reference/auth/login">GCloud Auth Login</a>
+        /// or with an external account credential.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("client_id")]
+        [JsonProperty("client_id")]
         public string ClientId { get; set; }
 
         /// <summary>
         /// Client Secret associated with UserCredential created by
-        /// <a href="https://cloud.google.com/sdk/gcloud/reference/auth/login">GCloud Auth Login</a>.
+        /// <a href="https://cloud.google.com/sdk/gcloud/reference/auth/login">GCloud Auth Login</a>
+        /// or with an external account credential.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("client_secret")]
+        [JsonProperty("client_secret")]
         public string ClientSecret { get; set; }
         
         /// <summary>
         /// Client Email associated with ServiceAccountCredential obtained from
         /// <a href="https://console.developers.google.com">Google Developers Console</a>
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("client_email")]
+        [JsonProperty("client_email")]
         public string ClientEmail { get; set; }
 
         /// <summary>
         /// Private Key associated with ServiceAccountCredential obtained from
         /// <a href="https://console.developers.google.com">Google Developers Console</a>.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("private_key")]
+        [JsonProperty("private_key")]
         public string PrivateKey { get; set; }
 
         /// <summary>
         /// Private Key ID associated with ServiceAccountCredential obtained from
         /// <a href="https://console.developers.google.com">Google Developers Console</a>.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("private_key_id")]
+        [JsonProperty("private_key_id")]
         public string PrivateKeyId { get; set; }
 
         /// <summary>
         /// Refresh Token associated with UserCredential created by
         /// <a href="https://cloud.google.com/sdk/gcloud/reference/auth/login">GCloud Auth Login</a>.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("refresh_token")]
+        [JsonProperty("refresh_token")]
         public string RefreshToken { get; set; }
+
+        /// <summary>
+        /// The STS audience associated with an external account credential.
+        /// </summary>
+        [JsonProperty("audience")]
+        public string Audience { get; set; }
+
+        /// <summary>
+        /// The STS subject token type associated with an external account credential.
+        /// </summary>
+        [JsonProperty("subject_token_type")]
+        public string SubjectTokenType { get; set; }
+
+        /// <summary>
+        /// The STS token exchange endpoint associated with an external account credential.
+        /// </summary>
+        [JsonProperty("token_url")]
+        public string TokenUrl { get; set; }
+
+        /// <summary>
+        /// This is the URL for the service account impersonation request
+        /// associated with an external account credential.
+        /// If this is not available, the STS returned access token
+        /// should be directly used without impersonation.
+        /// </summary>
+        [JsonProperty("service_account_impersonation_url")]
+        public string ServiceAccountImpersonationUrl { get; set; }
+
+        /// <summary>
+        /// The endpoint used to retrieve the account related information 
+        /// associated with an external account credential.
+        /// </summary>
+        [JsonProperty("token_info_url")]
+        public string TokenInfoUrl { get; set; }
+
+        /// <summary>
+        /// The credential source associated with an external account credential.
+        /// </summary>
+        [JsonProperty("credential_source")]
+        public CredentialSource CredentialSourceConfig { get; set; }
+
+        /// <summary>
+        /// Holder for the credential source parameters associated to an external account credentials.
+        /// </summary>
+        public class CredentialSource
+        {
+            /// <summary>
+            /// The environment identifier for AWS external accounts.
+            /// </summary>
+            [JsonProperty("environment_id")]
+            public string EnvironmentId { get; set; }
+
+            /// <summary>
+            /// For URL-sourced credentials this is the URL from which to obtain the subject token from.
+            /// For AWS credentials this is the URL from which to obtain the IAM role associated to the instance.
+            /// </summary>
+            [JsonProperty("url")]
+            public string Url { get; set; }
+
+            /// <summary>
+            /// For URL-sourced credentilas this are headers to be included on the request to obtain the subject token.
+            /// </summary>
+            [JsonProperty("headers")]
+            public Dictionary<string, string> Headers { get; set; }
+
+            /// <summary>
+            /// For file-sourced credentials this is the path to the file containing the subject token.
+            /// </summary>
+            [JsonProperty("file")]
+            public string File { get; set; }
+
+            /// <summary>
+            /// For URL and file sourced credentials, indicates the format in which the subject token will be returned.
+            /// </summary>
+            [JsonProperty("format")]
+            public SubjectTokenFormat Format { get; set; }
+
+            /// <summary>
+            /// Holder for the subject token format.
+            /// </summary>
+            public class SubjectTokenFormat
+            {
+                /// <summary>
+                /// For URL and file sourced credentials, indicates the format in which the subject token is returned.
+                /// Supported values are <code>text</code> and <code>json</code>.
+                /// Defaults to <code>text</code>.
+                /// </summary>
+                [JsonProperty("type")]
+                public string Type { get; set; }
+
+                /// <summary>
+                /// For URL and file sourced credentials, if the subject token is returned within a JSON, this indicates the
+                /// field in which it can be found.
+                /// </summary>
+                [JsonProperty("subject_token_field_name")]
+                public string SubjectTokenFieldName { get; set; }
+            }
+        }
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/Requests/GoogleWifStsTokenRequest.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Requests/GoogleWifStsTokenRequest.cs
@@ -1,0 +1,83 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Util;
+
+namespace Google.Apis.Auth.OAuth2.Requests
+{
+    /// <summary>
+    /// OAuth 2.0 subject token exchange request as defined in
+    /// https://datatracker.ietf.org/doc/html/rfc8693#section-2.1.
+    /// This is a partial definition of the spec as required to support Google WIF
+    /// which may be expanded and renamed if support for other than WIF is needed.
+    /// </summary>
+    internal class GoogleWifStsTokenRequest
+    {
+        /// <summary>
+        /// Gets the grant type for this request.
+        /// Only <code>urn:ietf:params:oauth:grant-type:token-exchange</code> is currently supported.
+        /// </summary>
+        [RequestParameter("grant_type")]
+        public string GrantType { get; } = "urn:ietf:params:oauth:grant-type:token-exchange";
+
+        /// <summary>
+        /// The audience for which the requested token is intended. For instance:
+        /// "//iam.googleapis.com/projects/my-project-id/locations/global/workloadIdentityPools/my-pool-id/providers/my-provider-id"
+        /// </summary>
+        [RequestParameter("audience")]
+        public string Audience { get; set; }
+
+        /// <summary>
+        /// The space-delimited list of desired scopes for the requested token as defined in
+        /// http://tools.ietf.org/html/rfc6749#section-3.3. 
+        /// </summary>
+        [RequestParameter("scope")]
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// The type of the requested security token.
+        /// Only <code>urn:ietf:params:oauth:token-type:access_token</code> is currently supported.
+        /// </summary>
+        [RequestParameter("requested_token_type")]
+        public string RequestedTokenType { get; } = "urn:ietf:params:oauth:token-type:access_token";
+
+        /// <summary>
+        /// In terms of Google 3PI support, this is the 3PI credential.
+        /// </summary>
+        [RequestParameter("subject_token")]
+        public string SubjectToken { get; set; }
+
+        /// <summary>
+        /// The subject token type.
+        /// </summary>
+        [RequestParameter("subject_token_type")]
+        public string SubjectTokenType { get; set; }
+
+        /// <summary>
+        /// Client ID and client secret are not part of STS token exchange spec.
+        /// But in the context of Google 3PI they are used to perform basic authorization
+        /// for token exchange.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Client ID and client secret are not part of STS token exchange spec.
+        /// But in the context of Google 3PI they are used to perform basic authorization
+        /// for token exchange.
+        /// </summary>
+        public string ClientSecret { get; set; }
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/Requests/GoogleWifStsTokenRequestExtensions.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Requests/GoogleWifStsTokenRequestExtensions.cs
@@ -1,0 +1,54 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Logging;
+using Google.Apis.Requests.Parameters;
+using Google.Apis.Util;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2.Requests
+{
+    internal static class GoogleWifStsTokenRequestExtensions
+    {
+        internal static async Task<TokenResponse> ExecuteAsync(this GoogleWifStsTokenRequest request, HttpClient httpClient,
+            string tokenServerUrl, IClock clock, ILogger logger, CancellationToken taskCancellationToken)
+        {
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, tokenServerUrl)
+            {
+                Content = ParameterUtils.CreateFormUrlEncodedContent(request)
+            };
+            httpRequest.Headers.Authorization = request.GetAuthenticationHeader();
+
+            var response = await httpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
+            return await TokenResponse.FromHttpResponseAsync(response, clock, logger).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// If present, Client ID and Client Secret should be used to perform basic authentication
+        /// with Client ID being the username and Client Secret the password.
+        /// </summary>
+        private static AuthenticationHeaderValue GetAuthenticationHeader(this GoogleWifStsTokenRequest request) =>
+            (request.ClientId is string && request.ClientSecret is string)
+            ? new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($"{request.ClientId}:{request.ClientSecret}")))
+            : null;
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ServiceCredential.cs
@@ -194,6 +194,7 @@ namespace Google.Apis.Auth.OAuth2
         /// <summary>Constructs a new service account credential using the given initializer.</summary>
         public ServiceCredential(Initializer initializer)
         {
+            initializer.ThrowIfNull(nameof(initializer));
             TokenServerUrl = initializer.TokenServerUrl;
             AccessMethod = initializer.AccessMethod.ThrowIfNull("initializer.AccessMethod");
             Clock = initializer.Clock.ThrowIfNull("initializer.Clock");

--- a/Src/Support/Google.Apis.Auth/OAuth2/UrlSourcedExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UrlSourcedExternalAccountCredential.cs
@@ -1,0 +1,127 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+using Google.Apis.Json;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    internal class UrlSourcedExternalAccountCredential : DirectUseExternalAccountCredential
+    {
+        new internal class Initializer : DirectUseExternalAccountCredential.Initializer
+        {
+            /// <summary>
+            /// The URL from which to obtain the subject token.
+            /// </summary>
+            public string SubjectTokenUrl { get; }
+
+            /// <summary>
+            /// Headers to include in the request for the subject token.
+            /// May be null or empty.
+            /// </summary>
+            public IDictionary<string, string> Headers { get; set; }
+
+            /// <summary>
+            /// If set, the subject token response will be parsed as JSON and the
+            /// value in the field with name <see cref="SubjectTokenJsonFieldName"/>
+            /// will be returned as the subject token.
+            /// </summary>
+            public string SubjectTokenJsonFieldName { get; set; }
+
+            internal Initializer(string tokenUrl, string audience, string subjectTokenType, string subjectTokenUrl)
+                : base(tokenUrl, audience, subjectTokenType) => SubjectTokenUrl = subjectTokenUrl;
+
+            internal Initializer(Initializer other) : base(other)
+            {
+                SubjectTokenUrl = other.SubjectTokenUrl;
+                Headers = other.Headers is null ? null : new Dictionary<string, string>(other.Headers);
+                SubjectTokenJsonFieldName = other.SubjectTokenJsonFieldName;
+            }
+
+            internal Initializer(UrlSourcedExternalAccountCredential other) : base(other)
+            {
+                SubjectTokenUrl = other.SubjectTokenUrl;
+                Headers = other.Headers is null ? null : new Dictionary<string, string>(other.Headers.ToDictionary(pair => pair.Key, pair => pair.Value));
+                SubjectTokenJsonFieldName = other.SubjectTokenJsonFieldName;
+            }
+        }
+
+        /// <summary>
+        /// The URL from which to obtain the subject token.
+        /// </summary>
+        public string SubjectTokenUrl { get; }
+
+        /// <summary>
+        /// Headers to include in the request for the subject token.
+        /// May be empty. Will not be null.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// If set, the subject token response will be parsed as JSON and the
+        /// value in the field with name <see cref="SubjectTokenJsonFieldName"/>
+        /// will be returned as the subject token.
+        /// </summary>
+        public string SubjectTokenJsonFieldName { get; }
+
+        internal UrlSourcedExternalAccountCredential(Initializer initializer) : base(initializer)
+        {
+            SubjectTokenUrl = initializer.SubjectTokenUrl;
+            Headers = initializer.Headers is null
+                ? new ReadOnlyDictionary<string, string>(new Dictionary<string, string>())
+                : new ReadOnlyDictionary<string, string>(initializer.Headers);
+            SubjectTokenJsonFieldName = initializer.SubjectTokenJsonFieldName;
+        }
+
+        /// <inheritdoc/>
+        public override IGoogleCredential MaybeWithScopes(IEnumerable<string> scopes) =>
+            new UrlSourcedExternalAccountCredential(new Initializer(this) { Scopes = scopes });
+
+        /// <inheritdoc/>
+        public override IGoogleCredential WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            new UrlSourcedExternalAccountCredential(new Initializer(this) { HttpClientFactory = httpClientFactory });
+
+        /// <inheritdoc/>
+        public override IGoogleCredential WithQuotaProject(string quotaProject) =>
+            new UrlSourcedExternalAccountCredential(new Initializer(this) { QuotaProject = quotaProject });
+
+        /// <inheritdoc/>
+        protected async override Task<string> GetSubjectTokenAsync(CancellationToken taskCancellationToken)
+        {
+            var httpRequest = new HttpRequestMessage(HttpMethod.Get, SubjectTokenUrl);
+            foreach (var headerPair in Headers)
+            {
+                httpRequest.Headers.Add(headerPair.Key, headerPair.Value);
+            }
+
+            var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
+            var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (string.IsNullOrEmpty(SubjectTokenJsonFieldName))
+            {
+                return responseText;
+            }
+
+            return NewtonsoftJsonSerializer.Instance.Deserialize<Dictionary<string, string>>(responseText)[SubjectTokenJsonFieldName];
+        }
+    }
+}


### PR DESCRIPTION
This PR:

- Refactors exisitng impersonation code to in preparation for supporting external account impersonation.
- Adds base support for external accounts.
- Adds support for URL-sourced external accounts.

Once this PR has been reviewed and merged, two other PRs (which are ready) will follow adding support for file-sourced and AWS external credentials.

Towards #2033

FYI: @lsirac, @jpassing, @moserware, @TimurSadykov : I'd appreciate your review/comments very much (couldn't add you as reviewers on this repo though).