### PR TITLE
build: Skip regeneration of Compute beta.

### DIFF
--- a/ExcludedServices.json
+++ b/ExcludedServices.json
@@ -41,4 +41,5 @@
 
   // b/415809720 for investigating the failure
   "compute.alpha",
+  "compute.beta",
 ]


### PR DESCRIPTION
See b/415809720

It's the same failure for alpha and beta. I've tested locally and everything else generates and builds fine.