### PR TITLE
feat: Add extension method for IHttpExecuteInterceptor to create a DelegatingHandler

### DIFF
--- a/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/GoogleCredential.cs
@@ -18,6 +18,7 @@ using Google.Apis.Http;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -32,7 +33,7 @@ namespace Google.Apis.Auth.OAuth2
     /// See <see cref="GetApplicationDefaultAsync(CancellationToken)"/> for the credential retrieval logic.
     /// </para>
     /// </summary>
-    public class GoogleCredential : ICredential, ITokenAccessWithHeaders, IOidcTokenProvider, IBlobSigner
+    public class GoogleCredential : ICredential, ITokenAccessWithHeaders, IOidcTokenProvider, IBlobSigner, IHttpExecuteInterceptor
     {
         /// <summary>Provider implements the logic for creating the application default credential.</summary>
         private static readonly DefaultCredentialProvider defaultCredentialProvider = new DefaultCredentialProvider();
@@ -378,5 +379,9 @@ namespace Google.Apis.Auth.OAuth2
         {
             return new GoogleCredential(credential);
         }
+
+        // Proxy IHttpExecuteInterceptor's only method.
+        Task IHttpExecuteInterceptor.InterceptAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            credential.InterceptAsync(request, cancellationToken);
     }
 }

--- a/Src/Support/Google.Apis.Auth/OAuth2/IGoogleCredential.cs
+++ b/Src/Support/Google.Apis.Auth/OAuth2/IGoogleCredential.cs
@@ -25,7 +25,7 @@ namespace Google.Apis.Auth.OAuth2
     /// credential types that can be used as an underlying credential in <see cref="GoogleCredential"/>
     /// should implement in contrast to <see cref="ICredential"/> that defines public functionality.
     /// </summary>
-    internal interface IGoogleCredential : ICredential, ITokenAccessWithHeaders
+    internal interface IGoogleCredential : ICredential, ITokenAccessWithHeaders, IHttpExecuteInterceptor
     {
         /// <summary>
         /// The ID of the project associated to this credential for the purposes of

--- a/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
+++ b/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
@@ -5,6 +5,7 @@
   <!-- build configuration -->
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <!-- nupkg information -->

--- a/Src/Support/Google.Apis.Core/Http/HttpExtenstions.cs
+++ b/Src/Support/Google.Apis.Core/Http/HttpExtenstions.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Google.Apis.Core.Http;
 using System.Net;
 using System.Net.Http;
 
@@ -47,5 +48,26 @@ namespace Google.Apis.Http
             request.Content.Headers.ContentLength = 0;
             return request.Content;
         }
+
+        /// <summary>
+        /// Creates a <see cref="DelegatingHandler"/> which applies the execution interceptor
+        /// in <paramref name="interceptor"/> (usually a credential) before delegating onwards.
+        /// </summary>
+        /// <param name="interceptor">The interceptor to execute before the remainder of the handler chain. Must not be null.</param>
+        /// <param name="innerHandler">The initial inner handler.</param>
+        /// <returns>A delegating HTTP message handler.</returns>
+        public static DelegatingHandler ToDelegatingHandler(this IHttpExecuteInterceptor interceptor, HttpMessageHandler innerHandler) =>
+            new InterceptorDelegatingHandler(interceptor, innerHandler);
+
+        /// <summary>
+        /// Creates a <see cref="DelegatingHandler"/> which applies the execution interceptor
+        /// in <paramref name="interceptor"/> (usually a credential) before delegating onwards.
+        /// The <see cref="DelegatingHandler.InnerHandler"/> of the returned handler must be specified before
+        /// the first request is made.
+        /// </summary>
+        /// <param name="interceptor">The interceptor to execute before the remainder of the handler chain. Must not be null.</param>
+        /// <returns>A delegating HTTP message handler.</returns>
+        public static DelegatingHandler ToDelegatingHandler(this IHttpExecuteInterceptor interceptor) =>
+            new InterceptorDelegatingHandler(interceptor);
     }
 }

--- a/Src/Support/Google.Apis.Core/Http/InterceptorDelegatingHandler.cs
+++ b/Src/Support/Google.Apis.Core/Http/InterceptorDelegatingHandler.cs
@@ -1,0 +1,48 @@
+﻿/*
+Copyright 2023 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Google.Apis.Http;
+using Google.Apis.Util;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Apis.Core.Http;
+
+/// <summary>
+/// A <see cref="DelegatingHandler"/> which executes an <see cref="IHttpExecuteInterceptor"/> before
+/// delegating onwards.
+/// </summary>
+internal sealed class InterceptorDelegatingHandler : DelegatingHandler
+{
+    private readonly IHttpExecuteInterceptor _interceptor;
+
+    internal InterceptorDelegatingHandler(IHttpExecuteInterceptor interceptor, HttpMessageHandler innerHandler) : base(innerHandler)
+    {
+        _interceptor = interceptor.ThrowIfNull(nameof(interceptor));
+    }
+
+    internal InterceptorDelegatingHandler(IHttpExecuteInterceptor interceptor)
+    {
+        _interceptor = interceptor.ThrowIfNull(nameof(interceptor));
+    }
+
+    protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        await _interceptor.InterceptAsync(request, cancellationToken).ConfigureAwait(false);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/Src/Support/IntegrationTests/HttpClientWithExecuteInterceptorTests.cs
+++ b/Src/Support/IntegrationTests/HttpClientWithExecuteInterceptorTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Http;
+using Google.Apis.Storage.v1;
+using IntegrationTests.Utils;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IntegrationTests;
+
+public class HttpClientWithExecuteInterceptorTests
+{
+    [Fact]
+    public async Task NoAuthentication_Fails()
+    {
+        using var client = new HttpClient();
+        var request = CreateListBucketsRequest();
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InterceptWithCredentials()
+    {
+        var credential = Helper.GetServiceCredential().CreateScoped(StorageService.Scope.DevstorageFullControl);
+        var handler = credential.ToDelegatingHandler(new HttpClientHandler());
+        using var client = new HttpClient(handler);
+        var request = CreateListBucketsRequest();
+        var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // Validate that this does look like a listing for buckets...
+        var json = await response.Content.ReadAsStringAsync();
+        var obj = JObject.Parse(json);
+        var kind = (string) obj["kind"];
+        Assert.Equal("storage#buckets", kind);
+    }
+
+    private static HttpRequestMessage CreateListBucketsRequest()
+    {
+        var uri = new StorageService().Buckets.List(Helper.GetProjectId()).CreateRequest().RequestUri;
+
+        return new HttpRequestMessage
+        {
+            RequestUri = uri,
+            Method = HttpMethod.Get
+        };
+    }
+}


### PR DESCRIPTION
This is a proposed plan for #2450

Lacking documentation and tests right now...

(Basically, this is all simple if folks have a concrete credential, as they all either implement IHttpExecuteInterceptor, or can do so very simply, such as GoogleCredential.)