### PR TITLE
fix: Drop trailing hex characters from version header values

### DIFF
--- a/Src/Support/Google.Apis/Requests/VersionHeaderBuilder.cs
+++ b/Src/Support/Google.Apis/Requests/VersionHeaderBuilder.cs
@@ -84,6 +84,12 @@ namespace Google.Apis.Requests
         /// </summary>
         public VersionHeaderBuilder AppendDotNetEnvironment() => AppendVersion("gl-dotnet", s_environmentVersion.Value);
 
+        /// <summary>
+        /// Whether the name or value that are supposed to be included in a header are valid
+        /// </summary>
+        private static bool IsHeaderNameValueValid(string nameOrValue) =>
+            !nameOrValue.Contains(" ") && !nameOrValue.Contains("/");
+
         private static string GetEnvironmentVersion()
         {
             // We can pick between the version reported by System.Environment.Version, or the version in the
@@ -125,7 +131,6 @@ namespace Google.Apis.Requests
             }
         }
 
-
         private static string FormatAssemblyVersion(System.Type type)
         {
             // Prefer AssemblyInformationalVersion, then AssemblyFileVersion,
@@ -133,9 +138,9 @@ namespace Google.Apis.Requests
 
             var assembly = type.GetTypeInfo().Assembly;
             var info = assembly.GetCustomAttributes<AssemblyInformationalVersionAttribute>().FirstOrDefault()?.InformationalVersion;
-            if (info != null)
+            if (info != null && IsHeaderNameValueValid(info)) // Skip informational version if it's not a valid header value
             {
-                return info;
+                return FormatInformationalVersion(info);
             }
             var file = assembly.GetCustomAttributes<AssemblyFileVersionAttribute>().FirstOrDefault()?.Version;
             if (file != null)
@@ -143,6 +148,35 @@ namespace Google.Apis.Requests
                 return string.Join(".", file.Split('.').Take(3));
             }
             return FormatVersion(assembly.GetName().Version);
+        }
+
+        // Visible for testing
+
+        /// <summary>
+        /// Formats an AssemblyInformationalVersionAttribute value to avoid losing useful information,
+        /// but also avoid including unnecessary hex that is appended automatically.
+        /// </summary>
+        internal static string FormatInformationalVersion(string info)
+        {
+            // In some cases, the runtime includes 40 hex digits after a + or period in InformationalVersion.
+            // In precisely those cases, we strip this.
+            int signIndex = Math.Max(info.LastIndexOf('.'), info.LastIndexOf('+'));
+            if (signIndex == -1 || signIndex != info.Length - 41)
+            {
+                return info;
+            }
+            for (int i = signIndex + 1; i < info.Length; i++)
+            {
+                char c = info[i];
+                bool isHex = (c >= '0' && c <= '9')
+                    || (c >= 'a' && c <= 'f')
+                    || (c >= 'A' && c <= 'F');
+                if (!isHex)
+                {
+                    return info;
+                }
+            }
+            return info.Substring(0, signIndex);
         }
 
         private static string FormatVersion(Version version) =>


### PR DESCRIPTION
This is equivalent to googleapis/gax-dotnet/pull/637