### PR TITLE
fix: Change the link to ADC documentation

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/DefaultCredentialProvider.cs
@@ -58,7 +58,7 @@ namespace Google.Apis.Auth.OAuth2
 
         /// <summary>Help link to the application default credentials feature.</summary>
         private const string HelpPermalink =
-            "https://cloud.google.com/docs/authentication/provide-credentials-adc";
+            "https://cloud.google.com/docs/authentication/external/set-up-adc";
 
         /// <summary>GCloud configuration directory on Linux/Mac, relative to $HOME.</summary>
         private static readonly string CloudSDKConfigDirectoryUnix = Path.Combine(".config", "gcloud");


### PR DESCRIPTION
This link is included in the exception message if ADC is requested and is not setup.

This change has been requested by the Auth TW team.