### PR TITLE
fix: Default JSON serializer instance is not affected by custom global settings for default value handling.

### DIFF
--- a/Src/Support/Google.Apis.Core/Json/NewtonsoftJsonSerializer.cs
+++ b/Src/Support/Google.Apis.Core/Json/NewtonsoftJsonSerializer.cs
@@ -145,7 +145,8 @@ namespace Google.Apis.Json
             {
                 NullValueHandling = NullValueHandling.Ignore,
                 MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-                ContractResolver = new NewtonsoftJsonContractResolver()
+                ContractResolver = new NewtonsoftJsonContractResolver(),
+                DefaultValueHandling = DefaultValueHandling.Include,
             };
 
         /// <inheritdoc/>


### PR DESCRIPTION
Fixes #2609