### PR TITLE
build: Skip Compute alpha generation as it's failing

### DIFF
--- a/ExcludedServices.json
+++ b/ExcludedServices.json
@@ -38,4 +38,7 @@
   "identitytoolkit.v1",
   "identitytoolkit.v2",
   "identitytoolkit.v3",
+
+  // b/415809720 for investigating the failure
+  "compute.alpha",
 ]


### PR DESCRIPTION
We have b/415809720 for looking into the failure.