### PR TITLE
Update support version: 1.58.0-beta01 -> 1.58.0-beta02

### DIFF
--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -2,7 +2,7 @@
 
   <!-- common nupkg information -->
   <PropertyGroup>
-    <Version>1.58.0-beta01</Version>
+    <Version>1.58.0-beta02</Version>
     <Authors>Google LLC</Authors>
     <Copyright>Copyright 2021 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>


### PR DESCRIPTION
Bug fixes:

- #2251 Which fixes a typo on then name of one of the AWS Credential environment variables.
- #2264 Which adds a missing line break in AWS Credential canonical request.

Features

- #2269 Support per-request max retry configuration.