### PR TITLE
chore: Update docfx to 2.76.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.71.1",
+      "version": "2.76.0",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
I've generated the support library documentation with this, and it looks fine.