### PR TITLE
chore: Update support packages to use PackageLicenseExpression

### DIFF
--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -7,7 +7,7 @@
     <Copyright>Copyright 2021 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>
     <PackageProjectUrl>https://github.com/googleapis/google-api-dotnet-client</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/googleapis/google-api-dotnet-client</RepositoryUrl>
     <PackageIconUrl>https://www.gstatic.com/images/branding/product/1x/google_developers_64dp.png</PackageIconUrl>


### PR DESCRIPTION
This was done for generated libraries a while ago. The LICENSE file is still present in the package, but PackageLicenseExpression enables simpler automation.

Additional fix for #2359.