### PR TITLE
Update version 1.68.0 -> 1.69.0

### DIFF
--- a/Src/Support/CommonProjectProperties.xml
+++ b/Src/Support/CommonProjectProperties.xml
@@ -2,7 +2,7 @@
 
   <!-- common nupkg information -->
   <PropertyGroup>
-    <Version>1.68.0</Version>
+    <Version>1.69.0</Version>
     <Authors>Google LLC</Authors>
     <Copyright>Copyright 2021 Google LLC</Copyright>
     <PackageTags>Google</PackageTags>

--- a/features.json
+++ b/features.json
@@ -2,10 +2,10 @@
   "language": "csharp",
   "description": "C# libraries for Google APIs.",
   // Version of the generated packages
-  "releaseVersion": "1.68.0",
+  "releaseVersion": "1.69.0",
   
   // Version of the support libraries upon which to depend.
-  "currentSupportVersion": "1.68.0",
+  "currentSupportVersion": "1.69.0",
 
   // Defines the map of Google.Cloud packages that supercede Google.Apis packages
   "cloudPackageMap": {


### PR DESCRIPTION
Fixes:

- #2869 Use universe-domain instead of universe_domain as the MDS endpoint
- #2870 BaseClientService.UniverDomain setter is obsolete
- #2871 Pause automatic requests to MDS Universe Domain endpoint

Features:

- #2746 Simplify setting the HttpClient timeout
- #2809 Improve error handling when signing with the IAM service

  BREAKING CHANGE: The ComputeCredential and ImpersonatedCredential SignBlobAsync methods will throw a GoogleApiException instead of a HttpRequestExtension. The GoogleApiException makes the HttpResponseMessage content available, which usually includes details about the error. We consider the risk of this change breaking users  lower than the risk of disrupting all users with a new major version so we've decided to release this breaking change on a minor version of the library. Please create an issue on this repo if you are affected and we will e happy to help.

- #2879 Use recommended retries for token and IAM sign blob endpoints
- #2913 Support GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variable

Dependencies:

- #2730 Remove unused dependency Microsoft.AspNetCore.Authorization from Google.Apis.Auth.AspNetCore3

  BREAKING CHANGE: Projects using Google.Apis.Auth.AspNetCore3 that transitively depend on Microsoft.AspNetCore.Authorization may be broken. They only need to add an implicit dependency themselves. We consider the risk of this change breaking users  lower than the risk of disrupting all users with a new major version so we've decided to release this breaking change on a minor version of the library. Please create an issue on this repo if you are affected and we will e happy to help.

Documentation:

- #2916 Add warning note about user provided credential configurations