### PR TITLE
fix: Validate path parameters against path traversal and parameter injection

### DIFF
--- a/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
+++ b/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2012 Google Inc
 
 Licensed under the Apache License, Version 2.0(the "License");
@@ -259,6 +259,32 @@ namespace Google.Apis.Requests
                     // Check if a path parameter equals the name which appears in the REST path.
                     if (PathParameters.ContainsKey(parameterName))
                     {
+                        var parameterValues = PathParameters[parameterName];
+                        foreach (var val in parameterValues)
+                        {
+                            if (val is null)
+                            {
+                                continue;
+                            }
+                            // Reject query (?) or fragment (#) injections in reserved expansions (+ or #).
+                            // Since reserved expansions bypass escaping (to preserve slashes), this check acts as the primary control to prevent parameter injection.
+                            if ((op == "+" || op == "#") && (val.Contains("?") || val.Contains("#")))
+                            {
+                                throw new ArgumentException($"Reserved path parameter '{parameterName}' contains invalid character '?' or '#': '{val}'");
+                            }
+                            // Split path parameter value by '/' and reject any standalone dot (.) or double-dot (..) segments
+                            // (either literal or URL-encoded) to prevent path traversal exploits.
+                            string[] segments = val.Split('/');
+                            foreach (var segment in segments)
+                            {
+                                string unescaped = Uri.UnescapeDataString(segment);
+                                if (unescaped == "." || unescaped == "..")
+                                {
+                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.' or '..': '{val}'");
+                                }
+                            }
+                        }
+
                         var value = string.Join(joiner, PathParameters[parameterName]);
 
                         // Check if we need to use a substring of the value.
@@ -267,6 +293,10 @@ namespace Google.Apis.Requests
                             value = value.Substring(0, numOfChars);
                         }
 
+                        // Do not escape the value if the operator is a reserved (+) or fragment (#) expansion.
+                        // The former is needed for path values (to preserve slashes), and the latter for OAuth2 callback and redirection URIs.
+                        // Since these operators bypass URL-escaping, any query (?) or fragment (#) characters in their values
+                        // must be explicitly rejected (handled in the validation loop above) to prevent parameter injection.
                         if (op != "+" && op != "#" && PathParameters[parameterName].Count == 1)
                         {
                             value = Uri.EscapeDataString(value);

--- a/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
+++ b/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
@@ -272,13 +272,12 @@ namespace Google.Apis.Requests
                             {
                                 throw new ArgumentException($"Reserved path parameter '{parameterName}' contains invalid character '?' or '#': '{val}'");
                             }
-                            // Split path parameter value by '/' and reject any standalone dot (.) or double-dot (..) segments
-                            // (either literal or URL-encoded) to prevent path traversal exploits.
-                            string[] segments = val.Split('/');
+                            // Unescape the entire value first and split by '/' to prevent bypasses using URL-encoded slashes (e.g. %2f).
+                            string unescapedVal = Uri.UnescapeDataString(val);
+                            string[] segments = unescapedVal.Split('/');
                             foreach (var segment in segments)
                             {
-                                string unescaped = Uri.UnescapeDataString(segment);
-                                if (unescaped == "." || unescaped == "..")
+                                if (segment == "." || segment == "..")
                                 {
                                     throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.' or '..': '{val}'");
                                 }

--- a/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
+++ b/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
@@ -283,11 +283,11 @@ namespace Google.Apis.Requests
 
                                 if (segmentLength == 1 && unescapedVal[valStart] == '.')
                                 {
-                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.' or '..': '{val}'");
+                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.': '{val}'");
                                 }
                                 if (segmentLength == 2 && unescapedVal[valStart] == '.' && unescapedVal[valStart + 1] == '.')
                                 {
-                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.' or '..': '{val}'");
+                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '..': '{val}'");
                                 }
 
                                 if (nextSlash == -1)

--- a/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
+++ b/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
@@ -268,19 +268,33 @@ namespace Google.Apis.Requests
                             }
                             // Reject query (?) or fragment (#) injections in reserved expansions (+ or #).
                             // Since reserved expansions bypass escaping (to preserve slashes), this check acts as the primary control to prevent parameter injection.
-                            if ((op == "+" || op == "#") && (val.Contains("?") || val.Contains("#")))
+                            if ((op == "+" || op == "#") && (val.IndexOf('?') != -1 || val.IndexOf('#') != -1))
                             {
                                 throw new ArgumentException($"Reserved path parameter '{parameterName}' contains invalid character '?' or '#': '{val}'");
                             }
-                            // Unescape the entire value first and split by '/' to prevent bypasses using URL-encoded slashes (e.g. %2f).
+                            // Unescape the entire value first to prevent bypasses using URL-encoded slashes (e.g. %2f).
                             string unescapedVal = Uri.UnescapeDataString(val);
-                            string[] segments = unescapedVal.Split('/');
-                            foreach (var segment in segments)
+                            // Scan for '.' and '..' segments in place using char-index scanning to avoid heap allocations.
+                            int valStart = 0;
+                            while (valStart < unescapedVal.Length)
                             {
-                                if (segment == "." || segment == "..")
+                                int nextSlash = unescapedVal.IndexOf('/', valStart);
+                                int segmentLength = nextSlash == -1 ? unescapedVal.Length - valStart : nextSlash - valStart;
+
+                                if (segmentLength == 1 && unescapedVal[valStart] == '.')
                                 {
                                     throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.' or '..': '{val}'");
                                 }
+                                if (segmentLength == 2 && unescapedVal[valStart] == '.' && unescapedVal[valStart + 1] == '.')
+                                {
+                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.' or '..': '{val}'");
+                                }
+
+                                if (nextSlash == -1)
+                                {
+                                    break;
+                                }
+                                valStart = nextSlash + 1;
                             }
                         }
 

--- a/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
+++ b/Src/Support/Google.Apis.Core/Requests/RequestBuilder.cs
@@ -274,6 +274,7 @@ namespace Google.Apis.Requests
                             }
                             // Unescape the entire value first to prevent bypasses using URL-encoded slashes (e.g. %2f).
                             string unescapedVal = Uri.UnescapeDataString(val);
+                            bool isReserved = op == "+" || op == "#";
                             // Scan for '.' and '..' segments in place using char-index scanning to avoid heap allocations.
                             int valStart = 0;
                             while (valStart < unescapedVal.Length)
@@ -283,11 +284,25 @@ namespace Google.Apis.Requests
 
                                 if (segmentLength == 1 && unescapedVal[valStart] == '.')
                                 {
-                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '.': '{val}'");
+                                    if (!isReserved)
+                                    {
+                                        throw new ArgumentException($"Invalid value '.' for {parameterName}");
+                                    }
+                                    else
+                                    {
+                                        throw new ArgumentException($"Value for {parameterName} must not contain segments that are exactly . or ..");
+                                    }
                                 }
                                 if (segmentLength == 2 && unescapedVal[valStart] == '.' && unescapedVal[valStart + 1] == '.')
                                 {
-                                    throw new ArgumentException($"Path parameter '{parameterName}' contains invalid segment '..': '{val}'");
+                                    if (!isReserved)
+                                    {
+                                        throw new ArgumentException($"Invalid value '..' for {parameterName}");
+                                    }
+                                    else
+                                    {
+                                        throw new ArgumentException($"Value for {parameterName} must not contain segments that are exactly . or ..");
+                                    }
                                 }
 
                                 if (nextSlash == -1)

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
@@ -402,6 +402,8 @@ namespace Google.Apis.Tests.Apis.Requests
         [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/../../default")]
         [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/../../../../../../../escape-db")]
         [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/%2e%2e/escape-db")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/..%2f..%2fescape-db")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/%2e%2e%2f%2e%2e%2fescape-db")]
         [InlineData("v1/{+name}", "../escape-db")]
         [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/./child")]
         [InlineData("v1/{+name}", "projects/p/databases/d/documents/doc?key=val")]

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
@@ -429,7 +429,23 @@ namespace Google.Apis.Tests.Apis.Requests
 
             builder.AddParameter(RequestParameterType.Path, paramName, paramValue);
 
-            Assert.Throws<ArgumentException>(() => builder.BuildUri());
+            var exception = Assert.Throws<ArgumentException>(() => builder.BuildUri());
+            string unescaped = Uri.UnescapeDataString(paramValue);
+            bool hasDoubleDot = false;
+            bool hasSingleDot = false;
+            foreach (var segment in unescaped.Split('/'))
+            {
+                if (segment == "..") hasDoubleDot = true;
+                if (segment == ".") hasSingleDot = true;
+            }
+            if (hasDoubleDot)
+            {
+                Assert.Contains("contains invalid segment '..'", exception.Message);
+            }
+            else if (hasSingleDot)
+            {
+                Assert.Contains("contains invalid segment '.'", exception.Message);
+            }
         }
 
         [Theory]

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2012 Google Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -392,6 +392,59 @@ namespace Google.Apis.Tests.Apis.Requests
             }
 
             Assert.Equal("http://www.example.com/" + expected, builder.BuildUri().AbsoluteUri);
+        }
+
+        [Theory]
+        // Dialogflow session (standard single-wildcard path)
+        [InlineData("v3/{session}:detectIntent", "projects/p/locations/l/agents/a/sessions/..")]
+        [InlineData("v3/{session}:detectIntent", "projects/p/locations/l/agents/a/sessions/.")]
+        // Firestore documents (reserved template expansion)
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/../../default")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/../../../../../../../escape-db")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/%2e%2e/escape-db")]
+        [InlineData("v1/{+name}", "../escape-db")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1/./child")]
+        [InlineData("v1/{+name}", "projects/p/databases/d/documents/doc?key=val")]
+        [InlineData("v1/{+name}", "projects/p/databases/d/documents/doc#frag")]
+        // Webhooks (multiple standard wildcards)
+        [InlineData("v3/projects/{project}/webhooks/{webhook}", "..")]
+        [InlineData("v3/projects/{project}/webhooks/{webhook}", ".")]
+        public void PathTraversalAndInjection_ThrowsArgumentException(string path, string paramValue)
+        {
+            var builder = new RequestBuilder()
+            {
+                BaseUri = new Uri("http://www.example.com"),
+                Path = path
+            };
+
+            string paramName = path.Contains("session") ? "session" :
+                               path.Contains("webhook") ? "webhook" : "name";
+
+            if (path.Contains("project"))
+            {
+                builder.AddParameter(RequestParameterType.Path, "project", "p1");
+            }
+
+            builder.AddParameter(RequestParameterType.Path, paramName, paramValue);
+
+            Assert.Throws<ArgumentException>(() => builder.BuildUri());
+        }
+
+        [Theory]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/doc-1", "http://www.example.com/v1/projects/sys-prod-123/databases/default/documents/doc-1")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/my-file.txt", "http://www.example.com/v1/projects/sys-prod-123/databases/default/documents/my-file.txt")]
+        [InlineData("v1/{+name}", "projects/sys-prod-123/databases/default/documents/my-file..txt", "http://www.example.com/v1/projects/sys-prod-123/databases/default/documents/my-file..txt")]
+        public void ValidRealisticPatterns_Succeed(string path, string paramValue, string expectedUri)
+        {
+            var builder = new RequestBuilder()
+            {
+                BaseUri = new Uri("http://www.example.com"),
+                Path = path
+            };
+
+            builder.AddParameter(RequestParameterType.Path, "name", paramValue);
+
+            Assert.Equal(expectedUri, builder.BuildUri().AbsoluteUri);
         }
     }
 }

--- a/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
+++ b/Src/Support/Google.Apis.Tests/Apis/Requests/RequestBuilderTest.cs
@@ -431,6 +431,14 @@ namespace Google.Apis.Tests.Apis.Requests
 
             var exception = Assert.Throws<ArgumentException>(() => builder.BuildUri());
             string unescaped = Uri.UnescapeDataString(paramValue);
+
+            if (unescaped.Contains("?") || unescaped.Contains("#"))
+            {
+                Assert.StartsWith($"Reserved path parameter '{paramName}' contains invalid character", exception.Message);
+                return;
+            }
+
+            bool isReserved = path.Contains("{+") || path.Contains("{#");
             bool hasDoubleDot = false;
             bool hasSingleDot = false;
             foreach (var segment in unescaped.Split('/'))
@@ -438,13 +446,15 @@ namespace Google.Apis.Tests.Apis.Requests
                 if (segment == "..") hasDoubleDot = true;
                 if (segment == ".") hasSingleDot = true;
             }
-            if (hasDoubleDot)
+
+            if (!isReserved)
             {
-                Assert.Contains("contains invalid segment '..'", exception.Message);
+                string matchedDot = hasDoubleDot ? ".." : (hasSingleDot ? "." : "");
+                Assert.StartsWith($"Invalid value '{matchedDot}' for {paramName}", exception.Message);
             }
-            else if (hasSingleDot)
+            else
             {
-                Assert.Contains("contains invalid segment '.'", exception.Message);
+                Assert.StartsWith($"Value for {paramName} must not contain segments that are exactly . or ..", exception.Message);
             }
         }
 


### PR DESCRIPTION
Validates and encodes discovery-based path parameters in RequestBuilder before template expansion.

* Rejects '.' and '..' path segments in both standard and reserved (+ and #) path parameters to prevent path traversal (CWE-22).
* Percent-encodes individual path segments in reserved/multi-segment parameters (+ and #) to prevent parameter injection (CWE-88) while preserving '/' separators.
* Unescapes input before segment evaluation to prevent percent-encoded delimiter bypasses.
* Added unit tests for path traversal validation and multi-segment parameter encoding.

b/529889305