### PR TITLE
Fixing memory leaks caused by not disposing HttpRequestMessage and HttpResponseMessage

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/AwsExternalAccountCredential.AwsMetadataServerClient.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/AwsExternalAccountCredential.AwsMetadataServerClient.cs
@@ -68,18 +68,18 @@ namespace Google.Apis.Auth.OAuth2
                 }
 
                 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works
-                var request = new HttpRequestMessage(HttpMethod.Put, _imdsV2SessionTokenUrl)
+                using var request = new HttpRequestMessage(HttpMethod.Put, _imdsV2SessionTokenUrl)
                 {
                     Headers = { { ImdsV2SessionTokenTtlHeaderName, ImdsV2SessionTokenTtlSeconds } }
                 };
-                var response = await _httpClient.SendAsync(request, _cancellationToken).ConfigureAwait(false);
+                using var response = await _httpClient.SendAsync(request, _cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
 
             internal async Task<string> FetchMetadataAsync(string metadataUrl)
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, metadataUrl);
+                using var request = new HttpRequestMessage(HttpMethod.Get, metadataUrl);
 
                 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-v2-how-it-works
                 if (await _imdsV2SessionToken.Value.ConfigureAwait(false) is string sessionToken)
@@ -87,7 +87,7 @@ namespace Google.Apis.Auth.OAuth2
                     request.Headers.Add(MetatadaServerRequestImdsV2SessionTokenHeaderName, sessionToken);
                 }
 
-                var response = await _httpClient.SendAsync(request, _cancellationToken).ConfigureAwait(false);
+                using var response = await _httpClient.SendAsync(request, _cancellationToken).ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();
                 return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }

--- a/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/ComputeCredential.cs
@@ -194,9 +194,9 @@ namespace Google.Apis.Auth.OAuth2
         public override async Task<bool> RequestAccessTokenAsync(CancellationToken taskCancellationToken)
         {
             // Create and send the HTTP request to compute server token URL.
-            var httpRequest = new HttpRequestMessage(HttpMethod.Get, EffectiveTokenServerUrl);
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, EffectiveTokenServerUrl);
             httpRequest.Headers.Add(MetadataFlavor, GoogleMetadataHeader);
-            var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
             Token = await TokenResponse.FromHttpResponseAsync(response, Clock, Logger).ConfigureAwait(false);
             return true;
         }
@@ -227,10 +227,10 @@ namespace Google.Apis.Auth.OAuth2
                 }
             }
 
-            var httpRequest = new HttpRequestMessage(HttpMethod.Get, uri);
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, uri);
             httpRequest.Headers.Add(MetadataFlavor, GoogleMetadataHeader);
 
-            var response = await HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
             var token = await TokenResponse.FromHttpResponseAsync(response, Clock, Logger).ConfigureAwait(false);
             caller.Token = token;
             return true;
@@ -266,10 +266,10 @@ namespace Google.Apis.Auth.OAuth2
 
         private async Task<string> FetchDefaultServiceAccountEmailAsync()
         {
-            var httpRequest = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.EffectiveComputeDefaultServiceAccountEmailUrl);
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.EffectiveComputeDefaultServiceAccountEmailUrl);
             httpRequest.Headers.Add(MetadataFlavor, GoogleMetadataHeader);
 
-            var response = await HttpClient.SendAsync(httpRequest).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(httpRequest).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
@@ -309,9 +309,9 @@ namespace Google.Apis.Auth.OAuth2
                     cts.CancelAfter(MetadataServerPingTimeoutInMilliseconds);
                     try
                     {
-                        var httpRequest = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.EffectiveMetadataServerUrl);
+                        using var httpRequest = new HttpRequestMessage(HttpMethod.Get, GoogleAuthConsts.EffectiveMetadataServerUrl);
                         httpRequest.Headers.Add(MetadataFlavor, GoogleMetadataHeader);
-                        var response = await httpClient.SendAsync(httpRequest, cts.Token).ConfigureAwait(false);
+                        using var response = await httpClient.SendAsync(httpRequest, cts.Token).ConfigureAwait(false);
                         if (response.Headers.TryGetValues(MetadataFlavor, out var headerValues)
                             && headerValues.Contains(GoogleMetadataHeader))
                         {

--- a/Src/Support/Google.Apis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/Flows/GoogleAuthorizationCodeFlow.cs
@@ -114,9 +114,9 @@ namespace Google.Apis.Auth.OAuth2.Flows
             {
                 Token = token
             };
-            var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.Build());
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, request.Build());
 
-            var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/Src/Support/Google.Apis.Auth/OAuth2/UrlSourcedExternalAccountCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/UrlSourcedExternalAccountCredential.cs
@@ -109,13 +109,13 @@ namespace Google.Apis.Auth.OAuth2
         /// <inheritdoc/>
         protected async override Task<string> GetSubjectTokenAsyncImpl(CancellationToken taskCancellationToken)
         {
-            var httpRequest = new HttpRequestMessage(HttpMethod.Get, SubjectTokenUrl);
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Get, SubjectTokenUrl);
             foreach (var headerPair in Headers)
             {
                 httpRequest.Headers.Add(headerPair.Key, headerPair.Value);
             }
 
-            var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
+            using var response = await HttpClient.SendAsync(httpRequest, taskCancellationToken).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
             var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/Src/Support/Google.Apis/Download/MediaDownloader.cs
+++ b/Src/Support/Google.Apis/Download/MediaDownloader.cs
@@ -272,7 +272,7 @@ namespace Google.Apis.Download
                 uri.Query = uri.Query.Substring(1) + "&alt=media";
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Get, uri.Uri);
+            using var request = new HttpRequestMessage(HttpMethod.Get, uri.Uri);
             request.Headers.Range = Range;
             if (ResponseStreamInterceptorProvider != null)
             {

--- a/Src/Support/Google.Apis/Requests/BatchRequest.cs
+++ b/Src/Support/Google.Apis/Requests/BatchRequest.cs
@@ -420,7 +420,7 @@ namespace Google.Apis.Requests
         [VisibleForTestOnly]
         internal static async Task<HttpContent> CreateIndividualRequest(IClientServiceRequest request)
         {
-            HttpRequestMessage requestMessage = request.CreateRequest(false);
+            using HttpRequestMessage requestMessage = request.CreateRequest(false);
             string requestContent = await CreateRequestContentString(requestMessage).ConfigureAwait(false);
 
             var content = new StringContent(requestContent);

--- a/Src/Support/Google.Apis/Upload/ResumableUpload.cs
+++ b/Src/Support/Google.Apis/Upload/ResumableUpload.cs
@@ -534,7 +534,7 @@ namespace Google.Apis.Upload
             }
             // The first "resuming" request is to query the server in which point the upload was interrupted.
             var range = String.Format("bytes */{0}", StreamLength < 0 ? "*" : StreamLength.ToString());
-            HttpRequestMessage request = new RequestBuilder()
+            using HttpRequestMessage request = new RequestBuilder()
             {
                 BaseUri = UploadUri,
                 Method = HttpConsts.Put
@@ -543,9 +543,8 @@ namespace Google.Apis.Upload
 
             try
             {
-                HttpResponseMessage response;
                 new ServerErrorCallback(this).AddToRequest(request);
-                response = await HttpClient.SendAsync(request, cancellationToken)
+                using HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (await HandleResponse(response).ConfigureAwait(false))
@@ -623,7 +622,7 @@ namespace Google.Apis.Upload
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            HttpRequestMessage request = new RequestBuilder()
+            using HttpRequestMessage request = new RequestBuilder()
                 {
                     BaseUri = UploadUri,
                     Method = HttpConsts.Put
@@ -648,7 +647,7 @@ namespace Google.Apis.Upload
             // but just occasionally it'll return a 308 that makes us resend a chunk. We need to
             // be aware of that so that the upload interceptor is called appropriately afterwards.
             long bytesServerReceivedBefore = BytesServerReceived;
-            HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken)
+            using HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken)
                 .ConfigureAwait(false);
             var completed = await HandleResponse(response).ConfigureAwait(false);
             long bytesServerReceivedAfter = BytesServerReceived;
@@ -1134,9 +1133,9 @@ namespace Google.Apis.Upload
         /// <inheritdoc/>
         public override async Task<Uri> InitiateSessionAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            HttpRequestMessage request = CreateInitializeRequest();
+            using HttpRequestMessage request = CreateInitializeRequest();
             Options?.ModifySessionInitiationRequest?.Invoke(request);
-            var response = await Service.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            using var response = await Service.HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
This PR fixes a memory leak caused by not disposing HttpRequestMessage and HttpResponseMessage. On long running program, a small amount of memory were never released.