### PR TITLE
feat: Improve SourceLink for NuGet packages

### DIFF
--- a/BuildGenerated.sh
+++ b/BuildGenerated.sh
@@ -46,6 +46,7 @@ echo $PROJECTS | xargs dotnet sln Generated.sln add
 
 echo "Building/packing"
 export CI=true
+export DeterministicSourcePaths=true
 dotnet pack Generated.sln -c Release -o $NUPKG_DIR
 
 echo "Build complete"

--- a/BuildSupport.sh
+++ b/BuildSupport.sh
@@ -4,6 +4,7 @@ set -e
 
 # Forces sourcelink to work during the build.
 export CI=true
+export DeterministicSourcePaths=true
 
 dotnet build Src/Support/GoogleApisClient.sln -c Release
 dotnet pack Src/Support/GoogleApisClient.sln -c Release -o NuPkgs/Support

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- Package properties -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+</Project>

--- a/Src/Directory.Build.targets
+++ b/Src/Directory.Build.targets
@@ -1,0 +1,15 @@
+<Project>
+  <!-- See https://github.com/dotnet/sourcelink/issues/572 -->
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
+  
+  <!-- Common references and items that are fine to include in all projects -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/Src/Support/Google.Apis.Auth.AspNetCore3/Google.Apis.Auth.AspNetCore3.csproj
+++ b/Src/Support/Google.Apis.Auth.AspNetCore3/Google.Apis.Auth.AspNetCore3.csproj
@@ -32,8 +32,6 @@ Supported Platforms:
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.0.3" />
     <ProjectReference Include="..\Google.Apis.Auth\Google.Apis.Auth.csproj" />
-
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
+++ b/Src/Support/Google.Apis.Auth.Tests/Google.Apis.Auth.Tests.csproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
     <ProjectReference Include="..\Google.Apis.Tests\Google.Apis.Tests.csproj" />
 
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
   </ItemGroup>
 

--- a/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
+++ b/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
@@ -24,8 +24,6 @@ This package includes auth components like user-credential, authorization code f
     <ProjectReference Include="..\Google.Apis\Google.Apis.csproj" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
+++ b/Src/Support/Google.Apis.Core/Google.Apis.Core.csproj
@@ -21,11 +21,6 @@ The Google APIs Core Library contains the Google APIs HTTP layer, JSON support, 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
-
-    <!-- Does not affect the output packages, and makes testing sourcelink simple -->
-    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/Src/Support/Google.Apis.IntegrationTests/Google.Apis.IntegrationTests.csproj
+++ b/Src/Support/Google.Apis.IntegrationTests/Google.Apis.IntegrationTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
+++ b/Src/Support/Google.Apis.Tests/Google.Apis.Tests.csproj
@@ -17,8 +17,6 @@
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
     <Compile Include="..\..\Generated\Google.Apis.Translate.v2\Google.Apis.Translate.v2.cs" Link="Apis\Services\Google.Apis.Translate.v2.cs" />
     <Compile Include="..\..\Generated\/Google.Apis.ManufacturerCenter.v1\Google.Apis.ManufacturerCenter.v1.cs" Link="Apis\Services\Google.Apis.ManufacturerCenter.v1.cs" />
-
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/Src/Support/Google.Apis/Google.Apis.csproj
+++ b/Src/Support/Google.Apis/Google.Apis.csproj
@@ -22,8 +22,6 @@ The library supports service requests, media upload and download, etc.
     <ProjectReference Include="..\Google.Apis.Core\Google.Apis.Core.csproj" />
 
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">


### PR DESCRIPTION
- Use deterministic builds
- Use a newer version of SourceLink (and centralize it)
- Fix issues with unexpected output files
- Use a newer version of refernece assemblies (and centralize it)

This will generate warnings for Src/Generated projects until we adopt a new version of the generator which doesn't include the reference assemblies and SourceLink package directly.