### PR TITLE
chore: Update docfx to 2.59.2

### DIFF
--- a/DocfxFunctions.sh
+++ b/DocfxFunctions.sh
@@ -3,7 +3,7 @@
 
 declare -r REPO_ROOT=$(readlink -f $(dirname ${BASH_SOURCE}))
 declare -r TOOL_PACKAGES=$REPO_ROOT/packages
-declare -r DOCFX_VERSION=2.56.6
+declare -r DOCFX_VERSION=2.59.2
 declare -r DOCFX=$TOOL_PACKAGES/docfx.$DOCFX_VERSION/docfx.exe
 
 # Appears to fix some issues in docfx.


### PR DESCRIPTION
I suspect that installing .NET 6 on the CI machine caused the
previous version of docfx to fail. (It's always been somewhat picky
about SDK versions.)