### PR TITLE
ci: Allow skipdownload to only generate changes

### DIFF
--- a/BuildGenerated.sh
+++ b/BuildGenerated.sh
@@ -30,7 +30,6 @@ while [[ $# -gt 0 ]]; do
   case $key in
     --skipdownload)
       SKIPDOWNLOAD=TRUE
-      GENERATE_CHANGES_ONLY=FALSE
       ;;
     --skiprevert)
       SKIPREVERT=TRUE


### PR DESCRIPTION
This effectively rollbacks https://github.com/googleapis/google-api-dotnet-client/pull/2496/commits/6611c9691157e4aea277e514623f4bb0f99f3a37 to allow for the use case where:

- We first download.
- We revert changes that are not relevant for generation, like revision only changes.
- We generate what remains.

For instance, the latest release took a long time because it generated and attempted to push everything. No harm done as Nuget won't allow pushing the same package twice, but it is still clearer (for diagnosing failed releases and for quota purposes) to only generate and push what has changed.