### PR TITLE
chore: Downgrade docfx to 2.75.3 temporarily

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.76.0",
+      "version": "2.75.3",
       "commands": [
         "docfx"
       ]


### PR DESCRIPTION
Generation works locally, but is failing in Kokoro.

See b/342517197