### PR TITLE
chore: Fix SourceLink in the build

### DIFF
--- a/BuildGenerated.sh
+++ b/BuildGenerated.sh
@@ -45,6 +45,7 @@ dotnet new sln --name Generated
 echo $PROJECTS | xargs dotnet sln Generated.sln add
 
 echo "Building/packing"
+export CI=true
 dotnet pack Generated.sln -c Release -o $NUPKG_DIR
 
 echo "Build complete"


### PR DESCRIPTION
Note: we still don't get a deterministic build, but this is a step in the right direction.