### PR TITLE
tests: Update BouncyCastle dependency.

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -20,11 +20,11 @@
     <ProjectReference Include="..\Google.Apis.Tests\Google.Apis.Tests.csproj" />
 
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Net.Http" />
-    <PackageReference Include="BouncyCastle" Version="1.8.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tests now pass in .NET 6 as well.
Closes b/342060412