### PR TITLE
chore: Convert DateTimeOffset to string with the invariant culture

### DIFF
--- a/Src/Support/Google.Apis.Core/Util/Utilities.cs
+++ b/Src/Support/Google.Apis.Core/Util/Utilities.cs
@@ -231,7 +231,7 @@ namespace Google.Apis.Util
             ? null
             // While FFF sounds like it should work, we really want to produce no subsecond parts or 3 digits.
             : date.Value.Millisecond == 0 ? date.Value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'")
-            : date.Value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'");
+            : date.Value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
 
         /// <summary>
         /// Deserializes the given raw value to an object using <see cref="NewtonsoftJsonSerializer.Instance"/>,

--- a/Src/Support/Google.Apis.Tests/Apis/Utils/UtilitiesTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Utils/UtilitiesTest.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using Google.Apis.Util;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Globalization;
 using System.Threading;
@@ -123,6 +124,24 @@ namespace Google.Apis.Tests.Apis.Util
         {
             var value = new DateTimeOffset(2023, 6, 13, 15, 54, 13, TimeSpan.Zero).AddTicks(tickOfSecond);
             Assert.Equal(expectedResult, Utilities.GetStringFromDateTimeOffset(value));
+        }
+
+        [Fact]
+        public void DateTimeOffsetConversionsAreInvariant()
+        {
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("da-DK");
+                var dto = new DateTimeOffset(2023, 6, 13, 15, 54, 13, 500, TimeSpan.Zero);
+                string text = "2023-06-13T15:54:13.500Z";
+                Assert.Equal(text, Utilities.GetStringFromDateTimeOffset(dto));
+                Assert.Equal(dto, Utilities.GetDateTimeOffsetFromString(text));
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
 
         // Local time of 2023-06-13T15:54:13, with variable UTC offset.


### PR DESCRIPTION
Fixes #911

We should release this as a new patch of the support library, and release all libraries to depend on it - but only after September 1st.