### PR TITLE
chore: Use a vanilla reference in net462 for System.Management

### DIFF
--- a/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
+++ b/Src/Support/Google.Apis.Auth/Google.Apis.Auth.csproj
@@ -32,7 +32,7 @@ This package includes auth components like user-credential, authorization code f
 
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Net.Http" />
-    <PackageReference Include="System.Management" Version="7.0.2" />
+    <Reference Include="System.Management" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">


### PR DESCRIPTION
The lib/net462 folder in System.Management version 7.0.2 is empty, so this *should* be equivalent.

Addresses #2820.