### PR TITLE
tools: Finish the build immediately if we don't have anything to build

### DIFF
--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -40,6 +40,12 @@ then
   ls DiscoveryJson/*.json > tmp/ApisToGenerate.txt
 fi
 
+if [[ ! -s tmp/ApisToGenerate.txt ]]
+then
+  echo "No APIs to generate; exiting build"
+  exit 0
+fi
+
 # Generate all APIs listed in tmp/ApisToGenerate.txt
 ./GenerateApis.sh @tmp/ApisToGenerate.txt
 


### PR DESCRIPTION
Arguably with this in place we don't *need* the previous changes to GenerateApis.sh and BuildGenerated.sh, but they're probably still worth having. This is an earlier "out" though, and avoids worrying about git etc. (If there's nothing to generate, there are no changes to push.)