### PR TITLE
chore: Improve HttpListener-based test reliability

### DIFF
--- a/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.cs
@@ -127,7 +127,6 @@ namespace Google.Apis.Tests.Apis.Upload
                 do
                 {
                     _httpListener = new HttpListener();
-                    _httpListener.IgnoreWriteExceptions = true;
                     HttpPrefix = $"http://localhost:{rnd.Next(49152, 65535)}/";
                     _httpListener.Prefixes.Add(HttpPrefix);
                     try


### PR DESCRIPTION
This also stops ignoring write errors in HttpListener. I don't know why we used to ignore them, but it made it harder to diagnose the problem here.