### PR TITLE
chore: Update docfx to 2.71.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.71.0",
+      "version": "2.71.1",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
The bug that affects google-cloud-dotnet doesn't affect this repo, due to the configuration we're using.

(I'm not sure why I didn't create this PR at the time...)

docfx has moved on since this anyway, but it would be good to be consistent between this and google-cloud-dotnet.