### PR TITLE
feat: Add support for file-sourced external credentials.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ExternalAccountCredentialTestsBase.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ExternalAccountCredentialTestsBase.cs
@@ -1,0 +1,154 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Responses;
+using Google.Apis.Json;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    public abstract class ExternalAccountCredentialTestsBase
+    {
+        protected const string SubjectTokenText = "dummy_subject_token";
+        protected const string SubjectTokenJsonField = "subject_token_field";
+        protected static readonly string SubjectTokenJson = $@"{{""{SubjectTokenJsonField}"": ""{SubjectTokenText}""}}";
+
+        protected const string TokenUrl = "https://dummy.token.url/";
+        protected const string GrantTypeClaim = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange";
+        protected const string RequestedTokenTypeClaim = "requested_token_type=urn:ietf:params:oauth:token-type:access_token";
+        protected const string Audience = "dummy_audience";
+        protected const string SubjectTokenType = "dummy_token_type";
+        protected const string Scope = "dummy_scope";
+        protected const string ImpersonationScope = "https://www.googleapis.com/auth/iam";
+        protected const string ClientId = "dummy_client_ID";
+        protected const string ClientSecret = "dummy_client_secret";
+        protected const string WorkforcePoolUserProject = "dummy_workforce_project";
+        protected const string ImpersonationUrl = "https://dummy.impersonation.url/";
+
+        protected const string AccessToken = "dummy_access_token";
+        protected const string RefreshedAccessToken = "dummy_refreshed_access_token";
+        protected const string ImpersonatedAccessToken = "dummy_impersonated_access_token";
+        protected const string QuotaProject = "dummy_project_id";
+        protected const string QuotaProjectHeaderName = "x-goog-user-project";
+
+        protected static async Task<HttpResponseMessage> ValidateAccessTokenRequest(HttpRequestMessage accessTokenRequest, string scope, bool isWorkforce = false)
+        {
+            Assert.Equal(TokenUrl, accessTokenRequest.RequestUri.ToString());
+            Assert.Equal(HttpMethod.Post, accessTokenRequest.Method);
+
+            string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
+
+            if (isWorkforce)
+            {
+                Assert.Null(accessTokenRequest.Headers.Authorization);
+                Assert.Contains($"options={{\"userProject\":\"{WorkforcePoolUserProject}\"}}", contentText);
+            }
+            else
+            {
+                Assert.Equal("Basic", accessTokenRequest.Headers.Authorization.Scheme);
+                Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes($"{ClientId}:{ClientSecret}")), accessTokenRequest.Headers.Authorization.Parameter);
+                Assert.DoesNotContain("options=", contentText);
+            }
+
+            Assert.Contains(GrantTypeClaim, contentText);
+            Assert.Contains(RequestedTokenTypeClaim, contentText);
+            Assert.Contains($"audience={Audience}", contentText);
+            Assert.Contains($"subject_token_type={SubjectTokenType}", contentText);
+            Assert.Contains($"subject_token={SubjectTokenText}", contentText);
+            Assert.Contains($"scope={scope}", contentText);
+
+            return await BuildAccessTokenResponse(AccessToken);
+        }
+
+        protected static async Task<HttpResponseMessage> ValidateImpersonatedAccessTokenRequest(HttpRequestMessage accessTokenRequest)
+        {
+            Assert.Equal(ImpersonationUrl, accessTokenRequest.RequestUri.ToString());
+            Assert.Equal(HttpMethod.Post, accessTokenRequest.Method);
+
+            Assert.Contains(accessTokenRequest.Headers, header => header.Key == QuotaProjectHeaderName && header.Value.Single() == QuotaProject);
+
+            Assert.Equal("Bearer", accessTokenRequest.Headers.Authorization.Scheme);
+            Assert.Equal(AccessToken, accessTokenRequest.Headers.Authorization.Parameter);
+
+            string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
+
+            Assert.Contains(Scope, contentText);
+
+            return await BuildAccessTokenResponse(new
+            {
+                accessToken = ImpersonatedAccessToken,
+                expireTime = "2020-05-13T16:00:00.045123456Z"
+            });
+        }
+
+        protected static async Task<HttpResponseMessage> ValidateAccessTokenFromJsonSubjectTokenRequest(HttpRequestMessage accessTokenRequest)
+        {
+            string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
+
+            // Even if the subject token was returned as a JSON, the access token request should receive the token value only.
+            Assert.Contains($"subject_token={SubjectTokenText}", contentText);
+
+            return await BuildAccessTokenResponse(AccessToken);
+        }
+
+        protected static Task<HttpResponseMessage> AccessTokenRequest(HttpRequestMessage accessTokenRequest) =>
+            BuildAccessTokenResponse(AccessToken);
+
+        protected static Task<HttpResponseMessage> RefreshTokenRequest(HttpRequestMessage accessTokenRequest) =>
+            BuildAccessTokenResponse(RefreshedAccessToken);
+
+        protected static Task<HttpResponseMessage> BuildAccessTokenResponse(string accessToken) =>
+            BuildAccessTokenResponse(new TokenResponse
+            {
+                AccessToken = accessToken,
+                ExpiresInSeconds = 24 * 60 * 60
+            });
+
+        protected static Task<HttpResponseMessage> BuildAccessTokenResponse(object accessToken)
+        {
+            string content = NewtonsoftJsonSerializer.Instance.Serialize(accessToken);
+            return Task.FromResult(new HttpResponseMessage
+            {
+                Content = new StringContent(content, Encoding.UTF8)
+            });
+        }
+
+        protected static void AssertAccessTokenWithHeaders(AccessTokenWithHeaders token)
+        {
+            Assert.Equal(AccessToken, token.AccessToken);
+            var header = Assert.Single(token.Headers);
+            Assert.Equal(QuotaProjectHeaderName, header.Key);
+            var headerValue = Assert.Single(header.Value);
+            Assert.Equal(QuotaProject, headerValue);
+        }
+
+        protected static void AssertImpersonatedAccessTokenWithHeaders(AccessTokenWithHeaders token)
+        {
+            Assert.Equal(ImpersonatedAccessToken, token.AccessToken);
+            var header = Assert.Single(token.Headers);
+            Assert.Equal(QuotaProjectHeaderName, header.Key);
+            var headerValue = Assert.Single(header.Value);
+            Assert.Equal(QuotaProject, headerValue);
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/FileSourcedExternalAccountCredentialTest.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/FileSourcedExternalAccountCredentialTest.cs
@@ -1,0 +1,203 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Tests.Mocks;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Google.Apis.Auth.Tests.OAuth2
+{
+    public class FileSourcedExternalAccountCredentialsTests : ExternalAccountCredentialTestsBase
+    {
+        private static string WriteSubjectTokenToTempFile(string subjectToken)
+        {
+            string path = Path.GetTempFileName();
+            File.WriteAllText(path, subjectToken);
+            return path;
+        }
+
+        [Fact]
+        public async Task FetchesAccessToken()
+        {
+            var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenText);
+            var messageHandler = new DelegatedMessageHandler(request => ValidateAccessTokenRequest(request, Scope));
+
+            var credential = new FileSourcedExternalAccountCredential(
+                new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    ClientId = ClientId,
+                    ClientSecret = ClientSecret,
+                    Scopes = new string[] { Scope },
+                    QuotaProject = QuotaProject
+                });
+
+            var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
+
+            AssertAccessTokenWithHeaders(token);
+            Assert.Equal(1, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task FetchesAccessToken_Impersonated()
+        {
+            var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenText);
+            var messageHandler = new DelegatedMessageHandler(
+                request => ValidateAccessTokenRequest(request, ImpersonationScope),
+                ValidateImpersonatedAccessTokenRequest);
+
+            var credential = new FileSourcedExternalAccountCredential(
+                new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    ClientId = ClientId,
+                    ClientSecret = ClientSecret,
+                    Scopes = new string[] { Scope },
+                    QuotaProject = QuotaProject,
+                    ServiceAccountImpersonationUrl = ImpersonationUrl
+                });
+
+            var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
+
+            AssertImpersonatedAccessTokenWithHeaders(token);
+            Assert.Equal(2, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task FetchesAccessToken_Workforce()
+        {
+            var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenText);
+            var messageHandler = new DelegatedMessageHandler(request => ValidateAccessTokenRequest(request, Scope, isWorkforce: true));
+
+            var credential = new FileSourcedExternalAccountCredential(
+                new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    WorkforcePoolUserProject = WorkforcePoolUserProject,
+                    Scopes = new string[] { Scope },
+                    QuotaProject = QuotaProject
+                });
+
+            var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
+
+            AssertAccessTokenWithHeaders(token);
+            Assert.Equal(1, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task FetchesAccessToken_ClientIdAndSecret_IgnoresWorkforce()
+        {
+            var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenText);
+            var messageHandler = new DelegatedMessageHandler(request => ValidateAccessTokenRequest(request, Scope, isWorkforce: false));
+
+            var credential = new FileSourcedExternalAccountCredential(
+                new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    WorkforcePoolUserProject = WorkforcePoolUserProject,
+                    ClientId = ClientId,
+                    ClientSecret = ClientSecret,
+                    Scopes = new string[] { Scope },
+                    QuotaProject = QuotaProject
+                });
+
+            var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
+
+            AssertAccessTokenWithHeaders(token);
+            Assert.Equal(1, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task FetchesAccessToken_JsonSubjectToken()
+        {
+            var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenJson);
+            var messageHandler = new DelegatedMessageHandler(ValidateAccessTokenFromJsonSubjectTokenRequest);
+
+            var credential = new FileSourcedExternalAccountCredential(
+                new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    SubjectTokenJsonFieldName = SubjectTokenJsonField
+                });
+
+            Assert.Equal(AccessToken, await credential.GetAccessTokenForRequestAsync());
+
+            Assert.Equal(1, messageHandler.Calls);
+        }
+
+        [Fact]
+        public async Task RefreshesAccessToken()
+        {
+            var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenText);
+            var messageHandler = new DelegatedMessageHandler(AccessTokenRequest, RefreshTokenRequest);
+            var clock = new MockClock(DateTime.UtcNow);
+
+            var credential = new FileSourcedExternalAccountCredential(
+                new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                {
+                    HttpClientFactory = new MockHttpClientFactory(messageHandler),
+                    Clock = clock
+                });
+
+            Assert.Equal(AccessToken, await credential.GetAccessTokenForRequestAsync());
+
+            clock.UtcNow = clock.UtcNow.AddDays(2);
+
+            Assert.Equal(RefreshedAccessToken, await credential.GetAccessTokenForRequestAsync());
+
+            Assert.Equal(2, messageHandler.Calls);
+        }
+
+        public static TheoryData<FileSourcedExternalAccountCredential, Type> SubjectTokenExceptionData
+        {
+            get
+            {
+                var subjectTokenPath = WriteSubjectTokenToTempFile(SubjectTokenText);
+
+                var data = new TheoryData<FileSourcedExternalAccountCredential, Type>
+                {
+                    {
+                        new FileSourcedExternalAccountCredential(
+                            new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, "unknownPath")),
+                        typeof(FileNotFoundException)
+                    },
+                    {
+                        new FileSourcedExternalAccountCredential(
+                            new FileSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, subjectTokenPath)
+                            {
+                                SubjectTokenJsonFieldName = "unknownField"
+                            }),
+                        typeof(JsonReaderException)
+                    }
+                };
+
+                return data;
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SubjectTokenExceptionData))]
+        public async Task SubjectTokenException(FileSourcedExternalAccountCredential credential, Type innerExceptionType)
+        {
+            var exception = await Assert.ThrowsAsync<SubjectTokenException>(async () => await credential.GetAccessTokenForRequestAsync());
+            Assert.IsType(innerExceptionType, exception.InnerException);
+        }
+    }
+}

--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/UrlSourcedExternalAccountCredentialTest.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/UrlSourcedExternalAccountCredentialTest.cs
@@ -15,45 +15,23 @@ limitations under the License.
 */
 
 using Google.Apis.Auth.OAuth2;
-using Google.Apis.Auth.OAuth2.Responses;
-using Google.Apis.Json;
 using Google.Apis.Tests.Mocks;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Google.Apis.Auth.Tests.OAuth2
 {
-    public class UrlSourcedExternalAccountCredentialsTests
+    public class UrlSourcedExternalAccountCredentialsTests : ExternalAccountCredentialTestsBase
     {
         private const string SubjectTokenUrl = "https://dummy.subject.token.url/";
         private static readonly KeyValuePair<string, string> SubjectTokenServiceHeader = new KeyValuePair<string, string>("key1", "value1");
-
-        private const string SubjectTokenText = "dummy_subject_token";
-        private const string SubjectTokenJsonField = "subject_token_field";
-        private static readonly string SubjectTokenJson = $@"{{""{SubjectTokenJsonField}"": ""{SubjectTokenText}""}}";
-
-        private const string TokenUrl = "https://dummy.token.url/";
-        private const string GrantTypeClaim = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange";
-        private const string RequestedTokenTypeClaim = "requested_token_type=urn:ietf:params:oauth:token-type:access_token";
-        private const string Audience = "dummy_audience";
-        private const string SubjectTokenType = "dummy_token_type";
-        private const string Scope = "dummy_scope";
-        private const string ImpersonationScope = "https://www.googleapis.com/auth/iam";
-        private const string ClientId = "dummy_client_ID";
-        private const string ClientSecret = "dummy_client_secret";
-        private const string WorkforcePoolUserProject = "dummy_workforce_project";
-
-        private const string AccessToken = "dummy_access_token";
-        private const string RefreshedAccessToken = "dummy_refreshed_access_token";
-        private const string ImpersonatedAccessToken = "dummy_impersonated_access_token";
-        private const string QuotaProject = "dummy_project_id";
-        private const string QuotaProjectHeaderName = "x-goog-user-project";
 
         private static Task<HttpResponseMessage> ValidateSubjectTokenRequest(HttpRequestMessage subjectTokenRequest)
         {
@@ -68,42 +46,14 @@ namespace Google.Apis.Auth.Tests.OAuth2
             });
         }
 
-        private static async Task<HttpResponseMessage> ValidateAccessTokenRequest(HttpRequestMessage accessTokenRequest, string scope, bool isWorkforce = false)
-        {
-            Assert.Equal(TokenUrl, accessTokenRequest.RequestUri.ToString());
-            Assert.Equal(HttpMethod.Post, accessTokenRequest.Method);
-
-            string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
-
-            if (isWorkforce)
+        private static Task<HttpResponseMessage> SubjectTokenRequest(HttpRequestMessage subjectTokenRequest) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Assert.Null(accessTokenRequest.Headers.Authorization);
-                Assert.Contains($"options={{\"userProject\":\"{WorkforcePoolUserProject}\"}}", contentText);
-            }
-            else
-            {
-                Assert.Equal("Basic", accessTokenRequest.Headers.Authorization.Scheme);
-                Assert.Equal(Convert.ToBase64String(Encoding.UTF8.GetBytes($"{ClientId}:{ClientSecret}")), accessTokenRequest.Headers.Authorization.Parameter);
-                Assert.DoesNotContain("options=", contentText);
-            }
+                Content = new StringContent(SubjectTokenText)
+            });
 
-            Assert.Contains(GrantTypeClaim, contentText);
-            Assert.Contains(RequestedTokenTypeClaim, contentText);
-            Assert.Contains($"audience={Audience}", contentText);
-            Assert.Contains($"subject_token_type={SubjectTokenType}", contentText);
-            Assert.Contains($"subject_token={SubjectTokenText}", contentText);
-            Assert.Contains($"scope={scope}", contentText);
-
-            return new HttpResponseMessage
-            {
-                Content = new StringContent(
-                    NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
-                    {
-                        AccessToken = AccessToken,
-                        ExpiresInSeconds = 24 * 60 * 60,
-                    }), Encoding.UTF8)
-            };
-        }
+        private static Task<HttpResponseMessage> SubjectTokenRequestFailure(HttpRequestMessage subjectTokenRequest) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
 
         [Fact]
         public async Task FetchesAccessToken()
@@ -123,19 +73,13 @@ namespace Google.Apis.Auth.Tests.OAuth2
 
             var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
 
-            Assert.Equal(AccessToken, token.AccessToken);
-            var header = Assert.Single(token.Headers);
-            Assert.Equal(QuotaProjectHeaderName, header.Key);
-            var headerValue = Assert.Single(header.Value);
-            Assert.Equal(QuotaProject, headerValue);
+            AssertAccessTokenWithHeaders(token);
             Assert.Equal(2, messageHandler.Calls);
         }
 
         [Fact]
         public async Task FetchesAccessToken_Impersonated()
         {
-            const string impersonationUrl = "https://dummy.impersonation.url/";
-
             var messageHandler = new DelegatedMessageHandler(
                 ValidateSubjectTokenRequest,
                 request => ValidateAccessTokenRequest(request, ImpersonationScope),
@@ -150,43 +94,13 @@ namespace Google.Apis.Auth.Tests.OAuth2
                     ClientSecret = ClientSecret,
                     Scopes = new string[] { Scope },
                     QuotaProject = QuotaProject,
-                    ServiceAccountImpersonationUrl = impersonationUrl
+                    ServiceAccountImpersonationUrl = ImpersonationUrl
                 });
 
             var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
 
-            Assert.Equal(ImpersonatedAccessToken, token.AccessToken);
-            var header = Assert.Single(token.Headers);
-            Assert.Equal(QuotaProjectHeaderName, header.Key);
-            var headerValue = Assert.Single(header.Value);
-            Assert.Equal(QuotaProject, headerValue);
-
+            AssertImpersonatedAccessTokenWithHeaders(token);
             Assert.Equal(3, messageHandler.Calls);
-
-            static async Task<HttpResponseMessage> ValidateImpersonatedAccessTokenRequest(HttpRequestMessage accessTokenRequest)
-            {
-                Assert.Equal(impersonationUrl, accessTokenRequest.RequestUri.ToString());
-                Assert.Equal(HttpMethod.Post, accessTokenRequest.Method);
-
-                Assert.Contains(accessTokenRequest.Headers, header => header.Key == QuotaProjectHeaderName && header.Value.Single() == QuotaProject);
-
-                Assert.Equal("Bearer", accessTokenRequest.Headers.Authorization.Scheme);
-                Assert.Equal(AccessToken, accessTokenRequest.Headers.Authorization.Parameter);
-
-                string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
-
-                Assert.Contains(Scope, contentText);
-
-                return new HttpResponseMessage()
-                { 
-                    Content = new StringContent(
-                        NewtonsoftJsonSerializer.Instance.Serialize(new
-                        { 
-                            accessToken = ImpersonatedAccessToken,
-                            expireTime = "2020-05-13T16:00:00.045123456Z"
-                        }))
-                };
-            }
         }
 
         [Fact]
@@ -206,11 +120,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
 
             var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
 
-            Assert.Equal(AccessToken, token.AccessToken);
-            var header = Assert.Single(token.Headers);
-            Assert.Equal(QuotaProjectHeaderName, header.Key);
-            var headerValue = Assert.Single(header.Value);
-            Assert.Equal(QuotaProject, headerValue);
+            AssertAccessTokenWithHeaders(token);
             Assert.Equal(2, messageHandler.Calls);
         }
 
@@ -233,11 +143,7 @@ namespace Google.Apis.Auth.Tests.OAuth2
 
             var token = await credential.GetAccessTokenWithHeadersForRequestAsync();
 
-            Assert.Equal(AccessToken, token.AccessToken);
-            var header = Assert.Single(token.Headers);
-            Assert.Equal(QuotaProjectHeaderName, header.Key);
-            var headerValue = Assert.Single(header.Value);
-            Assert.Equal(QuotaProject, headerValue);
+            AssertAccessTokenWithHeaders(token);
             Assert.Equal(2, messageHandler.Calls);
         }
 
@@ -264,24 +170,6 @@ namespace Google.Apis.Auth.Tests.OAuth2
                     Content = new StringContent(SubjectTokenJson)
                 });
             }
-
-            static async Task<HttpResponseMessage> ValidateAccessTokenFromJsonSubjectTokenRequest(HttpRequestMessage accessTokenRequest)
-            {
-                string contentText = WebUtility.UrlDecode(await accessTokenRequest.Content.ReadAsStringAsync());
-
-                // Even if the subject token was returned as a JSON, the access token request should receive the token value only.
-                Assert.Contains($"subject_token={SubjectTokenText}", contentText);
-
-                return new HttpResponseMessage()
-                {
-                    Content = new StringContent(
-                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
-                        {
-                            AccessToken = AccessToken,
-                            ExpiresInSeconds = 24 * 60 * 60,
-                        }), Encoding.UTF8)
-                };
-            }
         }
 
         [Fact]
@@ -304,34 +192,36 @@ namespace Google.Apis.Auth.Tests.OAuth2
             Assert.Equal(RefreshedAccessToken, await credential.GetAccessTokenForRequestAsync());
 
             Assert.Equal(4, messageHandler.Calls);
+        }
 
-            static Task<HttpResponseMessage> SubjectTokenRequest(HttpRequestMessage subjectTokenRequest) =>
-                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(SubjectTokenText)
-                });
+        public static TheoryData<UrlSourcedExternalAccountCredential, Type> SubjectTokenExceptionData => new TheoryData<UrlSourcedExternalAccountCredential, Type>
+        {
+            {
+                new UrlSourcedExternalAccountCredential(
+                    new UrlSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, SubjectTokenUrl)
+                    {
+                        // We retry 3 times so let's fail three times so the error is truly surfaced.
+                        HttpClientFactory = new MockHttpClientFactory(new DelegatedMessageHandler(SubjectTokenRequestFailure, SubjectTokenRequestFailure, SubjectTokenRequestFailure))
+                    }),
+                typeof(HttpRequestException)
+            },
+            {
+                new UrlSourcedExternalAccountCredential(
+                    new UrlSourcedExternalAccountCredential.Initializer(TokenUrl, Audience, SubjectTokenType, SubjectTokenUrl)
+                    {
+                        HttpClientFactory = new MockHttpClientFactory(new DelegatedMessageHandler(SubjectTokenRequest)),
+                        SubjectTokenJsonFieldName = "unknownField"
+                    }),
+                typeof(JsonReaderException)
+            }
+        };
 
-            static Task<HttpResponseMessage> AccessTokenRequest(HttpRequestMessage accessTokenRequest) =>
-                Task.FromResult(new HttpResponseMessage()
-                {
-                    Content = new StringContent(
-                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
-                        {
-                            AccessToken = AccessToken,
-                            ExpiresInSeconds = 24 * 60 * 60,
-                        }), Encoding.UTF8)
-                });
-
-            static Task<HttpResponseMessage> RefreshTokenRequest(HttpRequestMessage accessTokenRequest) =>
-                Task.FromResult(new HttpResponseMessage()
-                {
-                    Content = new StringContent(
-                        NewtonsoftJsonSerializer.Instance.Serialize(new TokenResponse
-                        {
-                            AccessToken = RefreshedAccessToken,
-                            ExpiresInSeconds = 24 * 60 * 60,
-                        }), Encoding.UTF8)
-                });
+        [Theory]
+        [MemberData(nameof(SubjectTokenExceptionData))]
+        public async Task SubjectTokenException(UrlSourcedExternalAccountCredential credential, Type innerExceptionType)
+        {
+            var exception = await Assert.ThrowsAsync<SubjectTokenException>(async () => await credential.GetAccessTokenForRequestAsync());
+            Assert.IsType(innerExceptionType, exception.InnerException);
         }
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
@@ -279,7 +279,16 @@ namespace Google.Apis.Auth.OAuth2
             }
             else if (!string.IsNullOrEmpty(parameters.CredentialSourceConfig.File))
             {
-                throw new NotImplementedException("File-sourced credentials not yet supported.");
+                return new FileSourcedExternalAccountCredential(new FileSourcedExternalAccountCredential.Initializer(
+                    parameters.TokenUrl, parameters.Audience, parameters.SubjectTokenType, parameters.CredentialSourceConfig.File)
+                {
+                    QuotaProject = parameters.QuotaProject,
+                    ServiceAccountImpersonationUrl = parameters.ServiceAccountImpersonationUrl,
+                    WorkforcePoolUserProject = parameters.WorkforcePoolUserProject,
+                    ClientId = parameters.ClientId,
+                    ClientSecret = parameters.ClientSecret,
+                    SubjectTokenJsonFieldName = parameters.ExtractSubjectTokenFieldName(),
+                });
             }
             else if (!string.IsNullOrEmpty(parameters.CredentialSourceConfig.Url))
             {
@@ -291,9 +300,7 @@ namespace Google.Apis.Auth.OAuth2
                     WorkforcePoolUserProject = parameters.WorkforcePoolUserProject,
                     ClientId = parameters.ClientId,
                     ClientSecret = parameters.ClientSecret,
-                    SubjectTokenJsonFieldName = parameters.CredentialSourceConfig.Format?.Type?.Equals("json", StringComparison.OrdinalIgnoreCase) == true
-                        ? parameters.CredentialSourceConfig.Format.SubjectTokenFieldName
-                        : null
+                    SubjectTokenJsonFieldName = parameters.ExtractSubjectTokenFieldName(),
                 };
                 if (parameters.CredentialSourceConfig.Headers is object)
                 {

--- a/Src/Support/Google.Apis.Auth/OAuth2/FileSourcedExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/FileSourcedExternalAccountCredential.cs
@@ -1,0 +1,141 @@
+﻿/*
+Copyright 2022 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+using Google.Apis.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Auth.OAuth2
+{
+    /// <summary>
+    /// File-sourced credentials as described in the
+    /// "Determining the subject token in file-sourced credentials" section of
+    /// https://google.aip.dev/auth/4117.
+    /// </summary>
+    public sealed class FileSourcedExternalAccountCredential : ExternalAccountCredential, IGoogleCredential
+    {
+        new internal class Initializer : ExternalAccountCredential.Initializer
+        {
+            /// <summary>
+            /// The file from which to obtain the subject token.
+            /// </summary>
+            internal string SubjectTokenFilePath { get; }
+
+            /// <summary>
+            /// If set, the subject token file content will be parsed as JSON and the
+            /// value in the field with name <see cref="SubjectTokenJsonFieldName"/>
+            /// will be returned as the subject token.
+            /// </summary>
+            internal string SubjectTokenJsonFieldName { get; set; }
+
+            internal Initializer(string tokenUrl, string audience, string subjectTokenType, string subjectTokenFilePath)
+                : base(tokenUrl, audience, subjectTokenType) => SubjectTokenFilePath = subjectTokenFilePath;
+
+            internal Initializer(Initializer other) : base(other)
+            {
+                SubjectTokenFilePath = other.SubjectTokenFilePath;
+                SubjectTokenJsonFieldName = other.SubjectTokenJsonFieldName;
+            }
+
+            internal Initializer(FileSourcedExternalAccountCredential other) : base(other)
+            {
+                SubjectTokenFilePath = other.SubjectTokenFilePath;
+                SubjectTokenJsonFieldName = other.SubjectTokenJsonFieldName;
+            }
+        }
+
+        /// <summary>
+        /// The file path from which to obtain the subject token.
+        /// </summary>
+        public string SubjectTokenFilePath { get; }
+
+        /// <summary>
+        /// If set, the subject token file content will be parsed as JSON and the
+        /// value in the field with name <see cref="SubjectTokenJsonFieldName"/>
+        /// will be returned as the subject token.
+        /// </summary>
+        public string SubjectTokenJsonFieldName { get; }
+
+        internal FileSourcedExternalAccountCredential(Initializer initializer) : base(initializer)
+        {
+            SubjectTokenFilePath = initializer.SubjectTokenFilePath;
+            SubjectTokenJsonFieldName = initializer.SubjectTokenJsonFieldName;
+        }
+
+        /// <inheritdoc/>
+        private protected override GoogleCredential WithoutImpersonationConfigurationImpl() =>
+            ServiceAccountImpersonationUrl is null
+            ? new GoogleCredential(this)
+            : new GoogleCredential(new FileSourcedExternalAccountCredential(new Initializer(this)
+            {
+                ServiceAccountImpersonationUrl = null
+            }));
+
+        /// <inheritdoc/>
+        protected override async Task<string> GetSubjectTokenAsyncImpl(CancellationToken taskCancellationToken)
+        {
+            var fileContent = await ReadSubjectTokenFileContentAsync().ConfigureAwait(false);
+            string subjectToken;
+
+            if (string.IsNullOrEmpty(SubjectTokenJsonFieldName))
+            {
+                subjectToken = fileContent;
+            }
+            else
+            {
+                var jsonResponse = NewtonsoftJsonSerializer.Instance.Deserialize<Dictionary<string, string>>(fileContent);
+
+                subjectToken = jsonResponse[SubjectTokenJsonFieldName];
+            }
+
+            return subjectToken;
+
+            async Task<string> ReadSubjectTokenFileContentAsync()
+            {
+                using var reader = File.OpenText(SubjectTokenFilePath);
+                return await reader.ReadToEndAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
+        string IGoogleCredential.QuotaProject => QuotaProject;
+
+        /// <inheritdoc/>
+        bool IGoogleCredential.HasExplicitScopes => HasExplicitScopes;
+
+        /// <inheritdoc/>
+        bool IGoogleCredential.SupportsExplicitScopes => SupportsExplicitScopes;
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithQuotaProject(string quotaProject) =>
+            new FileSourcedExternalAccountCredential(new Initializer(this) { QuotaProject = quotaProject });
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.MaybeWithScopes(IEnumerable<string> scopes) =>
+            new FileSourcedExternalAccountCredential(new Initializer(this) { Scopes = scopes });
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithUserForDomainWideDelegation(string user) =>
+            WithUserForDomainWideDelegation(user);
+
+        /// <inheritdoc/>
+        IGoogleCredential IGoogleCredential.WithHttpClientFactory(IHttpClientFactory httpClientFactory) =>
+            new FileSourcedExternalAccountCredential(new Initializer(this) { HttpClientFactory = httpClientFactory });
+    }
+}

--- a/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/JsonCredentialParameters.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Google.Apis.Auth.OAuth2
@@ -206,5 +207,13 @@ namespace Google.Apis.Auth.OAuth2
                 public string SubjectTokenFieldName { get; set; }
             }
         }
+    }
+
+    internal static class JsonCredentialParametersExtensions
+    {
+        public static string ExtractSubjectTokenFieldName(this JsonCredentialParameters parameters) =>
+            parameters.CredentialSourceConfig.Format?.Type?.Equals("json", StringComparison.OrdinalIgnoreCase) == true
+                ? parameters.CredentialSourceConfig.Format.SubjectTokenFieldName
+                : null;
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/UrlSourcedExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UrlSourcedExternalAccountCredential.cs
@@ -108,7 +108,7 @@ namespace Google.Apis.Auth.OAuth2
             }));
 
         /// <inheritdoc/>
-        protected async override Task<string> GetSubjectTokenAsync(CancellationToken taskCancellationToken)
+        protected async override Task<string> GetSubjectTokenAsyncImpl(CancellationToken taskCancellationToken)
         {
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, SubjectTokenUrl);
             foreach (var headerPair in Headers)
@@ -117,6 +117,7 @@ namespace Google.Apis.Auth.OAuth2
             }
 
             var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
             var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (string.IsNullOrEmpty(SubjectTokenJsonFieldName))


### PR DESCRIPTION
Towards #2033.

Also refactors the existing external account credential tests to make it easier to reuse test code.

FYI: @lsirac, @jpassing , @moserware