### PR TITLE
chore: Attempt to fix docfx references

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "docfx": {
+      "version": "2.60.0",
+      "commands": [
+        "docfx"
+      ]
+    }
+  }
+}

--- a/.kokoro/BuildGeneratedDocs.sh
+++ b/.kokoro/BuildGeneratedDocs.sh
@@ -15,9 +15,6 @@ install_docfx
 rm -rf Src/Generated/*/obj
 rm -rf Src/Generated/*/bin
 
-# Some versions of docfx fail if VSINSTALLDIR is set (and isn't a version they expect)
-export VSINSTALLDIR=
-
 # Extract the support libraries version number from the XML.
 # This is pretty horrible, but it works...
 declare -r supportversion=$(grep \<Version\> Src/Support/CommonProjectProperties.xml | sed 's/</>/g' | cut -d\> -f 3)
@@ -61,8 +58,8 @@ build_site() {
   sed -i "s/\\\$title/$package/g" $directory/index.md  
   sed -i "s/\\\$entry_namespace/$package/g" $directory/index.md  
   
-  $DOCFX metadata -f --disableGitFeatures $json
-  $DOCFX build --disableGitFeatures $json
+  dotnet docfx metadata -f --disableGitFeatures $json
+  dotnet docfx build --disableGitFeatures $json
 
   if [ ! -d $directory/obj/api ]
   then

--- a/.kokoro/BuildGeneratedDocs.sh
+++ b/.kokoro/BuildGeneratedDocs.sh
@@ -23,9 +23,16 @@ declare -r supportversion=$(grep \<Version\> Src/Support/CommonProjectProperties
 # TODO: Work out somewhere better to put these!
 rm -rf obj
 mkdir obj
-curl -sSL https://googleapis.dev/dotnet/Google.Apis/$supportversion/xrefmap.yml -o obj/Google.Apis.xrefmap.yml
-curl -sSL https://googleapis.dev/dotnet/Google.Apis.Core/$supportversion/xrefmap.yml -o obj/Google.Apis.Core.xrefmap.yml
-curl -sSL https://googleapis.dev/dotnet/Google.Apis.Auth/$supportversion/xrefmap.yml -o obj/Google.Apis.Auth.xrefmap.yml
+
+# Temporary workaround for failure to fetch xref maps from googleapis.dev: build locally and copy.
+# This is far from great, as it means we could refer to unreleased methods, but it's better than nothing.
+.kokoro/BuildSupportDocs.sh
+cp Src/Support/Google.Apis/obj/site/xrefmap.yml obj/Google.Apis.xrefmap.yml
+cp Src/Support/Google.Apis.Core/obj/site/xrefmap.yml obj/Google.Apis.Core.xrefmap.yml
+cp Src/Support/Google.Apis.Auth/obj/site/xrefmap.yml obj/Google.Apis.Auth.xrefmap.yml
+#curl -sSL https://googleapis.dev/dotnet/Google.Apis/$supportversion/xrefmap.yml -o obj/Google.Apis.xrefmap.yml
+#curl -sSL https://googleapis.dev/dotnet/Google.Apis.Core/$supportversion/xrefmap.yml -o obj/Google.Apis.Core.xrefmap.yml
+#curl -sSL https://googleapis.dev/dotnet/Google.Apis.Auth/$supportversion/xrefmap.yml -o obj/Google.Apis.Auth.xrefmap.yml
 
 build_site() {
   declare -r package=$1

--- a/.kokoro/BuildSupportDocs.sh
+++ b/.kokoro/BuildSupportDocs.sh
@@ -16,9 +16,6 @@ rm -rf Src/Support/*/obj
 rm -rf Src/Support/*/bin
 dotnet build Src/Support/GoogleApisClient.sln
 
-# Some versions of docfx fail if VSINSTALLDIR is set (and isn't a version they expect)
-export VSINSTALLDIR=
-
 # Extract the support libraries version number from the XML.
 # This is pretty horrible, but it works...
 declare -r version=$(grep \<Version\> Src/Support/CommonProjectProperties.xml | sed 's/</>/g' | cut -d\> -f 3)
@@ -45,8 +42,8 @@ build_site() {
   sed -i "s/\\\$title/Google API support libraries/g" $directory/index.md
   sed -i "s/\\\$entry_namespace/$entry_namespace/g" $directory/index.md  
   
-  $DOCFX metadata -f --disableGitFeatures $json
-  $DOCFX build --disableGitFeatures $json
+  dotnet docfx metadata -f --disableGitFeatures $json
+  dotnet docfx build --disableGitFeatures $json
   
   if [ ! -d $directory/obj/api ]
   then

--- a/DocfxFunctions.sh
+++ b/DocfxFunctions.sh
@@ -11,16 +11,5 @@ declare -r DOCFX=$TOOL_PACKAGES/docfx.$DOCFX_VERSION/docfx.exe
 export VSINSTALLDIR=
 
 install_docfx() {
-  if [[ ! -f $DOCFX ]]
-  then
-    (echo "Fetching docfx v${DOCFX_VERSION}";
-     mkdir -p $TOOL_PACKAGES;
-     cd $TOOL_PACKAGES;
-     mkdir docfx.$DOCFX_VERSION;
-     cd docfx.$DOCFX_VERSION;
-     curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
-     unzip -q tmp.zip;
-     rm tmp.zip;
-     )
-  fi  
+  dotnet tool install docfx > /dev/null
 }


### PR DESCRIPTION
The first commit, which updates docfx to use 2.60.0 as a dotnet tool, fixes some API documentation generation.
The second commit is a workaround for the reference files being missing.