### PR TITLE
chore: Suppress warning for System.CodeDom on older frameworks

### DIFF
--- a/Src/Support/Google.Apis.Auth.AspNetCore.IntegrationTests/Google.Apis.Auth.AspNetCore.IntegrationTests.csproj
+++ b/Src/Support/Google.Apis.Auth.AspNetCore.IntegrationTests/Google.Apis.Auth.AspNetCore.IntegrationTests.csproj
@@ -3,6 +3,12 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <CheckEolTargetFramework>False</CheckEolTargetFramework>
+
+    <!--
+      - The (indirect) System.Management dependency complains on older frameworks,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Google.Apis.Auth.AspNetCore3.IntegrationTests.csproj
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3.IntegrationTests/Google.Apis.Auth.AspNetCore3.IntegrationTests.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <!--
+      - The (indirect) System.Management dependency complains on older frameworks,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3/Google.Apis.Auth.AspNetCore3.csproj
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3/Google.Apis.Auth.AspNetCore3.csproj
@@ -5,6 +5,12 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <CheckEolTargetFramework>False</CheckEolTargetFramework>
+
+    <!--
+      - The (indirect) System.Management dependency complains on older frameworks,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <!-- nupkg information -->

--- a/Src/Support/Google.Apis.Auth.PlatformServices/Google.Apis.Auth.PlatformServices.csproj
+++ b/Src/Support/Google.Apis.Auth.PlatformServices/Google.Apis.Auth.PlatformServices.csproj
@@ -5,6 +5,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
+
+    <!--
+      - The (indirect) System.Management dependency complains on older frameworks,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -7,6 +7,12 @@
     <AssemblyOriginatorKeyFile>..\..\..\google.apis.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+
+    <!--
+      - The (indirect) System.Management dependency complains on older frameworks,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
+++ b/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
@@ -6,6 +6,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net45;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+    
+    <!--
+      - The System.Management dependency complains on .NET 4.6.1 and netstandard 2.0,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <!-- nupkg information -->

--- a/Src/Support/IntegrationTests/IntegrationTests.csproj
+++ b/Src/Support/IntegrationTests/IntegrationTests.csproj
@@ -7,6 +7,12 @@
     <AssemblyOriginatorKeyFile>..\..\..\google.apis.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+
+    <!--
+      - The (indirect) System.Management dependency complains on older frameworks,
+      - but we use it carefully.
+      -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is the sort of internal version of #2596 - but this only fixes the support build, not applications depending on the auth library.