### PR TITLE
feat: Hide ILogger from Intellisense

### DIFF
--- a/Src/Support/Google.Apis.Core/Logging/ILogger.cs
+++ b/Src/Support/Google.Apis.Core/Logging/ILogger.cs
@@ -15,10 +15,12 @@ limitations under the License.
 */
 
 using System;
+using System.ComponentModel;
 
 namespace Google.Apis.Logging
 {
     /// <summary>Describes a logging interface which is used for outputting messages.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public interface ILogger
     {
         /// <summary>Gets an indication whether debug output is logged or not.</summary>


### PR DESCRIPTION
When writing "ILogger", most users almost certainly want to import Microsoft.Extensions.Logging.ILogger. Importing Google.Apis.Logging.ILogger is a cause of frustration.

In an ideal world, Intellisense would still show this type, but at a lower priority - or perhaps only if Microsoft.Extensions.Logging wasn't available. Unfortunately, that doesn't seem to be an option.

When this feature is released, we should update https://cloud.google.com/dotnet/docs/reference/help/troubleshooting#how-can-i-trace-requests-and-responses-in-rest-based-apis to mention that users should *expect* not to be prompted for this namespace.