### PR TITLE
build!: Remove unused dependency Microsoft.AspNetCore.Authorization

### DIFF
--- a/Src/Support/Google.Apis.Auth.AspNetCore3/Google.Apis.Auth.AspNetCore3.csproj
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3/Google.Apis.Auth.AspNetCore3.csproj
@@ -31,7 +31,6 @@ Supported Platforms:
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.0.3" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
 
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />


### PR DESCRIPTION
BREAKING CHANGE: Projects using that transitively depend on Microsoft.AspNetCore.Authorization may be broken. They only need to add an implicit dependency themselves. Although this is a breaking change, we will release it a new minor version oly as we find it would be more disruptive otherwise.