### PR TITLE
Update support version: 1.57.0 -> 1.58.0-beta01

### DIFF
--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -2,7 +2,7 @@
 
   <!-- common nupkg information -->
   <PropertyGroup>
-    <Version>1.57.0</Version>
+    <Version>1.58.0-beta01</Version>
     <Authors>Google LLC</Authors>
     <Copyright>Copyright 2021 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>


### PR DESCRIPTION
Features
- #2228 Supports Quota Project environment variable for ADC.
- #2219 Removes obsolete OOB code. BREAKING CHANGE: We have removed OOB support from the library because the feature is not supported by Google OAuth as of October 3rd 2022. See the [official announcement](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob) for more information.
- #2216 Log errors when trying to reach Compute's metadata server.
- #2177, #2197, #2200, #2206, #2215, #2235 Support for Workload Identity Federation and Worforce Identity Federation.
- #2103 Compute credentials support explicit scopes.
- #2096 Improves deserialization error handling.