### PR TITLE
tools: Separate generation from release

### DIFF
--- a/.kokoro/autogenerate.bat
+++ b/.kokoro/autogenerate.bat
@@ -1,0 +1,2 @@
+cd /d %~dp0
+"C:\Program Files\Git\bin\bash.exe" autogenerate.sh

--- a/.kokoro/autogenerate.sh
+++ b/.kokoro/autogenerate.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script:
+# - Updates Discovery docs
+# - Runs the generator on new/changed APIs
+# - Builds any generated APIs
+# - Creates a PR with changes
+#
+# It does not release any NuGet packages; that's handled by autorelease.sh
+# (The reason for the split is so that we only ever release
+# code that's already in GitHub - which means SourceLink should be accurate.)
+
+set -ex
+
+# Make sure secrets are loaded in a well known location before running the release
+source ./populatesecrets.sh
+populate_all_secrets
+# Restore tools, in particular the SBOM generator.
+mkdir -p ../NuPkgs/Support
+dotnet tool restore
+
+declare -r github_user="$(cat "$SECRETS_LOCATION"/google-api-dotnet-client-github-user-name)"
+declare -r github_email="$(cat "$SECRETS_LOCATION"/google-api-dotnet-client-github-user-email)"
+declare -r github_token="$(cat "$SECRETS_LOCATION"/google-api-dotnet-client-github-token)"
+
+now="$(date +%Y-%m-%d.%H-%M-%S)"
+branchname="release-$now"
+cd ..
+
+# Create a new branch to push the changes to.
+git branch --no-track $branchname
+git checkout $branchname
+# So that chmod changes are ignored.
+git config core.fileMode false
+# Even though we use the token to authenticate, we need the email for the CLA.
+git config user.name "$github_user"
+git config user.email "$github_email"
+
+# Fetch all discovery docs into tmp/DiscoveryJson, copying new/updated ones
+# into DiscoveryJson. The tmp/ApisToGenerate.txt file lists the Discovery
+# docs that are updated.
+./UpdateDiscovery.sh tmp/ApisToGenerate.txt
+
+# If we actually want to generate everything, just list all the Discovery docs.
+if [ "$FORCE_ALL" == "true" ]
+then
+  # Note that this form of ls ends up with the file containing
+  # DiscoveryJson/xyz.json rather than just xyz.json.
+  ls DiscoveryJson/*.json > tmp/ApisToGenerate.txt
+fi
+
+if [[ ! -s tmp/ApisToGenerate.txt ]]
+then
+  echo "No APIs to generate; exiting build"
+  exit 0
+fi
+
+# Generate all APIs listed in tmp/ApisToGenerate.txt
+./GenerateApis.sh @tmp/ApisToGenerate.txt
+
+# Build and pack all APIs listed in tmp/ApisToGenerate.txt
+# (We don't actually need to pack here, but it's simplest to always do so.)
+./BuildGenerated.sh @tmp/ApisToGenerate.txt
+
+# Push changes to git, not to the main branch but to branchname
+git add -A
+git commit -m "Update discovery documents and generated code" -m "automatically_generated_update"
+# We change the origin URL so that we can push with SSH
+git remote set-url origin git@github.com:googleapis/google-api-dotnet-client.git
+git push --set-upstream origin $branchname
+
+# Create a PR for the changes in branchname.
+prRequestBody='{"title":"Release PR: '"$branchname"'", "body": "Changes in this PR will be published to Nuget on the next release cycle.", "head": "'"$branchname"'", "base": "main"}'
+curl -v -i -X POST https://api.github.com/repos/googleapis/google-api-dotnet-client/pulls -H 'Authorization: token '"$github_token" -H "Content-Type:application/json" -H "accept: */*" -d "$prRequestBody"
+
+# All done :)
+echo "Success - Discovery libraries generation completed."

--- a/.kokoro/autorelease.sh
+++ b/.kokoro/autorelease.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# This script:
+# - Checks which generated APIs do not have up-to-date NuGet packages yet
+# - Generates them
+# - Pushes the NuGet packages
+#
+# It does not update Discovery docs or run the generator;
+# that's handled by autogenerate.sh.
+# (The reason for the split is so that we only ever release
+# code that's already in GitHub - which means SourceLink should be accurate.)
+
 set -ex
 
 # Make sure secrets are loaded in a well known location before running the release
@@ -9,72 +19,35 @@ populate_all_secrets
 mkdir -p ../NuPkgs/Support
 dotnet tool restore
 
-declare -r github_user="$(cat "$SECRETS_LOCATION"/google-api-dotnet-client-github-user-name)"
-declare -r github_email="$(cat "$SECRETS_LOCATION"/google-api-dotnet-client-github-user-email)"
-declare -r github_token="$(cat "$SECRETS_LOCATION"/google-api-dotnet-client-github-token)"
 declare -r nuget_token="$(cat "$SECRETS_LOCATION"/google-apis-nuget-api-key)"
 
-now="$(date +%Y-%m-%d.%H-%M-%S)"
-branchname="release-$now"
 cd ..
 
-# Create a new branch to push the changes to.
-git branch --no-track $branchname
-git checkout $branchname
-# So that chmod changes are ignored.
-git config core.fileMode false
-# Even though we use the token to authenticate, we need the email for the CLA.
-git config user.name "$github_user"
-git config user.email "$github_email"
+rm -rf tmp
+mkdir tmp
+dotnet run --project=Src/Tools/PackageChecker -- Src/Generated > tmp/ApisToBuild.txt
 
-# Fetch all discovery docs into tmp/DiscoveryJson, copying new/updated ones
-# into DiscoveryJson. The tmp/ApisToGenerate.txt file lists the Discovery
-# docs that are updated.
-./UpdateDiscovery.sh tmp/ApisToGenerate.txt
-
-# If we actually want to generate everything, just list all the Discovery docs.
-if [ "$FORCE_ALL" == "true" ]
+if [[ ! -s tmp/ApisToBuild.txt ]]
 then
-  # Note that this form of ls ends up with the file containing
-  # DiscoveryJson/xyz.json rather than just xyz.json.
-  ls DiscoveryJson/*.json > tmp/ApisToGenerate.txt
-fi
-
-if [[ ! -s tmp/ApisToGenerate.txt ]]
-then
-  echo "No APIs to generate; exiting build"
+  echo "All APIs have already been released; exiting build"
   exit 0
 fi
 
-# Generate all APIs listed in tmp/ApisToGenerate.txt
-./GenerateApis.sh @tmp/ApisToGenerate.txt
 
-# Build and pack all APIs listed in tmp/ApisToGenerate.txt
-./BuildGenerated.sh @tmp/ApisToGenerate.txt
+# Build and pack all APIs listed in tmp/ApisToBuild.txt
+./BuildGenerated.sh @tmp/ApisToBuild.txt
 
 # Release all the NuGet packages we've created.
 for pkg in ./NuPkgs/Generated/*.nupkg; do
   if [[ $pkg != *.symbols.* ]]; then
     dotnet generate-sbom $pkg
-    # We take care to only generate packages that have changed, except when FORCE_ALL == true.
-    # Still we have encountered a couple of instances where line endings differences and similar
-    # have been detected as changes which results in an attempt to push an already published
-    # package. So to be safe, let's always return true here.
-    nuget push $pkg $nuget_token -Source nuget.org || true
+    # We take care not to generate packages which have already been
+    # released (via the PackageChecker tool) so if nuget push fails,
+    # it's reasonable to fail the build.
+    nuget push $pkg $nuget_token -Source nuget.org
     sleep 10
   fi
 done
-
-# Push changes to git, not to the main branch but to branchname
-git add -A
-git commit -m "Update discovery documents and generated code" -m "automatically_generated_update"
-# We change the origin URL so that we can push with SSH
-git remote set-url origin git@github.com:googleapis/google-api-dotnet-client.git
-git push --set-upstream origin $branchname
-
-# Create a PR for the changes in branchname.
-prRequestBody='{"title":"Release PR: '"$branchname"'", "body": "Changes in this PR have already been published to Nuget.", "head": "'"$branchname"'", "base": "main"}'
-curl -v -i -X POST https://api.github.com/repos/googleapis/google-api-dotnet-client/pulls -H 'Authorization: token '"$github_token" -H "Content-Type:application/json" -H "accept: */*" -d "$prRequestBody"
 
 # All done :)
 echo "Success - Discovery libraries release completed."

--- a/Src/Tools/BuildGeneratedArgumentTranslator/Program.cs
+++ b/Src/Tools/BuildGeneratedArgumentTranslator/Program.cs
@@ -33,7 +33,7 @@ if (args.Length == 0)
     Console.WriteLine("Arguments, one of two forms:");
     Console.WriteLine("  <generation-dir> <file-or-dir> [...]");
     Console.WriteLine("  <generation-dir> @file");
-    Console.WriteLine("where @file specifies a file one file/directory per line.");
+    Console.WriteLine("where @file specifies a file with one file/directory per line.");
     Console.WriteLine("Each file or directory should be either a project file/directory, or a Discovery file.");
     return 1;
 }

--- a/Src/Tools/PackageChecker/PackageChecker.csproj
+++ b/Src/Tools/PackageChecker/PackageChecker.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/Src/Tools/PackageChecker/Program.cs
+++ b/Src/Tools/PackageChecker/Program.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Checks for the presence of NuGet packages with the version number declared
+// in each project file beneath the given directory, reporting project files that
+// should be built and released.
+
+using System.Net;
+using System.Xml.Linq;
+
+if (args.Length != 1)
+{
+    Console.WriteLine("Argument: <parent-directory>");
+    Console.WriteLine("(All project files below this directory, recursively, will be checked.");
+    return 1;
+}
+
+bool errors = false;
+var client = new HttpClient();
+
+// Fetch everything in parallel.
+var packages = Directory.GetFiles(args[0], "*.csproj", SearchOption.AllDirectories).Select(Fetch).ToList();
+
+// We don't care what order we await the tasks in.
+foreach (var package in packages)
+{
+    var response = await package.ResponseTask;
+    switch (response.StatusCode)
+    {
+        case HttpStatusCode.OK:
+            // Ignore
+            break;
+        case HttpStatusCode.NotFound:
+            // We want to build/generate this
+            Console.WriteLine(package.ProjectFile.Replace("\\", "/"));
+            break;
+        default:
+            // Keep going to find all broken packages, but remember to fail eventually.
+            Console.Error.WriteLine($"Package {package.Id} check failed with status code {response.StatusCode}");
+            errors = true;
+            break;
+    }
+}
+
+return errors ? 1 : 0;
+
+Package Fetch(string projectFile)
+{
+    var doc = XDocument.Load(projectFile);
+    string id = Path.GetFileNameWithoutExtension(projectFile);
+    var version = doc.Root.Element("PropertyGroup").Element("Version").Value;
+
+    var url = new Uri($"https://globalcdn.nuget.org/packages/{id.ToLowerInvariant()}.{version}.nupkg");
+    var request = new HttpRequestMessage
+    {
+        RequestUri = url,
+        Method = HttpMethod.Head
+    };
+    var responseTask = client.SendAsync(request);
+    return new Package(projectFile, id, version, responseTask);
+}
+
+record Package (string ProjectFile, string Id, string Version, Task<HttpResponseMessage> ResponseTask);

--- a/Src/Tools/Tools.sln
+++ b/Src/Tools/Tools.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildGeneratedArgumentTrans
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiscoveryDocUpdater", "DiscoveryDocUpdater\DiscoveryDocUpdater.csproj", "{4E0AE5D1-56DA-483D-989F-55750D2585ED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageChecker", "PackageChecker\PackageChecker.csproj", "{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x64.Build.0 = Release|Any CPU
 		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x86.ActiveCfg = Release|Any CPU
 		{4E0AE5D1-56DA-483D-989F-55750D2585ED}.Release|x86.Build.0 = Release|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Debug|x64.Build.0 = Debug|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Debug|x86.Build.0 = Debug|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Release|x64.ActiveCfg = Release|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Release|x64.Build.0 = Release|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Release|x86.ActiveCfg = Release|Any CPU
+		{6BA67CEC-7B2F-4A1C-B457-2C804C299D9E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The autogenerate script is responsible for updating Discovery docs and source code (and checking the code builds) and pushing a PR to GitHub; the autorelease script finds packages which haven't been released and builds/releases them (without doing any generation etc).

Part of b/350910134 - but we need Kokoro config changes to be submitted at "about the same time"