### PR TITLE
feat: Check BIOS for determining GCE residency.

### DIFF
--- a/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
+++ b/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
@@ -40,6 +40,7 @@ Supported Platforms:
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="System.Management" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net45'">
@@ -48,6 +49,7 @@ Supported Platforms:
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.Management" Version="7.0.2" />
   </ItemGroup>
 
   <!-- build and include the (empty) platformservices dll in package; required for binary backward compatibility -->


### PR DESCRIPTION
Closes #2475 

@jskeet a few comments on this one:

- The first commit is the implementation for Linux which is more or less straightforward.
- The second commit is the implementation for Windows, checking against Windows Management Instrumentation and not the Registry. Checking against WMI is what's recommend internally.

I'm happy to rewrite the second commit using reflection so we don't need the extra System.Management dependency, but then we'd have to ask users to include the dll themselves as we cannot add it conditionally on OS, or at least I haven't found how to do that.