### PR TITLE
feat: Supports environment variable quota project ID.

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleAuthConsts.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleAuthConsts.cs
@@ -91,6 +91,21 @@ namespace Google.Apis.Auth.OAuth2
         internal const string IamScope = "https://www.googleapis.com/auth/iam";
 
         /// <summary>
+        /// Name of the environment variable that will be checked for an ambient quota project ID.
+        /// If set, this value will be applied to Application Default Credentials.
+        /// </summary>
+        public const string QuotaProjectEnvironmentVariable = "GOOGLE_CLOUD_QUOTA_PROJECT";
+
+        /// <summary>
+        /// The non empty value set on <see cref="QuotaProjectEnvironmentVariable"/>, if any;
+        /// null otherwise.
+        /// </summary>
+        internal static string EnvironmentQuotaProject =>
+            Environment.GetEnvironmentVariable(QuotaProjectEnvironmentVariable) is string environmentQuotaProject && environmentQuotaProject != ""
+            ? environmentQuotaProject
+            : null;
+
+        /// <summary>
         /// The effective Compute Engine authorization token server URL.
         /// This takes account of the GCE_METADATA_HOST environment variable.
         /// </summary>

--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -306,6 +306,24 @@ namespace Google.Apis.Auth.OAuth2
             new GoogleCredential(credential.WithQuotaProject(quotaProject));
 
         /// <summary>
+        /// Creates a copy of this credential with the ambient quota project as set in
+        /// <see cref="GoogleAuthConsts.QuotaProjectEnvironmentVariable"/>.
+        /// If <see cref="GoogleAuthConsts.QuotaProjectEnvironmentVariable"/> is not set, or if
+        /// it is set to the empty value, this method returns this instance.
+        /// </summary>
+        /// <remarks>
+        /// The ADC quota project value will be overwritten only if the environment variable is present
+        /// and set to a non-empty value.
+        /// If the environment variable is not present or if it is present but unset, the credential
+        /// returned will maintain whatever quota project value it already had, i.e. the credential's
+        /// quota project value will not be unset.
+        /// </remarks>
+        public GoogleCredential CreateWithEnvironmentQuotaProject() =>
+            GoogleAuthConsts.EnvironmentQuotaProject is string environmentQuotaProject
+            ? CreateWithQuotaProject(environmentQuotaProject)
+            : this;
+
+        /// <summary>
         /// Creates a copy of this credential with the specified HTTP client factory.
         /// </summary>
         /// <param name="factory">The HTTP client factory to be used by the new credential.


### PR DESCRIPTION
- If set, the value on the environment variable is always applied to ADC.
- A helper method is provided to apply this value to any credential.