### PR TITLE
fix: Only generate .json files, not .json.original files

### DIFF
--- a/BuildGenerated.sh
+++ b/BuildGenerated.sh
@@ -122,8 +122,8 @@ then
   if [[ $GENERATE_CHANGES_ONLY == "TRUE" ]]
   then
     # Only generate libraries for discovery docs that have changed or are new.
-    modified=$(git status -s -- $DISCOVERY_DOC_DIR | grep -E '^ M' | cut "-d " -f3)
-    added=$(git status -s -- $DISCOVERY_DOC_DIR | grep -E '^\?\?' | cut "-d " -f2)
+    modified=$(git status -s -- $DISCOVERY_DOC_DIR | grep -E '\.json$' | grep -E '^ M' | cut "-d " -f3)
+    added=$(git status -s -- $DISCOVERY_DOC_DIR | grep -E '\.json$' | grep -E '^\?\?' | cut "-d " -f2)
     needs_generation=(${modified[@]} ${added[@]})
     # If we generate only a subset of the existing discoveries, we do so in a temporary
     # folder so as not to delete generated code for the unmodified discoveries.


### PR DESCRIPTION
Fixes #2384

We don't need to force regeneration - I've delisted the latest Admin Discovery package (which is the only one we patch now), and the only changes were in comments, so we can just wait for the next time it's regenerated normally.