### PR TITLE
tools: Make autogenerate.sh fail noisily if we can't create a PR

### DIFF
--- a/.kokoro/autogenerate.sh
+++ b/.kokoro/autogenerate.sh
@@ -88,7 +88,13 @@ git push --set-upstream origin $branchname
 
 # Create a PR for the changes in branchname.
 prRequestBody='{"title":"feat: API regeneration: '"$branchname"'", "body": "Changes in this PR will be published to Nuget on the next release cycle.", "head": "'"$branchname"'", "base": "main"}'
-curl -v -i -X POST https://api.github.com/repos/googleapis/google-api-dotnet-client/pulls -H 'Authorization: token '"$github_token" -H "Content-Type:application/json" -H "accept: */*" -d "$prRequestBody"
+curl -v -i -X POST \
+  https://api.github.com/repos/googleapis/google-api-dotnet-client/pulls \
+  -H 'Authorization: token '"$github_token" \
+  -H "Content-Type:application/json" \
+  -H "accept: */*" \
+  -d "$prRequestBody" \
+  --fail-with-body
 
 # All done :)
 echo "Success - Discovery libraries generation completed."


### PR DESCRIPTION
After merging this, we can manually run the job to make sure we see the failure.