### PR TITLE
chore: Fix docfx build

### DIFF
--- a/.kokoro/BuildGeneratedDocs.sh
+++ b/.kokoro/BuildGeneratedDocs.sh
@@ -65,7 +65,7 @@ build_site() {
   sed -i "s/\\\$title/$package/g" $directory/index.md  
   sed -i "s/\\\$entry_namespace/$package/g" $directory/index.md  
   
-  dotnet docfx metadata -f --disableGitFeatures $json
+  dotnet docfx metadata --disableGitFeatures $json
   dotnet docfx build --disableGitFeatures $json
 
   if [ ! -d $directory/obj/api ]

--- a/.kokoro/BuildSupportDocs.sh
+++ b/.kokoro/BuildSupportDocs.sh
@@ -42,7 +42,7 @@ build_site() {
   sed -i "s/\\\$title/Google API support libraries/g" $directory/index.md
   sed -i "s/\\\$entry_namespace/$entry_namespace/g" $directory/index.md  
   
-  dotnet docfx metadata -f --disableGitFeatures $json
+  dotnet docfx metadata --disableGitFeatures $json
   dotnet docfx build --disableGitFeatures $json
   
   if [ ! -d $directory/obj/api ]


### PR DESCRIPTION
The -f command line option has been removed in 2.62.0. (docfx no longer supports incremental builds, which we were disabling anyway.)

Fixes #2337