### PR TITLE
chore: Skip generation of Integrations V1.

### DIFF
--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -58,6 +58,7 @@ rm -f DiscoveryJson/contentwarehouse_v1.json
 # b/299569133 method.request.type instead of method.request.$ref
 # type is not a supported field in method.request.
 rm -f DiscoveryJson/integrations_v1alpha.json
+rm -f DiscoveryJson/integrations_v1.json
 # b/299567447 method.request.type instead of method.request.$ref
 # type is not a supported field in method.request.
 rm -f DiscoveryJson/datalineage_v1.json


### PR DESCRIPTION
This is failing for the same reasons as Integration V1Alpha was failing before. It's alreayd beeing looked at internally.