### PR TITLE
chore: Remove Moq

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.5.25" />
-    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />


### PR DESCRIPTION
We only used it in a couple of Auth tests, and given our fairly old set of test targets (which are fiddly to change), it's simplest just to create fakes for those tests.