### PR TITLE
chore: Just use --fail instead of --fail-with-body

### DIFF
--- a/.kokoro/autogenerate.sh
+++ b/.kokoro/autogenerate.sh
@@ -94,7 +94,7 @@ curl -v -i -X POST \
   -H "Content-Type:application/json" \
   -H "accept: */*" \
   -d "$prRequestBody" \
-  --fail-with-body
+  --fail
 
 # All done :)
 echo "Success - Discovery libraries generation completed."


### PR DESCRIPTION
(The version of curl we currently use doesn't support fail-with-body)