### PR TITLE
fix: Do not generate libraries from original discoveries that have been patched.

### DIFF
--- a/DiscoveryJson/admin_directory_v1.json
+++ b/DiscoveryJson/admin_directory_v1.json
@@ -3967,12 +3967,12 @@
               "type": "string"
             },
             "customer": {
-              "description": "The unique ID for the customer's Google Workspace account. In case of a multi-domain account, to fetch all users for a customer, use this field instead of `domain`. You can also use the `my_customer` alias to represent your account's `customerId`. The `customerId` is also returned as part of the [Users](/admin-sdk/directory/v1/reference/users) resource. You must provide either the `customer` or the `domain` parameter.",
+              "description": "The unique ID for the customer's Google Workspace account. In case of a multi-domain account, to fetch all groups for a customer, use this field instead of `domain`. You can also use the `my_customer` alias to represent your account's `customerId`. The `customerId` is also returned as part of the [Users](/admin-sdk/directory/v1/reference/users) resource. You must provide either the `customer` or the `domain` parameter.",
               "location": "query",
               "type": "string"
             },
             "domain": {
-              "description": "The domain name. Use this field to get users from only one domain. To return all domains for a customer account, use the `customer` query parameter instead. Either the `customer` or the `domain` parameter must be provided.",
+              "description": "The domain name. Use this field to get groups from only one domain. To return all domains for a customer account, use the `customer` query parameter instead. Either the `customer` or the `domain` parameter must be provided.",
               "location": "query",
               "type": "string"
             },
@@ -4671,7 +4671,7 @@
       }
     }
   },
-  "revision": "20240611",
+  "revision": "20240603",
   "rootUrl": "https://admin.googleapis.com/",
   "schemas": {
     "Alias": {

--- a/DiscoveryJson/admin_directory_v1.json.original
+++ b/DiscoveryJson/admin_directory_v1.json.original
@@ -3967,12 +3967,12 @@
        "type": "string"
       },
       "customer": {
-       "description": "The unique ID for the customer's Google Workspace account. In case of a multi-domain account, to fetch all users for a customer, use this field instead of `domain`. You can also use the `my_customer` alias to represent your account's `customerId`. The `customerId` is also returned as part of the [Users](/admin-sdk/directory/v1/reference/users) resource. You must provide either the `customer` or the `domain` parameter.",
+       "description": "The unique ID for the customer's Google Workspace account. In case of a multi-domain account, to fetch all groups for a customer, use this field instead of `domain`. You can also use the `my_customer` alias to represent your account's `customerId`. The `customerId` is also returned as part of the [Users](/admin-sdk/directory/v1/reference/users) resource. You must provide either the `customer` or the `domain` parameter.",
        "location": "query",
        "type": "string"
       },
       "domain": {
-       "description": "The domain name. Use this field to get users from only one domain. To return all domains for a customer account, use the `customer` query parameter instead. Either the `customer` or the `domain` parameter must be provided.",
+       "description": "The domain name. Use this field to get groups from only one domain. To return all domains for a customer account, use the `customer` query parameter instead. Either the `customer` or the `domain` parameter must be provided.",
        "location": "query",
        "type": "string"
       },
@@ -4671,7 +4671,7 @@
    }
   }
  },
- "revision": "20240611",
+ "revision": "20240603",
  "rootUrl": "https://admin.googleapis.com/",
  "schemas": {
   "Alias": {

--- a/Src/Tools/DiscoveryDocUpdater/Program.cs
+++ b/Src/Tools/DiscoveryDocUpdater/Program.cs
@@ -54,7 +54,7 @@ foreach (string relativeDownloadedFile in downloadDirectoryFiles)
     {
         Console.WriteLine(service + ": New.");
         File.Copy(downloadedFile, targetFile);
-        newOrUpdated.Add(targetFile);
+        MaybeAddNewOrUpdated(targetFile);
         continue;
     }
 
@@ -83,7 +83,7 @@ foreach (string relativeDownloadedFile in downloadDirectoryFiles)
     
     Console.WriteLine(service + ": Updated.");
     File.Copy(downloadedFile, targetFile, true);
-    newOrUpdated.Add(targetFile);
+    MaybeAddNewOrUpdated(targetFile);
 }
 
 // Finally, delete any obsolete Discovery docs.
@@ -101,6 +101,19 @@ if (newOrUpdatedFile is not null)
 }
 
 return 0;
+
+void MaybeAddNewOrUpdated(string targetFile)
+{
+    // We patch some discovery docs, but we keep the original discovery doc with the .original extension.
+    // We want the original file to be copied to the target folder, but we don't want to include it on the
+    // list of new or updated discoveries as that will mean we will generate the library twice, both from the original
+    // unpatched discovery and the patched discovery. We'll keep the library for whatever file we found last.
+    // Note the patched discovery is indeed included.
+    if (Path.GetExtension(targetFile) != "original")
+    {
+        newOrUpdated.Add(targetFile);
+    }
+}
 
 // Simple utility method to compare two JObjects for equality;
 // we already sort Discovery docs, so just converting both to a string should be fine.

--- a/Src/Tools/Tools.sln
+++ b/Src/Tools/Tools.sln
@@ -9,9 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiscoveryDocDownloader", "D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CloudPackageMapGenerator", "CloudPackageMapGenerator\CloudPackageMapGenerator.csproj", "{3F62B2BF-BF29-4780-A5C2-D42979D89CE7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildGeneratedArgumentTranslator", "..\..\..\..\..\Users\jonskeet\GitHub\googleapis\google-api-dotnet-client\Src\Tools\BuildGeneratedArgumentTranslator\BuildGeneratedArgumentTranslator.csproj", "{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildGeneratedArgumentTranslator", "BuildGeneratedArgumentTranslator\BuildGeneratedArgumentTranslator.csproj", "{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiscoveryDocUpdater", "..\..\..\..\..\Users\jonskeet\GitHub\googleapis\google-api-dotnet-client\Src\Tools\DiscoveryDocUpdater\DiscoveryDocUpdater.csproj", "{C134AB8E-788C-4D54-8514-32AB1535E0AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiscoveryDocUpdater", "DiscoveryDocUpdater\DiscoveryDocUpdater.csproj", "{4E0AE5D1-56DA-483D-989F-55750D2585ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,30 +59,30 @@ Global
 		{3F62B2BF-BF29-4780-A5C2-D42979D89CE7}.Release|x64.Build.0 = Release|Any CPU
 		{3F62B2BF-BF29-4780-A5C2-D42979D89CE7}.Release|x86.ActiveCfg = Release|Any CPU
 		{3F62B2BF-BF29-4780-A5C2-D42979D89CE7}.Release|x86.Build.0 = Release|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Debug|x64.Build.0 = Debug|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Debug|x86.Build.0 = Debug|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Release|x64.ActiveCfg = Release|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Release|x64.Build.0 = Release|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Release|x86.ActiveCfg = Release|Any CPU
-		{9A28282A-2F2F-4F2E-9A4F-DFCBE1746202}.Release|x86.Build.0 = Release|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Debug|x64.Build.0 = Debug|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Debug|x86.Build.0 = Debug|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Release|x64.ActiveCfg = Release|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Release|x64.Build.0 = Release|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Release|x86.ActiveCfg = Release|Any CPU
-		{C134AB8E-788C-4D54-8514-32AB1535E0AC}.Release|x86.Build.0 = Release|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Debug|x64.Build.0 = Debug|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Debug|x86.Build.0 = Debug|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Release|x64.ActiveCfg = Release|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Release|x64.Build.0 = Release|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Release|x86.ActiveCfg = Release|Any CPU
+		{50E0FDFE-9544-4DB5-82E5-2A61DA550E55}.Release|x86.Build.0 = Release|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x64.Build.0 = Release|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We only generate from the patched discoveries.

Fixes #2769 .