### PR TITLE
tests: Test refactoring

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/Pkcs8Tests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/Pkcs8Tests.cs
@@ -123,7 +123,7 @@ lK1DcBvq+IFLucBdi0/9hXE=
                 catch (CryptographicException e)
                 {
                     // Fails in iteration 8 without the Pkcs8 fix in PR#937
-                    Assert.True(false, $"Failed in iteration {i}: {e}");
+                    Assert.Fail($"Failed in iteration {i}: {e}");
                 }
                 // Check that all the parameters exported are equal to the originally created parameters
                 var exportedParams = key.ExportParameters(true);

--- a/Src/Support/Google.Apis.Tests/Apis/Download/MediaDownloaderTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Download/MediaDownloaderTest.cs
@@ -219,26 +219,26 @@ namespace Google.Apis.Tests.Apis.Download
 
         /// <summary>Tests that download works in case the server returns multiple chunks to the client.</summary>
         [Fact]
-        public void Download_MultipleChunks()
+        public async Task Download_MultipleChunks()
         {
-            Subtest_Download_Chunks(2);
-            Subtest_Download_Chunks(MediaContent.Length - 1);
+            await Subtest_Download_Chunks(2);
+            await Subtest_Download_Chunks(MediaContent.Length - 1);
         }
 
         /// <summary>Tests that download works in case the data is retrieved in multiple chunks and is gzipped.</summary>
         [Fact]
-        public void Download_MultipleChunksGzipped()
+        public async Task Download_MultipleChunksGzipped()
         {
-            Subtest_Download_Chunks(2, true, 0, "GzipContent");
+            await Subtest_Download_Chunks(2, true, 0, "GzipContent");
         }
 
         /// <summary>Tests that download works in case the server returns a single chunk to the client.</summary>
         [Fact]
-        public void Download_SingleChunk()
+        public async Task Download_SingleChunk()
         {
-            Subtest_Download_Chunks(MediaContent.Length);
-            Subtest_Download_Chunks(MediaContent.Length + 1);
-            Subtest_Download_Chunks(100);
+            await Subtest_Download_Chunks(MediaContent.Length);
+            await Subtest_Download_Chunks(MediaContent.Length + 1);
+            await Subtest_Download_Chunks(100);
         }
 
         /// <summary>Tests that download works in case the URI download contains query parameters.</summary>
@@ -269,31 +269,31 @@ namespace Google.Apis.Tests.Apis.Download
         /// Tests that download asynchronously works in case the server returns multiple chunks to the client.
         /// </summary>
         [Fact]
-        public void DownloadAsync_MultipleChunks()
+        public async Task DownloadAsync_MultipleChunks()
         {
-            Subtest_Download_Chunks(2, false);
-            Subtest_Download_Chunks(MediaContent.Length - 1, false);
+            await Subtest_Download_Chunks(2, false);
+            await Subtest_Download_Chunks(MediaContent.Length - 1, false);
         }
 
         /// <summary>
         /// Tests that download asynchronously works in case the server returns a single chunk to the client.
         /// </summary>
         [Fact]
-        public void DownloadAsync_SingleChunk()
+        public async Task DownloadAsync_SingleChunk()
         {
-            Subtest_Download_Chunks(MediaContent.Length, false);
-            Subtest_Download_Chunks(MediaContent.Length + 1, false);
-            Subtest_Download_Chunks(100, false);
+            await Subtest_Download_Chunks(MediaContent.Length, false);
+            await Subtest_Download_Chunks(MediaContent.Length + 1, false);
+            await Subtest_Download_Chunks(100, false);
         }
 
         /// <summary>
         /// Tests that download asynchronously doesn't succeeded in case a download was cancelled "in the middle".
         /// </summary>
         [Fact]
-        public void DownloadAsync_Cancel()
+        public async Task DownloadAsync_Cancel()
         {
-            Subtest_Download_Chunks(2, false, 3);
-            Subtest_Download_Chunks(MediaContent.Length - 1, false, 1);
+            await Subtest_Download_Chunks(2, false, 3);
+            await Subtest_Download_Chunks(MediaContent.Length - 1, false, 1);
         }
 
         [Fact]
@@ -346,7 +346,7 @@ namespace Google.Apis.Tests.Apis.Download
         /// <param name="sync">Indicates if this download should be synchronously or asynchronously.</param>
         /// <param name="cancelChunk">Defines the chunk at which to cancel the download request.</param>
         /// <param name="target">Last component of the Uri to download</param>
-        private void Subtest_Download_Chunks(int chunkSize, bool sync = true, int cancelChunk = 0, string target = "content")
+        private async Task Subtest_Download_Chunks(int chunkSize, bool sync = true, int cancelChunk = 0, string target = "content")
         {
             string downloadUri = _httpPrefix + target;
             var cts = new CancellationTokenSource();
@@ -383,7 +383,7 @@ namespace Google.Apis.Tests.Apis.Download
                 {
                     try
                     {
-                        var result = downloader.DownloadAsync(downloadUri, outputStream, cts.Token).Result;
+                        var result = await downloader.DownloadAsync(downloadUri, outputStream, cts.Token);
                         if (result.Exception == null)
                         {
                             Assert.Equal(0, cancelChunk);
@@ -393,9 +393,9 @@ namespace Google.Apis.Tests.Apis.Download
                             Assert.IsType<OperationCanceledException>(result.Exception);
                         }
                     }
-                    catch (AggregateException ex)
+                    catch (TaskCanceledException)
                     {
-                        Assert.IsType<TaskCanceledException>(ex.InnerException);
+                        // Expected in some cases.
                     }
                 }
 
@@ -440,9 +440,7 @@ namespace Google.Apis.Tests.Apis.Download
                 downloader.Download(_httpPrefix + "NoContent", outputStream);
 
                 // We expect only one event -- "completed".
-                Assert.Equal(1, progressList.Count);
-
-                var progress = progressList[0];
+                var progress = Assert.Single(progressList);
 
                 Assert.Equal(DownloadStatus.Completed, progress.Status);
                 Assert.Equal(0, progress.BytesDownloaded);

--- a/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Http/ConfigurableMessageHandlerTest.cs
@@ -706,11 +706,11 @@ namespace Google.Apis.Tests.Apis.Http
         [Fact]
         public async Task SendAsync_BackOffUnsuccessfulResponseHandler_Cancel()
         {
-            // test back-off with maximum 30 minutes per single request
+            // Test back-off with maximum 30 minutes per single request
             var initializer = new BackOffHandler.Initializer(new ExponentialBackOff(TimeSpan.Zero))
-                {
-                    MaxTimeSpan = TimeSpan.FromMinutes(30)
-                };
+            {
+                MaxTimeSpan = TimeSpan.FromMinutes(30)
+            };
             await SubtestSendAsync_BackOffUnsuccessfulResponseHandler(HttpStatusCode.ServiceUnavailable, initializer, 2);
             await SubtestSendAsync_BackOffUnsuccessfulResponseHandler(HttpStatusCode.ServiceUnavailable, initializer, 6);
         }
@@ -765,7 +765,7 @@ namespace Google.Apis.Tests.Apis.Http
                     HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
                     Assert.False(cancel);
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
                     // A canceled request should throw an exception
                     Assert.True(cancel);

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/ClientServiceRequestTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/ClientServiceRequestTest.cs
@@ -380,7 +380,7 @@ namespace Google.Apis.Tests.Apis.Requests
             {
                 request = new TestClientServiceRequest(service, "POST", new MockRequest());
                 var exception = await Assert.ThrowsAnyAsync<Exception>(() => request.ExecuteAsync(handler.CancellationTokenSource.Token));
-                if (exception is TaskCanceledException)
+                if (exception is OperationCanceledException)
                 {
                     // We expect a task canceled exception in case the canceled request is less or equal total
                     // number of retries.

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/PageStreamerTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/PageStreamerTest.cs
@@ -83,17 +83,7 @@ namespace Google.Apis.Tests.Apis.Requests
             // Delay the resource fetching until we've cancelled the token
             cts.Cancel();
             gatekeeperSource.SetResult(0);
-            // TODO: Move to Assert.ThrowsAsync when we update to an appropriate version of NUnit.
-            // Assert.That is available, but the documentation is unclear how this interacts with await.
-            try
-            {
-                await task;
-                Assert.True(false, "Expected exception");
-            }
-            catch (OperationCanceledException)
-            {
-                // Expected
-            }
+            await Assert.ThrowsAsync< OperationCanceledException>(() => task);
         }
 
         // Has to be public so we can use it as a parameter for test cases

--- a/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.MultiChunk.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.MultiChunk.cs
@@ -437,7 +437,7 @@ namespace Google.Apis.Tests.Apis.Upload
                 var uploader = new TestResumableUpload(service, "MultiChunk", "POST", content, "text/plain", chunkSize);
                 if (cancelOnCall == 1)
                 {
-                    var progress = uploader.UploadAsync(server.CancellationToken).Result;
+                    var progress = await uploader.UploadAsync(server.CancellationToken);
                     Assert.Equal(UploadStatus.Failed, progress.Status);
                     Assert.IsAssignableFrom<OperationCanceledException>(progress.Exception);
                 }

--- a/Src/Support/Google.Apis.Tests/Apis/Utils/ExponentialBackOffTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Utils/ExponentialBackOffTest.cs
@@ -25,48 +25,26 @@ namespace Google.Apis.Tests.Apis.Utils
     public class ExponentialBackOffTest
     {
         /// <summary>Tests setting invalid value as <c>currentRetry</c> parameter.</summary>
-        [Fact]
-        public void GetNextBackOff_InvalidValue()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-2)]
+        public void GetNextBackOff_InvalidValue(int value)
         {
             ExponentialBackOff backOff = new ExponentialBackOff();
-            try
-            {
-                backOff.GetNextBackOff(0);
-                Assert.True(false, "Exception expected");
-            }
-            catch (ArgumentOutOfRangeException) { }
-
-            try
-            {
-                backOff.GetNextBackOff(-2);
-                Assert.True(false, "Exception expected");
-            }
-            catch (ArgumentOutOfRangeException) { }
+            Assert.Throws<ArgumentOutOfRangeException>(() => backOff.GetNextBackOff(value));
         }
 
         /// <summary>Tests constructor with invalid time span object (less then 0 or greater than 1sec).</summary>
-        [Fact]
-        public void Constructor_InvalidValue()
+        [Theory]
+        [InlineData(-1, 10)]
+        [InlineData(-1 * TimeSpan.TicksPerDay / TimeSpan.TicksPerMillisecond, 10)]
+        [InlineData(1001, 10)]
+        [InlineData(500, -1)]
+        [InlineData(500, 21)]
+        public void Constructor_InvalidValue(int milliseconds, int max)
         {
-            // Invalid delta.
-            SubtestConstructor_InvalidValue(TimeSpan.FromMilliseconds(-1));
-            SubtestConstructor_InvalidValue(TimeSpan.FromDays(-1));
-            SubtestConstructor_InvalidValue(TimeSpan.FromMilliseconds(1001));
-            // Invalid max.
-            SubtestConstructor_InvalidValue(TimeSpan.FromMilliseconds(500), -1);
-            SubtestConstructor_InvalidValue(TimeSpan.FromMilliseconds(500), 21);
-
-        }
-
-        /// <summary>A helper subtest to test invalid value given to the constructor.</summary>
-        private void SubtestConstructor_InvalidValue(TimeSpan ts, int max = 10)
-        {
-            try
-            {
-                ExponentialBackOff backOff = new ExponentialBackOff(ts, max);
-                Assert.True(false, "Exception expected");
-            }
-            catch (ArgumentOutOfRangeException) { }
+            var deltaBackoff = TimeSpan.FromMilliseconds(milliseconds);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ExponentialBackOff(deltaBackoff, max));
         }
 
         /// <summary>Tests next back-off time span maximum, minimum and average values for tries 1 to 15.</summary>

--- a/Src/Support/Google.Apis.Tests/Mocks/MockMessageHandler.cs
+++ b/Src/Support/Google.Apis.Tests/Mocks/MockMessageHandler.cs
@@ -28,6 +28,8 @@ namespace Google.Apis.Tests.Mocks
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            // TODO: Investigate making this async. The fact that this returns a null *task*
+            // at the moment (not a task with a null result) is alarming.
             RequestContent = request.Content.ReadAsStringAsync().Result;
             return null;
         }

--- a/Src/Support/IntegrationTests/GoogleJsonWebSignatureTests.cs
+++ b/Src/Support/IntegrationTests/GoogleJsonWebSignatureTests.cs
@@ -66,7 +66,7 @@ namespace IntegrationTests
             var content = new ByteArrayContent(contentBytes);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/x-www-form-urlencoded");
             var httpClient = new HttpClient();
-            var res = httpClient.PostAsync(codeReq, content).Result;
+            var res = await httpClient.PostAsync(codeReq, content);
             var json = JToken.Parse(Encoding.UTF8.GetString(await res.Content.ReadAsByteArrayAsync()));
             var jwt = (string)json["id_token"];
 

--- a/Src/Support/IntegrationTests/ServiceAccountTests.cs
+++ b/Src/Support/IntegrationTests/ServiceAccountTests.cs
@@ -34,7 +34,7 @@ namespace IntegrationTests
     public class ServiceAccountTests
     {
         [Fact]
-        public void ServiceCredential()
+        public async Task ServiceCredential()
         {
             // This is testing that a service-credential successfully authenticates to a Cloud Service.
             // If authentication fails, an exception will be thrown, failing the test.
@@ -48,7 +48,7 @@ namespace IntegrationTests
             });
 
             // Check an access token is available.
-            var ok = credential.UnderlyingCredential.GetAccessTokenForRequestAsync().Result;
+            var ok = await credential.UnderlyingCredential.GetAccessTokenForRequestAsync();
             Assert.NotNull(ok);
 
             // Following line will throw if authentication fails.

--- a/Src/Support/IntegrationTests/StorageApiTests.cs
+++ b/Src/Support/IntegrationTests/StorageApiTests.cs
@@ -48,8 +48,7 @@ namespace IntegrationTests
             var req = client.Buckets.List(Helper.GetProjectId()).Configure(req => req.PrettyPrint = true);
                 
             var resp = req.Execute();
-            Assert.Equal(1, memLog.LogEntries.Count);
-            var entry = memLog.LogEntries[0];
+            var entry = Assert.Single(memLog.LogEntries);
             // The JSON is pretty-printed, so contains many space characters
             Assert.Contains("  ", entry.Split(new[] { "Body: " }, StringSplitOptions.None)[1]);
 


### PR DESCRIPTION
These were mostly prompted by new xUnit warnings, but then looking at the number of calls to Task.Result and typos in the name "configuredHandler" prompted the rest of the changes.

There's plenty we could still do to improve the tests, but this is at least a significant improvement.