### PR TITLE
feat!: Improve error handling when signing with the IAM service

### DIFF
--- a/Src/Support/Google.Apis.Auth.Tests/OAuth2/ImpersonatedCredentialTests.cs
+++ b/Src/Support/Google.Apis.Auth.Tests/OAuth2/ImpersonatedCredentialTests.cs
@@ -206,8 +206,8 @@ namespace Google.Apis.Auth.Tests.OAuth2
         public async Task SignBlobAsync_Failure()
         {
             var credential = CreateImpersonatedCredentialWithErrorResponse();
-            var ex = await Assert.ThrowsAsync<HttpRequestException>(() => credential.SignBlobAsync(Encoding.ASCII.GetBytes("toSign")));
-            Assert.Equal("Response status code does not indicate success: 404 (Not Found).", ex.Message);
+            var ex = await Assert.ThrowsAsync<GoogleApiException>(() => credential.SignBlobAsync(Encoding.ASCII.GetBytes("toSign")));
+            Assert.Equal(HttpStatusCode.NotFound, ex.HttpStatusCode);
         }
 
         [Fact]

--- a/Src/Support/Google.Apis/Responses/HttpResponseMessageExtensions.cs
+++ b/Src/Support/Google.Apis/Responses/HttpResponseMessageExtensions.cs
@@ -20,7 +20,11 @@ using System.Threading.Tasks;
 
 namespace Google.Apis.Responses
 {
-    internal static class HttpResponseMessageExtensions
+    /// <summary>
+    /// Extensions for <see cref="HttpResponseMessage"/> to help with parasing errors as returned
+    /// by some Google services.
+    /// </summary>
+    public static class HttpResponseMessageExtensions
     {
         /// <summary>
         /// Attempts to deserialize a <see cref="RequestError"/> from the <paramref name="response"/>.
@@ -34,9 +38,9 @@ namespace Google.Apis.Responses
         /// </list>
         /// Any exception thrown while reading the <paramref name="response"/> <see cref="HttpResponseMessage.Content"/>
         /// will be bubbled up.
-        /// Otherwie this method will returned the deserialized <see cref="RequestError"/>.
+        /// Otherwise this method will return the deserialized <see cref="RequestError"/>.
         /// </remarks>
-        internal static async Task<RequestError> DeserializeErrorAsync(this HttpResponseMessage response, string name, ISerializer serializer)
+        public static async Task<RequestError> DeserializeErrorAsync(this HttpResponseMessage response, string name, ISerializer serializer)
         {
             if (response?.Content is null)
             {


### PR DESCRIPTION
BREAKING CHANGE: The ComputeCredential and ImpersonatedCredential SignBlobAsync methods will throw a GoogleApiException instead of a HttpRequestExtension. The GoogleApiException makes the HttpResponseMessage content available, which usually includes details about the error.