### PR TITLE
chore: Upgrade docfx to 2.71.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.65.3",
+      "version": "2.71.0",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
I've run full doc generation, and it appears to be okay.