### PR TITLE
chore: Update xunit to 2.6.2

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.MultiChunk.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Upload/ResumableUploadTest.MultiChunk.cs
@@ -382,17 +382,15 @@ namespace Google.Apis.Tests.Apis.Upload
         /// Resuming on program restart with a non-seekable stream is not supported.
         /// </summary>
         [Fact]
-        public void TestUploadWithUploaderRestart_UnknownSize()
+        public async Task TestUploadWithUploaderRestart_UnknownSize()
         {
             // Unknown stream size not supported, exception always thrown
-            using (var server = new MultiChunkServer(_server))
-            using (var service = new MockClientService(server.HttpPrefix))
-            {
-                var content = new UnknownSizeMemoryStream(UploadTestBytes);
-                var uploader = new TestResumableUpload(service, "whatever", "PUT", content, "", 100);
-                var url = new Uri("http://what.ever/");
-                Assert.ThrowsAsync<NotImplementedException>(() => uploader.ResumeAsync(url));
-            }
+            using var server = new MultiChunkServer(_server);
+            using var service = new MockClientService(server.HttpPrefix);
+            var content = new UnknownSizeMemoryStream(UploadTestBytes);
+            var uploader = new TestResumableUpload(service, "whatever", "PUT", content, "", 100);
+            var url = new Uri("http://what.ever/");
+            await Assert.ThrowsAsync<NotImplementedException>(() => uploader.ResumeAsync(url));
         }
 
         /// <summary>

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />

--- a/Src/Support/IntegrationTests/IntegrationTests.csproj
+++ b/Src/Support/IntegrationTests/IntegrationTests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
     <ProjectReference Include="..\Google.Apis.Tests\Google.Apis.Tests.csproj" />


### PR DESCRIPTION
This requires a fix to a test which wasn't awaiting the result of Assert.ThrowsAsync.