### PR TITLE
Update version: 1.57.0 => 1.58.0

### DIFF
--- a/CSharpGeneratorFunctions.sh
+++ b/CSharpGeneratorFunctions.sh
@@ -1,7 +1,7 @@
 # This is intended to be imported using the "source" function
 # from any script that wants to invoke the C#-based generator.
 
-declare -r GAPIC_GENERATOR_VERSION=1.4.8
+declare -r GAPIC_GENERATOR_VERSION=1.4.9
 
 TMP_CSHARP_GENERATOR_DIR=tmp-gapic-generator-csharp
 if [[ $CSHARP_GENERATOR_DIR == "" ]]

--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -2,7 +2,7 @@
 
   <!-- common nupkg information -->
   <PropertyGroup>
-    <Version>1.58.0-beta02</Version>
+    <Version>1.58.0</Version>
     <Authors>Google LLC</Authors>
     <Copyright>Copyright 2021 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>

--- a/features.json
+++ b/features.json
@@ -1,8 +1,8 @@
 {	
   "language": "csharp",	
   "description": "C# libraries for Google APIs.",	
-  "releaseVersion": "1.57.0", "comment1": "Version of generated package.",	
-  "currentSupportVersion": "1.57.0", "comment2": "Version of support library upon which to depend.",	
+  "releaseVersion": "1.58.0", "comment1": "Version of generated package.",	
+  "currentSupportVersion": "1.58.0", "comment2": "Version of support library upon which to depend.",	
   "pclSupportVersion": "1.25.0", "comment3": "Version of PCL support library.",	
   "net40SupportVersion": "1.10.0", "comment4": "Version of net40 support library.",	
 


### PR DESCRIPTION
And support version: 1.58.0-beta02 => 1.58.0

Dependencies:

- Client libraries no longer target netstandard1.0 or net40.

Bug fixes:

- #2273 Don't attempt to use an empty/null media type in batch responses
- #2251 Which fixes a typo on then name of one of the AWS Credential environment variables.
- #2264 Which adds a missing line break in AWS Credential canonical request.

Features
- #2269 Support per-request max retry configuration.
- #2228 Supports Quota Project environment variable for ADC.
- #2219 Removes obsolete OOB code. BREAKING CHANGE: We have removed OOB support from the library because the feature is not supported by Google OAuth as of October 3rd 2022. See the [official announcement](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob) for more information.
- #2216 Log errors when trying to reach Compute's metadata server.
- #2177, #2197, #2200, #2206, #2215, #2235 Support for Workload Identity Federation and Worforce Identity Federation.
- #2103 Compute credentials support explicit scopes.
- #2096 Improves deserialization error handling.