### PR TITLE
chore: Update commit message on regeneration

### DIFF
--- a/.kokoro/autogenerate.sh
+++ b/.kokoro/autogenerate.sh
@@ -64,7 +64,7 @@ fi
 
 # Push changes to git, not to the main branch but to branchname
 git add -A
-git commit -m "Update discovery documents and generated code" -m "automatically_generated_update"
+git commit -m "feat: Update discovery documents and generated code" -m "automatically_generated_update"
 # We change the origin URL so that we can push with SSH
 git remote set-url origin git@github.com:googleapis/google-api-dotnet-client.git
 git push --set-upstream origin $branchname


### PR DESCRIPTION
This just adds a conventional commit type of "feat" (which is almost always going to be appropriate; we don't need to check really).