### PR TITLE
Make HttpClientFactory.CreateHttpClient virtual (#3036)

### DIFF
--- a/Src/Support/Google.Apis.Core/Http/HttpClientFactory.cs
+++ b/Src/Support/Google.Apis.Core/Http/HttpClientFactory.cs
@@ -53,7 +53,7 @@ namespace Google.Apis.Http
         public IWebProxy Proxy { get; }
 
         /// <inheritdoc/>
-        public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args)
+        public virtual ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args)
         {
             // Create the handler.
             var handler = CreateHandler(args);


### PR DESCRIPTION
Fixes #3036

This PR marks HttpClientFactory.CreateHttpClient as virtual to allow consumers to override client creation (e.g., setting Timeout, handlers, etc.).